### PR TITLE
instroduced fm:: and lib_dispatch::

### DIFF
--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -251,8 +251,8 @@ void batched_gemm(batch<P> const &a, batch<P> const &b, batch<P> const &c,
   for (int i = 0; i < num_entries; ++i)
   {
     if (a(i) && b(i) && c(i))
-      gemm(&transpose_a, &transpose_b, &m, &n, &k, &alpha_, a(i), &lda, b(i),
-           &ldb, &beta_, c(i), &ldc);
+      lib_dispatch::gemm(&transpose_a, &transpose_b, &m, &n, &k, &alpha_, a(i),
+                         &lda, b(i), &ldb, &beta_, c(i), &ldc);
   }
 }
 
@@ -296,8 +296,8 @@ void batched_gemv(batch<P> const &a, batch<P> const &b, batch<P> const &c,
   for (int i = 0; i < num_entries; ++i)
   {
     if (a(i) && b(i) && c(i))
-      gemv(&transpose_a, &m, &n, &alpha_, a(i), &lda, b(i), &stride_b, &beta_,
-           c(i), &stride_c);
+      lib_dispatch::gemv(&transpose_a, &m, &n, &alpha_, a(i), &lda, b(i),
+                         &stride_b, &beta_, c(i), &stride_c);
   }
 }
 

--- a/src/fast_math.hpp
+++ b/src/fast_math.hpp
@@ -2,6 +2,8 @@
 #include "lib_dispatch.hpp"
 #include "tensors.hpp"
 
+namespace fm
+{
 // axpy - y = a*x
 template<typename P, mem_type mem, mem_type omem>
 fk::vector<P, mem> &
@@ -11,7 +13,7 @@ axpy(fk::vector<P, omem> const &x, fk::vector<P, mem> &y, P const alpha = 1.0)
   int n    = x.size();
   int one  = 1;
   P alpha_ = alpha;
-  axpy(&n, &alpha_, x.data(), &one, y.data(), &one);
+  lib_dispatch::axpy(&n, &alpha_, x.data(), &one, y.data(), &one);
   return y;
 }
 
@@ -22,7 +24,7 @@ fk::vector<P, mem> &copy(fk::vector<P, omem> const &x, fk::vector<P, mem> &y)
   assert(x.size() == y.size());
   int n   = x.size();
   int one = 1;
-  copy(&n, x.data(), &one, y.data(), &one);
+  lib_dispatch::copy(&n, x.data(), &one, y.data(), &one);
   return y;
 }
 
@@ -33,7 +35,7 @@ fk::vector<P, mem> &scal(P const alpha, fk::vector<P, mem> &x)
   int one  = 1;
   int n    = x.size();
   P alpha_ = alpha;
-  scal(&n, &alpha_, x.data(), &one);
+  lib_dispatch::scal(&n, &alpha_, x.data(), &one);
   return x;
 }
 
@@ -58,8 +60,8 @@ gemv(fk::matrix<P, amem> const &A, fk::vector<P, xmem> const &x,
   int m             = A.nrows();
   int n             = A.ncols();
 
-  gemv(&transa, &m, &n, &alpha_, A.data(), &lda, x.data(), &one, &beta_,
-       y.data(), &one);
+  lib_dispatch::gemv(&transa, &m, &n, &alpha_, A.data(), &lda, x.data(), &one,
+                     &beta_, y.data(), &one);
 
   return y;
 }
@@ -92,8 +94,9 @@ gemm(fk::matrix<P, amem> const &A, fk::matrix<P, bmem> const &B,
   int n             = cols_B;
   int k             = rows_B;
 
-  gemm(&transa, &transb, &m, &n, &k, &alpha_, A.data(), &lda, B.data(), &ldb,
-       &beta_, C.data(), &ldc);
+  lib_dispatch::gemm(&transa, &transb, &m, &n, &k, &alpha_, A.data(), &lda,
+                     B.data(), &ldb, &beta_, C.data(), &ldc);
 
   return C;
 }
+} // namespace fm

--- a/src/fast_math_tests.cpp
+++ b/src/fast_math_tests.cpp
@@ -2,7 +2,7 @@
 #include "tensors.hpp"
 #include "tests_general.hpp"
 
-TEMPLATE_TEST_CASE("gemm", "[fast_math]", float, double, int)
+TEMPLATE_TEST_CASE("fm::gemm", "[fast_math]", float, double, int)
 {
   // clang-format off
     fk::matrix<TestType> const ans{
@@ -16,10 +16,10 @@ TEMPLATE_TEST_CASE("gemm", "[fast_math]", float, double, int)
     };
 
     fk::matrix<TestType> const in2{
-        {12, 22, 32}, 
-	{13, 23, 33}, 
-	{14, 24, 34}, 
-	{15, 25, 35}, 
+        {12, 22, 32},
+	{13, 23, 33},
+	{14, 24, 34},
+	{15, 25, 35},
 	{16, 26, 36},
     };
   // clang-format on
@@ -27,7 +27,7 @@ TEMPLATE_TEST_CASE("gemm", "[fast_math]", float, double, int)
   SECTION("no transpose")
   {
     fk::matrix<TestType> result(in1.nrows(), in2.ncols());
-    gemm(in1, in2, result);
+    fm::gemm(in1, in2, result);
     REQUIRE(result == ans);
   }
 
@@ -36,7 +36,7 @@ TEMPLATE_TEST_CASE("gemm", "[fast_math]", float, double, int)
     fk::matrix<TestType> const in1_t = fk::matrix<TestType>(in1).transpose();
     fk::matrix<TestType> result(in1.nrows(), in2.ncols());
     bool const trans_A = true;
-    gemm(in1_t, in2, result, trans_A);
+    fm::gemm(in1_t, in2, result, trans_A);
     REQUIRE(result == ans);
   }
   SECTION("transpose b")
@@ -45,7 +45,7 @@ TEMPLATE_TEST_CASE("gemm", "[fast_math]", float, double, int)
     fk::matrix<TestType> result(in1.nrows(), in2.ncols());
     bool const trans_A = false;
     bool const trans_B = true;
-    gemm(in1, in2_t, result, trans_A, trans_B);
+    fm::gemm(in1, in2_t, result, trans_A, trans_B);
     REQUIRE(result == ans);
   }
 
@@ -56,7 +56,7 @@ TEMPLATE_TEST_CASE("gemm", "[fast_math]", float, double, int)
     fk::matrix<TestType> result(in1.nrows(), in2.ncols());
     bool const trans_A = true;
     bool const trans_B = true;
-    gemm(in1_t, in2_t, result, trans_A, trans_B);
+    fm::gemm(in1_t, in2_t, result, trans_A, trans_B);
     REQUIRE(result == ans);
   }
 
@@ -79,7 +79,7 @@ TEMPLATE_TEST_CASE("gemm", "[fast_math]", float, double, int)
     TestType const alpha = 2.0;
     TestType const beta  = 1.0;
 
-    gemm(in1, in2, result, trans_A, trans_B, alpha, beta);
+    fm::gemm(in1, in2, result, trans_A, trans_B, alpha, beta);
     REQUIRE(result == gold);
   }
 
@@ -103,12 +103,12 @@ TEMPLATE_TEST_CASE("gemm", "[fast_math]", float, double, int)
     fk::matrix<TestType, mem_type::view> result_view(result, 0, in1.nrows() - 1,
                                                      0, in2.ncols() - 1);
 
-    gemm(in1_view, in2_view, result_view);
+    fm::gemm(in1_view, in2_view, result_view);
     REQUIRE(result_view == ans);
   }
 }
 
-TEMPLATE_TEST_CASE("gemv", "[fast_math]", float, double, int)
+TEMPLATE_TEST_CASE("fm::gemv", "[fast_math]", float, double, int)
 {
   // clang-format off
     fk::vector<TestType> const ans
@@ -129,7 +129,7 @@ TEMPLATE_TEST_CASE("gemv", "[fast_math]", float, double, int)
   SECTION("no transpose")
   {
     fk::vector<TestType> result(ans.size());
-    gemv(A, x, result);
+    fm::gemv(A, x, result);
     REQUIRE(result == ans);
   }
 
@@ -138,7 +138,7 @@ TEMPLATE_TEST_CASE("gemv", "[fast_math]", float, double, int)
     fk::matrix<TestType> const A_trans = fk::matrix<TestType>(A).transpose();
     fk::vector<TestType> result(ans.size());
     bool const trans_A = true;
-    gemv(A_trans, x, result, trans_A);
+    fm::gemv(A_trans, x, result, trans_A);
     REQUIRE(result == ans);
   }
 
@@ -160,7 +160,7 @@ TEMPLATE_TEST_CASE("gemv", "[fast_math]", float, double, int)
     TestType const alpha = 2.0;
     TestType const beta  = 1.0;
 
-    gemv(A, x, result, trans_A, alpha, beta);
+    fm::gemv(A, x, result, trans_A, alpha, beta);
     REQUIRE(result == gold);
   }
 }
@@ -168,7 +168,7 @@ TEMPLATE_TEST_CASE("gemv", "[fast_math]", float, double, int)
 TEMPLATE_TEST_CASE("other vector routines", "[fast_math]", float, double, int)
 {
   fk::vector<TestType> const gold = {2, 3, 4, 5, 6};
-  SECTION("vector scale and accumulate (axpy)")
+  SECTION("vector scale and accumulate (fm::axpy)")
   {
     TestType const scale = 2.0;
 
@@ -182,18 +182,18 @@ TEMPLATE_TEST_CASE("other vector routines", "[fast_math]", float, double, int)
 
     fk::vector<TestType> const ans = {16, 19, 22, 25, 28};
 
-    REQUIRE(axpy(rhs, test, scale) == ans);
+    REQUIRE(fm::axpy(rhs, test, scale) == ans);
     test = gold;
-    REQUIRE(axpy(rhs_view, test, scale) == ans);
+    REQUIRE(fm::axpy(rhs_view, test, scale) == ans);
 
-    REQUIRE(axpy(rhs, test_view, scale) == ans);
+    REQUIRE(fm::axpy(rhs, test_view, scale) == ans);
     REQUIRE(test_own == ans);
     test_view = gold;
-    REQUIRE(axpy(rhs_view, test_view, scale) == ans);
+    REQUIRE(fm::axpy(rhs_view, test_view, scale) == ans);
     REQUIRE(test_own == ans);
   }
 
-  SECTION("vector copy (copy)")
+  SECTION("vector copy (fm::copy)")
   {
     fk::vector<TestType> test(gold.size());
     fk::vector<TestType> test_own(gold.size());
@@ -201,18 +201,18 @@ TEMPLATE_TEST_CASE("other vector routines", "[fast_math]", float, double, int)
 
     fk::vector<TestType, mem_type::view> const gold_view(gold);
 
-    REQUIRE(copy(gold, test) == gold);
+    REQUIRE(fm::copy(gold, test) == gold);
     test.scale(0);
-    REQUIRE(copy(gold_view, test) == gold);
+    REQUIRE(fm::copy(gold_view, test) == gold);
 
-    REQUIRE(copy(gold, test_view) == gold);
+    REQUIRE(fm::copy(gold, test_view) == gold);
     REQUIRE(test_own == gold);
     test_own.scale(0);
-    REQUIRE(copy(gold_view, test_view) == gold);
+    REQUIRE(fm::copy(gold_view, test_view) == gold);
     REQUIRE(test_own == gold);
   }
 
-  SECTION("vector scale (scal)")
+  SECTION("vector scale (fm::scal)")
   {
     TestType const x = 2.0;
     fk::vector<TestType> test(gold);
@@ -221,8 +221,8 @@ TEMPLATE_TEST_CASE("other vector routines", "[fast_math]", float, double, int)
 
     fk::vector<TestType> const ans = {4, 6, 8, 10, 12};
 
-    REQUIRE(scal(x, test) == ans);
-    REQUIRE(scal(x, test_view) == ans);
+    REQUIRE(fm::scal(x, test) == ans);
+    REQUIRE(fm::scal(x, test_view) == ans);
     REQUIRE(test_own == ans);
 
     test     = gold;
@@ -231,8 +231,8 @@ TEMPLATE_TEST_CASE("other vector routines", "[fast_math]", float, double, int)
     TestType const x2 = 0.0;
     fk::vector<TestType> const zeros(gold.size());
 
-    REQUIRE(scal(x2, test) == zeros);
-    REQUIRE(scal(x2, test_view) == zeros);
+    REQUIRE(fm::scal(x2, test) == zeros);
+    REQUIRE(fm::scal(x2, test_view) == zeros);
     REQUIRE(test_own == zeros);
   }
 }

--- a/src/lib_dispatch.cpp
+++ b/src/lib_dispatch.cpp
@@ -8,6 +8,8 @@
 //
 auto const ignore = [](auto ignored) { (void)ignored; };
 
+namespace lib_dispatch
+{
 template<typename P>
 void copy(int *n, P *x, int *incx, P *y, int *incy, resource const res)
 {
@@ -385,3 +387,4 @@ template void getri(int *n, float *A, int *lda, int *ipiv, float *work,
                     int *lwork, int *info, resource const res);
 template void getri(int *n, double *A, int *lda, int *ipiv, double *work,
                     int *lwork, int *info, resource const res);
+} // namespace lib_dispatch

--- a/src/lib_dispatch.hpp
+++ b/src/lib_dispatch.hpp
@@ -80,6 +80,8 @@ extern "C"
 
 // -- precision/execution resource wrapper for blas --
 
+namespace lib_dispatch
+{
 template<typename P>
 void copy(int *n, P *x, int *incx, P *y, int *incy,
           resource const res = resource::host);
@@ -175,3 +177,4 @@ extern template void getri(int *n, float *A, int *lda, int *ipiv, float *work,
                            int *lwork, int *info, resource const res);
 extern template void getri(int *n, double *A, int *lda, int *ipiv, double *work,
                            int *lwork, int *info, resource const res);
+} // namespace lib_dispatch

--- a/src/lib_dispatch_tests.cpp
+++ b/src/lib_dispatch_tests.cpp
@@ -7,8 +7,8 @@
 //
 // direct calls into BLAS are not covered for now
 //
-TEMPLATE_TEST_CASE("matrix-matrix multiply (gemm)", "[lib_dispatch]", float,
-                   double, int)
+TEMPLATE_TEST_CASE("matrix-matrix multiply (lib_dispatch::gemm)",
+                   "[lib_dispatch]", float, double, int)
 {
   // clang-format off
     fk::matrix<TestType> const ans{
@@ -22,10 +22,10 @@ TEMPLATE_TEST_CASE("matrix-matrix multiply (gemm)", "[lib_dispatch]", float,
     };
 
     fk::matrix<TestType> const in2{
-        {12, 22, 32}, 
-	{13, 23, 33}, 
-	{14, 24, 34}, 
-	{15, 25, 35}, 
+        {12, 22, 32},
+	{13, 23, 33},
+	{14, 24, 34},
+	{15, 25, 35},
 	{16, 26, 36},
     };
   // clang-format on
@@ -44,8 +44,8 @@ TEMPLATE_TEST_CASE("matrix-matrix multiply (gemm)", "[lib_dispatch]", float,
     int ldc            = result.stride();
     char const trans_a = 'n';
     char const trans_b = 'n';
-    gemm(&trans_a, &trans_b, &m, &n, &k, &alpha, in1.data(), &lda, in2.data(),
-         &ldb, &beta, result.data(), &ldc);
+    lib_dispatch::gemm(&trans_a, &trans_b, &m, &n, &k, &alpha, in1.data(), &lda,
+                       in2.data(), &ldb, &beta, result.data(), &ldc);
     REQUIRE(result == ans);
   }
 
@@ -64,8 +64,8 @@ TEMPLATE_TEST_CASE("matrix-matrix multiply (gemm)", "[lib_dispatch]", float,
     int ldc            = result.stride();
     char const trans_a = 't';
     char const trans_b = 'n';
-    gemm(&trans_a, &trans_b, &m, &n, &k, &alpha, in1_t.data(), &lda, in2.data(),
-         &ldb, &beta, result.data(), &ldc);
+    lib_dispatch::gemm(&trans_a, &trans_b, &m, &n, &k, &alpha, in1_t.data(),
+                       &lda, in2.data(), &ldb, &beta, result.data(), &ldc);
     REQUIRE(result == ans);
   }
   SECTION("transpose b")
@@ -83,8 +83,8 @@ TEMPLATE_TEST_CASE("matrix-matrix multiply (gemm)", "[lib_dispatch]", float,
     int ldc            = result.stride();
     char const trans_a = 'n';
     char const trans_b = 't';
-    gemm(&trans_a, &trans_b, &m, &n, &k, &alpha, in1.data(), &lda, in2_t.data(),
-         &ldb, &beta, result.data(), &ldc);
+    lib_dispatch::gemm(&trans_a, &trans_b, &m, &n, &k, &alpha, in1.data(), &lda,
+                       in2_t.data(), &ldb, &beta, result.data(), &ldc);
     REQUIRE(result == ans);
   }
 
@@ -104,8 +104,8 @@ TEMPLATE_TEST_CASE("matrix-matrix multiply (gemm)", "[lib_dispatch]", float,
     int ldc            = result.stride();
     char const trans_a = 't';
     char const trans_b = 't';
-    gemm(&trans_a, &trans_b, &m, &n, &k, &alpha, in1_t.data(), &lda,
-         in2_t.data(), &ldb, &beta, result.data(), &ldc);
+    lib_dispatch::gemm(&trans_a, &trans_b, &m, &n, &k, &alpha, in1_t.data(),
+                       &lda, in2_t.data(), &ldb, &beta, result.data(), &ldc);
     REQUIRE(result == ans);
   }
 
@@ -133,8 +133,8 @@ TEMPLATE_TEST_CASE("matrix-matrix multiply (gemm)", "[lib_dispatch]", float,
     int ldc            = result.stride();
     char const trans_a = 'n';
     char const trans_b = 'n';
-    gemm(&trans_a, &trans_b, &m, &n, &k, &alpha, in1.data(), &lda, in2.data(),
-         &ldb, &beta, result.data(), &ldc);
+    lib_dispatch::gemm(&trans_a, &trans_b, &m, &n, &k, &alpha, in1.data(), &lda,
+                       in2.data(), &ldb, &beta, result.data(), &ldc);
     REQUIRE(result == gold);
   }
 
@@ -165,14 +165,15 @@ TEMPLATE_TEST_CASE("matrix-matrix multiply (gemm)", "[lib_dispatch]", float,
     int ldc            = result.stride();
     char const trans_a = 'n';
     char const trans_b = 'n';
-    gemm(&trans_a, &trans_b, &m, &n, &k, &alpha, in1_extended.data(), &lda,
-         in2_extended.data(), &ldb, &beta, result.data(), &ldc);
+    lib_dispatch::gemm(&trans_a, &trans_b, &m, &n, &k, &alpha,
+                       in1_extended.data(), &lda, in2_extended.data(), &ldb,
+                       &beta, result.data(), &ldc);
     REQUIRE(result_view == ans);
   }
 }
 
-TEMPLATE_TEST_CASE("matrix-vector multiply (gemv)", "[lib_dispatch]", float,
-                   double, int)
+TEMPLATE_TEST_CASE("matrix-vector multiply (lib_dispatch::gemv)",
+                   "[lib_dispatch]", float, double, int)
 {
   // clang-format off
     fk::vector<TestType> const ans
@@ -202,8 +203,8 @@ TEMPLATE_TEST_CASE("matrix-vector multiply (gemv)", "[lib_dispatch]", float,
     int inc            = 1;
     char const trans_a = 'n';
 
-    gemv(&trans_a, &m, &n, &alpha, A.data(), &lda, x.data(), &inc, &beta,
-         result.data(), &inc);
+    lib_dispatch::gemv(&trans_a, &m, &n, &alpha, A.data(), &lda, x.data(), &inc,
+                       &beta, result.data(), &inc);
     REQUIRE(result == ans);
   }
 
@@ -220,8 +221,8 @@ TEMPLATE_TEST_CASE("matrix-vector multiply (gemv)", "[lib_dispatch]", float,
     int inc            = 1;
     char const trans_a = 't';
 
-    gemv(&trans_a, &m, &n, &alpha, A_trans.data(), &lda, x.data(), &inc, &beta,
-         result.data(), &inc);
+    lib_dispatch::gemv(&trans_a, &m, &n, &alpha, A_trans.data(), &lda, x.data(),
+                       &inc, &beta, result.data(), &inc);
     REQUIRE(result == ans);
   }
 
@@ -246,8 +247,8 @@ TEMPLATE_TEST_CASE("matrix-vector multiply (gemv)", "[lib_dispatch]", float,
     int inc            = 1;
     char const trans_a = 'n';
 
-    gemv(&trans_a, &m, &n, &alpha, A.data(), &lda, x.data(), &inc, &beta,
-         result.data(), &inc);
+    lib_dispatch::gemv(&trans_a, &m, &n, &alpha, A.data(), &lda, x.data(), &inc,
+                       &beta, result.data(), &inc);
     REQUIRE(result == gold);
   }
 
@@ -267,47 +268,48 @@ TEMPLATE_TEST_CASE("matrix-vector multiply (gemv)", "[lib_dispatch]", float,
     int incy           = 2;
     char const trans_a = 'n';
 
-    gemv(&trans_a, &m, &n, &alpha, A.data(), &lda, x_padded.data(), &incx,
-         &beta, result.data(), &incy);
+    lib_dispatch::gemv(&trans_a, &m, &n, &alpha, A.data(), &lda,
+                       x_padded.data(), &incx, &beta, result.data(), &incy);
     REQUIRE(result == gold);
   }
 }
 
-TEMPLATE_TEST_CASE("scale and copy routines (scal/copy)", "[lib_dispatch]",
-                   float, double, int)
+TEMPLATE_TEST_CASE(
+    "scale and copy routines (lib_dispatch::scal/lib_dispatch::copy)",
+    "[lib_dispatch]", float, double, int)
 {
   fk::vector<TestType> const x         = {1, 2, 3, 4, 5};
   fk::vector<TestType> const x_tripled = {3, 6, 9, 12, 15};
   TestType const scale                 = 3;
-  SECTION("scal - incx = 1")
+  SECTION("lib_dispatch::scal - incx = 1")
   {
     fk::vector<TestType> test(x);
     int n          = x.size();
     TestType alpha = scale;
     int incx       = 1;
-    scal(&n, &alpha, test.data(), &incx);
+    lib_dispatch::scal(&n, &alpha, test.data(), &incx);
     REQUIRE(test == x_tripled);
   }
-  SECTION("scal - incx =/= 1")
+  SECTION("lib_dispatch::scal - incx =/= 1")
   {
     fk::vector<TestType> test{1, 0, 2, 0, 3, 0, 4, 0, 5};
     fk::vector<TestType> const gold{3, 0, 6, 0, 9, 0, 12, 0, 15};
     int n          = x.size();
     TestType alpha = scale;
     int incx       = 2;
-    scal(&n, &alpha, test.data(), &incx);
+    lib_dispatch::scal(&n, &alpha, test.data(), &incx);
     REQUIRE(test == gold);
   }
-  SECTION("copy - inc = 1")
+  SECTION("lib_dispatch::copy - inc = 1")
   {
     fk::vector<TestType> x_test(x);
     fk::vector<TestType> y_test(x.size());
     int n   = x.size();
     int inc = 1;
-    copy(&n, x_test.data(), &inc, y_test.data(), &inc);
+    lib_dispatch::copy(&n, x_test.data(), &inc, y_test.data(), &inc);
     REQUIRE(y_test == x);
   }
-  SECTION("copy - inc =/= 1")
+  SECTION("lib_dispatch::copy - inc =/= 1")
   {
     fk::vector<TestType> x_test{1, 0, 2, 0, 3, 0, 4, 0, 5};
     fk::vector<TestType> const gold{1, 0, 0, 2, 0, 0, 3, 0, 0, 4, 0, 0, 5};
@@ -316,19 +318,19 @@ TEMPLATE_TEST_CASE("scale and copy routines (scal/copy)", "[lib_dispatch]",
     int n    = x.size();
     int incx = 2;
     int incy = 3;
-    copy(&n, x_test.data(), &incx, y_test.data(), &incy);
+    lib_dispatch::copy(&n, x_test.data(), &incx, y_test.data(), &incy);
     REQUIRE(y_test == gold);
   }
 }
 
-TEMPLATE_TEST_CASE("scale/accumulate (axpy)", "[lib_dispatch]", float, double,
-                   int)
+TEMPLATE_TEST_CASE("scale/accumulate (lib_dispatch::axpy)", "[lib_dispatch]",
+                   float, double, int)
 {
   fk::vector<TestType> const x    = {1, 2, 3, 4, 5};
   TestType const scale            = 3;
   fk::vector<TestType> const gold = {4, 7, 10, 13, 16};
 
-  SECTION("axpy - inc = 1")
+  SECTION("lib_dispatch::axpy - inc = 1")
   {
     fk::vector<TestType> y(x.size());
     std::fill(y.begin(), y.end(), 1.0);
@@ -336,11 +338,11 @@ TEMPLATE_TEST_CASE("scale/accumulate (axpy)", "[lib_dispatch]", float, double,
     int n          = x.size();
     TestType alpha = scale;
     int inc        = 1;
-    axpy(&n, &alpha, x.data(), &inc, y.data(), &inc);
+    lib_dispatch::axpy(&n, &alpha, x.data(), &inc, y.data(), &inc);
     REQUIRE(y == gold);
   }
 
-  SECTION("axpy - inc =/= 1")
+  SECTION("lib_dispatch::axpy - inc =/= 1")
   {
     fk::vector<TestType> y         = {1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1};
     fk::vector<TestType> const ans = {4, 0, 0, 7, 0, 0, 10, 0, 0, 13, 0, 0, 16};
@@ -350,26 +352,27 @@ TEMPLATE_TEST_CASE("scale/accumulate (axpy)", "[lib_dispatch]", float, double,
     TestType alpha = scale;
     int incx       = 2;
     int incy       = 3;
-    axpy(&n, &alpha, x_extended.data(), &incx, y.data(), &incy);
+    lib_dispatch::axpy(&n, &alpha, x_extended.data(), &incx, y.data(), &incy);
     REQUIRE(y == ans);
   }
 }
 
-TEMPLATE_TEST_CASE("dot product (dot)", "[lib_dispatch]", float, double, int)
+TEMPLATE_TEST_CASE("dot product (lib_dispatch::dot)", "[lib_dispatch]", float,
+                   double, int)
 {
   fk::vector<TestType> const x = {1, 2, 3, 4, 5};
   fk::vector<TestType> const y = {2, 4, 6, 8, 10};
   TestType const gold          = 110;
 
-  SECTION("dot - inc = 1")
+  SECTION("lib_dispatch::dot - inc = 1")
   {
     int n              = x.size();
     int inc            = 1;
-    TestType const ans = dot(&n, x.data(), &inc, y.data(), &inc);
+    TestType const ans = lib_dispatch::dot(&n, x.data(), &inc, y.data(), &inc);
     REQUIRE(ans == gold);
   }
 
-  SECTION("dot - inc =/= 1")
+  SECTION("lib_dispatch::dot - inc =/= 1")
   {
     fk::vector<TestType> const x_extended = {1, 0, 2, 0, 3, 0, 4, 0, 5};
 
@@ -378,8 +381,8 @@ TEMPLATE_TEST_CASE("dot product (dot)", "[lib_dispatch]", float, double, int)
     int n                                 = x.size();
     int incx                              = 2;
     int incy                              = 3;
-    TestType const ans =
-        dot(&n, x_extended.data(), &incx, y_extended.data(), &incy);
+    TestType const ans = lib_dispatch::dot(&n, x_extended.data(), &incx,
+                                           y_extended.data(), &incy);
     REQUIRE(ans == gold);
   }
 }

--- a/src/tensors.hpp
+++ b/src/tensors.hpp
@@ -698,7 +698,7 @@ P fk::vector<P, mem>::operator*(vector<P, omem> const &right) const
   int one         = 1;
   vector const &X = (*this);
 
-  return dot(&n, X.data(), &one, right.data(), &one);
+  return lib_dispatch::dot(&n, X.data(), &one, right.data(), &one);
 }
 
 //
@@ -721,8 +721,8 @@ fk::vector<P> fk::vector<P, mem>::operator*(fk::matrix<P, omem> const &A) const
 
   P zero = 0.0;
   P one  = 1.0;
-  gemv("t", &m, &n, &one, A.data(), &lda, X.data(), &one_i, &zero, Y.data(),
-       &one_i);
+  lib_dispatch::gemv("t", &m, &n, &one, A.data(), &lda, X.data(), &one_i, &zero,
+                     Y.data(), &one_i);
   return Y;
 }
 
@@ -737,7 +737,7 @@ fk::vector<P> fk::vector<P, mem>::operator*(P const x) const
   int n     = a.size();
   P alpha   = x;
 
-  scal(&n, &alpha, a.data(), &one_i);
+  lib_dispatch::scal(&n, &alpha, a.data(), &one_i);
 
   return a;
 }
@@ -770,7 +770,7 @@ fk::vector<P, mem> &fk::vector<P, mem>::scale(P const x)
   int n     = this->size();
   P alpha   = x;
 
-  scal(&n, &alpha, this->data(), &one_i);
+  lib_dispatch::scal(&n, &alpha, this->data(), &one_i);
 
   return *this;
 }
@@ -1353,8 +1353,8 @@ operator*(fk::vector<P, omem> const &right) const
 
   P one  = 1.0;
   P zero = 0.0;
-  gemv("n", &m, &n, &one, A.data(), &lda, right.data(), &one_i, &zero, Y.data(),
-       &one_i);
+  lib_dispatch::gemv("n", &m, &n, &one, A.data(), &lda, right.data(), &one_i,
+                     &zero, Y.data(), &one_i);
 
   return Y;
 }
@@ -1382,8 +1382,8 @@ fk::matrix<P> fk::matrix<P, mem>::operator*(matrix<P, omem> const &B) const
 
   P one  = 1.0;
   P zero = 0.0;
-  gemm("n", "n", &m, &n, &k, &one, A.data(), &lda, B.data(), &ldb, &zero,
-       C.data(), &ldc);
+  lib_dispatch::gemm("n", "n", &m, &n, &k, &one, A.data(), &lda, B.data(), &ldb,
+                     &zero, C.data(), &ldc);
 
   return C;
 }
@@ -1462,8 +1462,8 @@ fk::matrix<P, mem>::invert()
   P *work{new P[nrows() * ncols()]};
   int info;
 
-  getrf(&ncols_, &ncols_, data(0, 0), &lda, ipiv, &info);
-  getri(&ncols_, data(0, 0), &lda, ipiv, work, &lwork, &info);
+  lib_dispatch::getrf(&ncols_, &ncols_, data(0, 0), &lda, ipiv, &info);
+  lib_dispatch::getri(&ncols_, data(0, 0), &lda, ipiv, work, &lwork, &info);
 
   delete[] ipiv;
   delete[] work;
@@ -1498,7 +1498,7 @@ fk::matrix<P, mem>::determinant() const
   int n   = ncols();
   int lda = stride();
 
-  getrf(&n, &n, temp.data(0, 0), &lda, ipiv, &info);
+  lib_dispatch::getrf(&n, &n, temp.data(0, 0), &lda, ipiv, &info);
 
   P det    = 1.0;
   int sign = 1;
@@ -1529,7 +1529,7 @@ fk::matrix<P, mem>::update_col(int const col_idx, fk::vector<P, omem> const &v)
   int one{1};
   int stride = 1;
 
-  copy(&n, v.data(), &one, data(0, col_idx), &stride);
+  lib_dispatch::copy(&n, v.data(), &one, data(0, col_idx), &stride);
 
   return *this;
 }
@@ -1548,7 +1548,8 @@ fk::matrix<P, mem>::update_col(int const col_idx, std::vector<P> const &v)
   int one{1};
   int stride = 1;
 
-  copy(&n, const_cast<P *>(v.data()), &one, data(0, col_idx), &stride);
+  lib_dispatch::copy(&n, const_cast<P *>(v.data()), &one, data(0, col_idx),
+                     &stride);
 
   return *this;
 }
@@ -1569,7 +1570,7 @@ fk::matrix<P, mem>::update_row(int const row_idx, fk::vector<P, omem> const &v)
   int one{1};
   int lda = stride();
 
-  copy(&n, v.data(), &one, data(row_idx, 0), &lda);
+  lib_dispatch::copy(&n, v.data(), &one, data(row_idx, 0), &lda);
 
   return *this;
 }
@@ -1588,7 +1589,8 @@ fk::matrix<P, mem>::update_row(int const row_idx, std::vector<P> const &v)
   int one{1};
   int lda = stride();
 
-  copy(&n, const_cast<P *>(v.data()), &one, data(row_idx, 0), &lda);
+  lib_dispatch::copy(&n, const_cast<P *>(v.data()), &one, data(row_idx, 0),
+                     &lda);
 
   return *this;
 }

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -16,7 +16,7 @@ void explicit_time_advance(PDE<P> const &pde,
   assert(system.result_2.size() == system.batch_input.size());
   assert(system.result_3.size() == system.batch_input.size());
 
-  copy(system.batch_input, system.x_orig);
+  fm::copy(system.batch_input, system.x_orig);
 
   assert(time >= 0);
 
@@ -43,36 +43,36 @@ void explicit_time_advance(PDE<P> const &pde,
 
   apply_explicit(batches);
   scale_sources(pde, unscaled_sources, system.scaled_source, time);
-  axpy(system.scaled_source, system.batch_output);
-  copy(system.batch_output, system.result_1);
+  fm::axpy(system.scaled_source, system.batch_output);
+  fm::copy(system.batch_output, system.result_1);
   P const fx_scale_1 = a21 * dt;
-  axpy(system.batch_output, system.batch_input, fx_scale_1);
+  fm::axpy(system.batch_output, system.batch_input, fx_scale_1);
 
   apply_explicit(batches);
   scale_sources(pde, unscaled_sources, system.scaled_source, time + c2 * dt);
-  axpy(system.scaled_source, system.batch_output);
-  copy(system.batch_output, system.result_2);
-  copy(system.x_orig, system.batch_input);
+  fm::axpy(system.scaled_source, system.batch_output);
+  fm::copy(system.batch_output, system.result_2);
+  fm::copy(system.x_orig, system.batch_input);
   P const fx_scale_2a = a31 * dt;
   P const fx_scale_2b = a32 * dt;
-  axpy(system.result_1, system.batch_input, fx_scale_2a);
-  axpy(system.result_2, system.batch_input, fx_scale_2b);
+  fm::axpy(system.result_1, system.batch_input, fx_scale_2a);
+  fm::axpy(system.result_2, system.batch_input, fx_scale_2b);
 
   apply_explicit(batches);
   scale_sources(pde, unscaled_sources, system.scaled_source, time + c3 * dt);
-  axpy(system.scaled_source, system.batch_output);
-  copy(system.batch_output, system.result_3);
+  fm::axpy(system.scaled_source, system.batch_output);
+  fm::copy(system.batch_output, system.result_3);
 
   P const scale_1 = dt * b1;
   P const scale_2 = dt * b2;
   P const scale_3 = dt * b3;
 
-  copy(system.x_orig, system.batch_input);
-  axpy(system.result_1, system.batch_input, scale_1);
-  axpy(system.result_2, system.batch_input, scale_2);
-  axpy(system.result_3, system.batch_input, scale_3);
+  fm::copy(system.x_orig, system.batch_input);
+  fm::axpy(system.result_1, system.batch_input, scale_1);
+  fm::axpy(system.result_2, system.batch_input, scale_2);
+  fm::axpy(system.result_3, system.batch_input, scale_3);
 
-  copy(system.batch_input, system.batch_output);
+  fm::copy(system.batch_input, system.batch_output);
 }
 
 // scale source vectors for time
@@ -83,11 +83,12 @@ scale_sources(PDE<P> const &pde,
               fk::vector<P> &scaled_source, P const time)
 {
   // zero out final vect
-  scal(static_cast<P>(0.0), scaled_source);
+  fm::scal(static_cast<P>(0.0), scaled_source);
   // scale and accumulate all sources
   for (int i = 0; i < pde.num_sources; ++i)
   {
-    axpy(unscaled_sources[i], scaled_source, pde.sources[i].time_func(time));
+    fm::axpy(unscaled_sources[i], scaled_source,
+             pde.sources[i].time_func(time));
   }
   return scaled_source;
 }


### PR DESCRIPTION
addresses #97 

Except that names there were too hard to look at (for now). so we're keeping `fk::` to be quirky and historical, then a complimentary `fm::` for fast_math, and then the hopefully unfriendly `lib_dispatch::`