### PR TITLE
WIP: Fix/test lambdas bad

### DIFF
--- a/src/basis_tests.cpp
+++ b/src/basis_tests.cpp
@@ -6,15 +6,6 @@
 
 TEMPLATE_TEST_CASE("Multiwavelet", "[transformations]", double, float)
 {
-  auto const relaxed_comparison = [](auto const first, auto const second) {
-    auto first_it = first.begin();
-    std::for_each(second.begin(), second.end(), [&first_it](auto &second_elem) {
-      REQUIRE(Approx(*first_it++)
-                  .epsilon(std::numeric_limits<TestType>::epsilon() * 1e3) ==
-              second_elem);
-    });
-  };
-
   SECTION("Multiwavelet generation, degree = 1")
   {
     int const degree = 1;
@@ -45,7 +36,10 @@ TEMPLATE_TEST_CASE("Multiwavelet", "[transformations]", double, float)
     SECTION("degree = 1, h1") { REQUIRE(Approx(h1) == m_h1(0, 0)); }
     SECTION("degree = 1, g0") { REQUIRE(Approx(g0) == m_g0(0, 0)); }
     SECTION("degree = 1, g1") { REQUIRE(Approx(g1) == m_g1(0, 0)); }
-    SECTION("degree = 1, phi_co") { relaxed_comparison(phi_co, m_phi_co); }
+    SECTION("degree = 1, phi_co")
+    {
+      REQUIRE(relaxed_comparison<TestType>(phi_co, m_phi_co, 1e3));
+    }
     SECTION("degree = 1, scale_co")
     {
       REQUIRE(Approx(scale_co) == m_scale_co(0, 0));
@@ -82,14 +76,29 @@ TEMPLATE_TEST_CASE("Multiwavelet", "[transformations]", double, float)
     auto const [m_h0, m_h1, m_g0, m_g1, m_phi_co, m_scale_co] =
         generate_multi_wavelets<TestType>(degree);
 
-    SECTION("degree = 3, h0") { relaxed_comparison(h0, m_h0); }
-    SECTION("degree = 3, h1") { relaxed_comparison(h1, m_h1); }
-    SECTION("degree = 3, g0") { relaxed_comparison(g0, m_g0); }
-    SECTION("degree = 3, g1") { relaxed_comparison(g1, m_g1); }
-    SECTION("degree = 3, phi_co") { relaxed_comparison(phi_co, m_phi_co); }
+    SECTION("degree = 3, h0")
+    {
+      REQUIRE(relaxed_comparison<TestType>(h0, m_h0, 1e3));
+    }
+    SECTION("degree = 3, h1")
+    {
+      REQUIRE(relaxed_comparison<TestType>(h1, m_h1, 1e3));
+    }
+    SECTION("degree = 3, g0")
+    {
+      REQUIRE(relaxed_comparison<TestType>(g0, m_g0, 1e3));
+    }
+    SECTION("degree = 3, g1")
+    {
+      REQUIRE(relaxed_comparison<TestType>(g1, m_g1, 1e3));
+    }
+    SECTION("degree = 3, phi_co")
+    {
+      REQUIRE(relaxed_comparison<TestType>(phi_co, m_phi_co, 1e3));
+    }
     SECTION("degree = 3, scale_co")
     {
-      relaxed_comparison(scale_co, m_scale_co);
+      REQUIRE(relaxed_comparison<TestType>(scale_co, m_scale_co, 1e3));
     }
   }
 }
@@ -99,15 +108,6 @@ TEMPLATE_TEST_CASE("Multiwavelet", "[transformations]", double, float)
 TEMPLATE_TEST_CASE("operator_two_scale function working appropriately",
                    "[transformations]", double)
 {
-  auto const relaxed_comparison = [](auto const first, auto const second) {
-    auto first_it = first.begin();
-    std::for_each(second.begin(), second.end(), [&first_it](auto &second_elem) {
-      REQUIRE(Approx(*first_it++)
-                  .epsilon(std::numeric_limits<TestType>::epsilon() * 1e4) ==
-              second_elem);
-    });
-  };
-
   SECTION("operator_two_scale(2, 2)")
   {
     int const degree = 2;
@@ -122,7 +122,7 @@ TEMPLATE_TEST_CASE("operator_two_scale function working appropriately",
             std::to_string(degree) + "_" + std::to_string(levels) + ".dat"));
     fk::matrix<TestType> const test =
         operator_two_scale<TestType>(dim.get_degree(), dim.get_level());
-    relaxed_comparison(gold, test);
+    REQUIRE(relaxed_comparison<TestType>(gold, test, 1e4));
   }
 
   SECTION("operator_two_scale(2, 3)")
@@ -139,7 +139,7 @@ TEMPLATE_TEST_CASE("operator_two_scale function working appropriately",
             std::to_string(degree) + "_" + std::to_string(levels) + ".dat"));
     fk::matrix<TestType> const test =
         operator_two_scale<TestType>(dim.get_degree(), dim.get_level());
-    relaxed_comparison(gold, test);
+    REQUIRE(relaxed_comparison<TestType>(gold, test, 1e4));
   }
   SECTION("operator_two_scale(4, 3)")
   {
@@ -154,7 +154,7 @@ TEMPLATE_TEST_CASE("operator_two_scale function working appropriately",
         std::to_string(degree) + "_" + std::to_string(levels) + ".dat");
     fk::matrix<TestType> const test =
         operator_two_scale<TestType>(dim.get_degree(), dim.get_level());
-    relaxed_comparison(gold, test);
+    REQUIRE(relaxed_comparison<TestType>(gold, test, 1e4));
   }
   SECTION("operator_two_scale(5, 5)")
   {
@@ -168,7 +168,7 @@ TEMPLATE_TEST_CASE("operator_two_scale function working appropriately",
         std::to_string(degree) + "_" + std::to_string(levels) + ".dat");
     fk::matrix<TestType> const test =
         operator_two_scale<TestType>(dim.get_degree(), dim.get_level());
-    relaxed_comparison(gold, test);
+    REQUIRE(relaxed_comparison<TestType>(gold, test, 1e4));
   }
 
   SECTION("operator_two_scale(2, 6)")
@@ -185,6 +185,6 @@ TEMPLATE_TEST_CASE("operator_two_scale function working appropriately",
         std::to_string(degree) + "_" + std::to_string(levels) + ".dat");
     fk::matrix<TestType> const test =
         operator_two_scale<TestType>(dim.get_degree(), dim.get_level());
-    relaxed_comparison(gold, test);
+    REQUIRE(relaxed_comparison<TestType>(gold, test, 1e4));
   }
 }

--- a/src/batch_tests.cpp
+++ b/src/batch_tests.cpp
@@ -1633,26 +1633,6 @@ TEMPLATE_TEST_CASE("kronmult batching", "[batch]", float, double)
 
 TEMPLATE_TEST_CASE("batch builder", "[batch]", float, double)
 {
-  auto const relaxed_comparison = [](auto const &first, auto const &second) {
-    auto const diff = first - second;
-
-    auto const abs_compare = [](TestType const a, TestType const b) {
-      return (std::abs(a) < std::abs(b));
-    };
-    TestType const result =
-        std::abs(*std::max_element(diff.begin(), diff.end(), abs_compare));
-    if constexpr (std::is_same<TestType, double>::value)
-    {
-      TestType const tol = std::numeric_limits<TestType>::epsilon() * 1e5;
-      REQUIRE(result <= tol);
-    }
-    else
-    {
-      TestType const tol = std::numeric_limits<TestType>::epsilon() * 1e3;
-      REQUIRE(result <= tol);
-    }
-  };
-
   SECTION("1d, 1 term, degree 2, level 2")
   {
     int const degree = 2;
@@ -1693,7 +1673,7 @@ TEMPLATE_TEST_CASE("batch builder", "[batch]", float, double)
     batch<TestType> const r_c = batches[1][2];
     batched_gemv(r_a, r_b, r_c, alpha, beta);
 
-    relaxed_comparison(gold, system.batch_output);
+    REQUIRE(diff_comparison<TestType>(gold, system.batch_output));
   }
 
   SECTION("1d, 1 term, degree 4, level 3")
@@ -1737,7 +1717,7 @@ TEMPLATE_TEST_CASE("batch builder", "[batch]", float, double)
     batch<TestType> const r_c = batches[1][2];
     batched_gemv(r_a, r_b, r_c, alpha, beta);
 
-    relaxed_comparison(gold, system.batch_output);
+    REQUIRE(diff_comparison<TestType>(gold, system.batch_output));
   }
 
   SECTION("2d, 2 terms, level 2, degree 2")
@@ -1792,7 +1772,7 @@ TEMPLATE_TEST_CASE("batch builder", "[batch]", float, double)
     fk::vector<TestType> const gold =
         fk::vector<TestType>(read_vector_from_txt_file(file_path));
 
-    relaxed_comparison(gold, system.batch_output);
+    REQUIRE(diff_comparison<TestType>(gold, system.batch_output));
   }
 
   SECTION("2d, 2 terms, level 3, degree 4, full grid")
@@ -1847,7 +1827,7 @@ TEMPLATE_TEST_CASE("batch builder", "[batch]", float, double)
     fk::vector<TestType> const gold =
         fk::vector<TestType>(read_vector_from_txt_file(file_path));
 
-    relaxed_comparison(gold, system.batch_output);
+    REQUIRE(diff_comparison<TestType>(gold, system.batch_output));
   }
 
   SECTION("3d, 3 terms, level 3, degree 4, sparse grid")
@@ -1902,7 +1882,7 @@ TEMPLATE_TEST_CASE("batch builder", "[batch]", float, double)
     fk::vector<TestType> const gold =
         fk::vector<TestType>(read_vector_from_txt_file(file_path));
 
-    relaxed_comparison(gold, system.batch_output);
+    REQUIRE(diff_comparison<TestType>(gold, system.batch_output));
   }
 
   SECTION("6d, 6 terms, level 2, degree 3, sparse grid")
@@ -1957,32 +1937,12 @@ TEMPLATE_TEST_CASE("batch builder", "[batch]", float, double)
     fk::vector<TestType> const gold =
         fk::vector<TestType>(read_vector_from_txt_file(file_path));
 
-    relaxed_comparison(gold, system.batch_output);
+    REQUIRE(diff_comparison<TestType>(gold, system.batch_output));
   }
 }
 
 TEMPLATE_TEST_CASE("batch splitter", "[batch]", float, double)
 {
-  auto const relaxed_comparison = [](auto const &first, auto const &second) {
-    auto const diff = first - second;
-
-    auto const abs_compare = [](TestType const a, TestType const b) {
-      return (std::abs(a) < std::abs(b));
-    };
-    TestType const result =
-        std::abs(*std::max_element(diff.begin(), diff.end(), abs_compare));
-    if constexpr (std::is_same<TestType, double>::value)
-    {
-      TestType const tol = std::numeric_limits<TestType>::epsilon() * 1e5;
-      REQUIRE(result <= tol);
-    }
-    else
-    {
-      TestType const tol = std::numeric_limits<TestType>::epsilon() * 1e3;
-      REQUIRE(result <= tol);
-    }
-  };
-
   // sanity checks for each pde w/ no workspace limit (no splitting)
   SECTION("1d, 1 term, degree 4, level 3")
   {
@@ -2025,7 +1985,7 @@ TEMPLATE_TEST_CASE("batch splitter", "[batch]", float, double)
     batch<TestType> const r_c = batches[1][2];
     batched_gemv(r_a, r_b, r_c, alpha, beta);
 
-    relaxed_comparison(gold, system.batch_output);
+    REQUIRE(diff_comparison<TestType>(gold, system.batch_output));
   }
 
   SECTION("2d, 2 terms, level 3, degree 4, full grid")
@@ -2080,7 +2040,7 @@ TEMPLATE_TEST_CASE("batch splitter", "[batch]", float, double)
     fk::vector<TestType> const gold =
         fk::vector<TestType>(read_vector_from_txt_file(file_path));
 
-    relaxed_comparison(gold, system.batch_output);
+    REQUIRE(diff_comparison<TestType>(gold, system.batch_output));
   }
 
   SECTION("3d, 3 terms, level 3, degree 4, sparse grid")
@@ -2135,7 +2095,7 @@ TEMPLATE_TEST_CASE("batch splitter", "[batch]", float, double)
     fk::vector<TestType> const gold =
         fk::vector<TestType>(read_vector_from_txt_file(file_path));
 
-    relaxed_comparison(gold, system.batch_output);
+    REQUIRE(diff_comparison<TestType>(gold, system.batch_output));
   }
   SECTION("6d, 6 terms, level 2, degree 3, sparse grid")
   {
@@ -2189,7 +2149,7 @@ TEMPLATE_TEST_CASE("batch splitter", "[batch]", float, double)
     fk::vector<TestType> const gold =
         fk::vector<TestType>(read_vector_from_txt_file(file_path));
 
-    relaxed_comparison(gold, system.batch_output);
+    REQUIRE(diff_comparison<TestType>(gold, system.batch_output));
   }
 
   // now, check highest level of splitting (1 MB limit)
@@ -2240,7 +2200,7 @@ TEMPLATE_TEST_CASE("batch splitter", "[batch]", float, double)
       TestType const reduction_beta = (i == 0) ? 0.0 : 1.0;
       batched_gemv(r_a, r_b, r_c, alpha, reduction_beta);
     }
-    relaxed_comparison(gold, system.batch_output);
+    REQUIRE(diff_comparison<TestType>(gold, system.batch_output));
   }
 
   SECTION("2d, 2 terms, level 3, degree 4, full grid")
@@ -2300,7 +2260,7 @@ TEMPLATE_TEST_CASE("batch splitter", "[batch]", float, double)
     fk::vector<TestType> const gold =
         fk::vector<TestType>(read_vector_from_txt_file(file_path));
 
-    relaxed_comparison(gold, system.batch_output);
+    REQUIRE(diff_comparison<TestType>(gold, system.batch_output));
   }
 
   SECTION("3d, 3 terms, level 3, degree 4, sparse grid")
@@ -2361,7 +2321,7 @@ TEMPLATE_TEST_CASE("batch splitter", "[batch]", float, double)
     fk::vector<TestType> const gold =
         fk::vector<TestType>(read_vector_from_txt_file(file_path));
 
-    relaxed_comparison(gold, system.batch_output);
+    REQUIRE(diff_comparison<TestType>(gold, system.batch_output));
   }
 
   SECTION("6d, 6 terms, level 2, degree 3, sparse grid")
@@ -2422,6 +2382,6 @@ TEMPLATE_TEST_CASE("batch splitter", "[batch]", float, double)
     fk::vector<TestType> const gold =
         fk::vector<TestType>(read_vector_from_txt_file(file_path));
 
-    relaxed_comparison(gold, system.batch_output);
+    REQUIRE(diff_comparison<TestType>(gold, system.batch_output));
   }
 }

--- a/src/coefficients_tests.cpp
+++ b/src/coefficients_tests.cpp
@@ -4,19 +4,6 @@
 #include "tensors.hpp"
 #include "tests_general.hpp"
 
-template<typename P>
-static inline void relaxed_comparison(fk::matrix<double> const first,
-                                      fk::matrix<double> const second)
-{
-  auto first_it = first.begin();
-
-  std::for_each(second.begin(), second.end(), [&first_it](auto &second_elem) {
-    REQUIRE(
-        Approx(*first_it++).epsilon(std::numeric_limits<P>::epsilon() * 1e3) ==
-        second_elem);
-  });
-}
-
 TEMPLATE_TEST_CASE("continuity 1 (single term)", "[coefficients]", double,
                    float)
 {
@@ -26,7 +13,7 @@ TEMPLATE_TEST_CASE("continuity 1 (single term)", "[coefficients]", double,
   fk::matrix<double> const gold = read_matrix_from_txt_file(filename);
   fk::matrix<double> const test = generate_coefficients<TestType>(
       continuity1->get_dimensions()[0], continuity1->get_terms()[0][0], 0.0);
-  relaxed_comparison<TestType>(gold, test);
+  REQUIRE(relaxed_comparison<TestType>(gold, test, 1e3));
 }
 
 TEMPLATE_TEST_CASE("continuity 2 terms", "[coefficients]", double, float)
@@ -47,7 +34,7 @@ TEMPLATE_TEST_CASE("continuity 2 terms", "[coefficients]", double, float)
       fk::matrix<double> const gold = read_matrix_from_txt_file(filename);
       fk::matrix<double> const test = generate_coefficients<TestType>(
           pde->get_dimensions()[d], pde->get_terms()[t][d], time);
-      relaxed_comparison<TestType>(gold, test);
+      REQUIRE(relaxed_comparison<TestType>(gold, test, 1e3));
     }
   }
 }
@@ -70,7 +57,7 @@ TEMPLATE_TEST_CASE("continuity 3 terms", "[coefficients]", double, float)
       fk::matrix<double> const gold = read_matrix_from_txt_file(filename);
       fk::matrix<double> const test = generate_coefficients<TestType>(
           pde->get_dimensions()[d], pde->get_terms()[t][d], time);
-      relaxed_comparison<TestType>(gold, test);
+      REQUIRE(relaxed_comparison<TestType>(gold, test, 1e3));
     }
   }
 }
@@ -93,7 +80,7 @@ TEMPLATE_TEST_CASE("continuity 6 terms", "[coefficients]", double, float)
       fk::matrix<double> const gold = read_matrix_from_txt_file(filename);
       fk::matrix<double> const test = generate_coefficients<TestType>(
           pde->get_dimensions()[d], pde->get_terms()[t][d], time);
-      relaxed_comparison<TestType>(gold, test);
+      REQUIRE(relaxed_comparison<TestType>(gold, test, 1e3));
     }
   }
 }

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -95,7 +95,7 @@ public:
 private:
   void set_level(int level)
   {
-    assert(level > 0);
+    assert(level > 1);
     level_         = level;
     int const dofs = degree_ * two_raised_to(level_);
     to_basis_operator_.clear_and_resize(dofs, dofs) =
@@ -322,13 +322,13 @@ public:
 
     // modify for appropriate level/degree
     // if default lev/degree not used
-    if (num_levels > 0 || degree > 0)
+    if (num_levels > 1 || degree > 0)
     {
       // FIXME -- temp -- eventually independent levels for each dim will be
 
       for (dimension<P> &d : dimensions_)
       {
-        if (num_levels > 0)
+        if (num_levels > 1)
           d.set_level(num_levels);
         if (degree > 0)
           d.set_degree(degree);
@@ -350,7 +350,7 @@ public:
     for (dimension<P> const d : dimensions_)
     {
       assert(d.get_degree() > 0);
-      assert(d.get_level() > 0);
+      assert(d.get_level() > 1);
       assert(d.domain_max > d.domain_min);
     }
 

--- a/src/pde_tests.cpp
+++ b/src/pde_tests.cpp
@@ -7,8 +7,9 @@
 // our trig functions don't exactly match matlab. we need a little wiggle room.
 auto relaxed_compare = [](auto fx, auto gold) {
   auto relaxed_epsilon = std::numeric_limits<decltype(gold)>::epsilon() * 1e2;
-  REQUIRE(Approx(fx).epsilon(relaxed_epsilon) == gold);
+  return Approx(fx).epsilon(relaxed_epsilon) == gold;
 };
+
 TEMPLATE_TEST_CASE("testing contuinity 1 implementations", "[pde]", double,
                    float)
 {
@@ -23,7 +24,7 @@ TEMPLATE_TEST_CASE("testing contuinity 1 implementations", "[pde]", double,
       TestType const gold = read_scalar_from_txt_file(
           base_dir + "initial_dim" + std::to_string(i) + ".dat");
       TestType const fx = pde->get_dimensions()[i].initial_condition(x)(0);
-      relaxed_compare(fx, gold);
+      REQUIRE(relaxed_compare(fx, gold));
     }
   }
 
@@ -34,12 +35,12 @@ TEMPLATE_TEST_CASE("testing contuinity 1 implementations", "[pde]", double,
       TestType const gold = read_scalar_from_txt_file(
           base_dir + "exact_dim" + std::to_string(i) + ".dat");
       TestType const fx = pde->exact_vector_funcs[i](x)(0);
-      relaxed_compare(fx, gold);
+      REQUIRE(relaxed_compare(fx, gold));
     }
     TestType const gold =
         read_scalar_from_txt_file(base_dir + "exact_time.dat");
     TestType const fx = pde->exact_time(x(0));
-    relaxed_compare(fx, gold);
+    REQUIRE(relaxed_compare(fx, gold));
   }
   SECTION("continuity 1 source functions")
   {
@@ -53,12 +54,12 @@ TEMPLATE_TEST_CASE("testing contuinity 1 implementations", "[pde]", double,
             source_string + "dim" + std::to_string(j) + ".dat";
         TestType const gold = read_scalar_from_txt_file(full_path);
         TestType const fx   = pde->sources[i].source_funcs[j](x)(0);
-        relaxed_compare(fx, gold);
+        REQUIRE(relaxed_compare(fx, gold));
       }
       TestType const gold =
           read_scalar_from_txt_file(source_string + "time.dat");
       TestType const fx = pde->sources[i].time_func(x(0));
-      relaxed_compare(fx, gold);
+      REQUIRE(relaxed_compare(fx, gold));
     }
   }
 
@@ -83,7 +84,7 @@ TEMPLATE_TEST_CASE("testing contuinity 2 implementations", "[pde]", double,
       TestType const gold = read_scalar_from_txt_file(
           base_dir + "initial_dim" + std::to_string(i) + ".dat");
       TestType const fx = pde->get_dimensions()[i].initial_condition(x)(0);
-      relaxed_compare(fx, gold);
+      REQUIRE(relaxed_compare(fx, gold));
     }
   }
 
@@ -94,12 +95,12 @@ TEMPLATE_TEST_CASE("testing contuinity 2 implementations", "[pde]", double,
       TestType const gold = read_scalar_from_txt_file(
           base_dir + "exact_dim" + std::to_string(i) + ".dat");
       TestType const fx = pde->exact_vector_funcs[i](x)(0);
-      relaxed_compare(fx, gold);
+      REQUIRE(relaxed_compare(fx, gold));
     }
     TestType const gold =
         read_scalar_from_txt_file(base_dir + "exact_time.dat");
     TestType const fx = pde->exact_time(x(0));
-    relaxed_compare(fx, gold);
+    REQUIRE(relaxed_compare(fx, gold));
   }
   SECTION("continuity 2 source functions")
   {
@@ -113,12 +114,12 @@ TEMPLATE_TEST_CASE("testing contuinity 2 implementations", "[pde]", double,
             source_string + "dim" + std::to_string(j) + ".dat";
         TestType const gold = read_scalar_from_txt_file(full_path);
         TestType const fx   = pde->sources[i].source_funcs[j](x)(0);
-        relaxed_compare(fx, gold);
+        REQUIRE(relaxed_compare(fx, gold));
       }
       TestType const gold =
           read_scalar_from_txt_file(source_string + "time.dat");
       TestType const fx = pde->sources[i].time_func(x(0));
-      relaxed_compare(fx, gold);
+      REQUIRE(relaxed_compare(fx, gold));
     }
   }
 
@@ -145,7 +146,7 @@ TEMPLATE_TEST_CASE("testing contuinity 3 implementations", "[pde]", double,
           base_dir + "initial_dim" + std::to_string(i) + ".dat");
 
       TestType const fx = pde->get_dimensions()[i].initial_condition(x)(0);
-      relaxed_compare(fx, gold);
+      REQUIRE(relaxed_compare(fx, gold));
     }
   }
 
@@ -156,12 +157,12 @@ TEMPLATE_TEST_CASE("testing contuinity 3 implementations", "[pde]", double,
       TestType const gold = read_scalar_from_txt_file(
           base_dir + "exact_dim" + std::to_string(i) + ".dat");
       TestType const fx = pde->exact_vector_funcs[i](x)(0);
-      relaxed_compare(fx, gold);
+      REQUIRE(relaxed_compare(fx, gold));
     }
     TestType const gold =
         read_scalar_from_txt_file(base_dir + "exact_time.dat");
     TestType const fx = pde->exact_time(x(0));
-    relaxed_compare(fx, gold);
+    REQUIRE(relaxed_compare(fx, gold));
   }
   SECTION("continuity 3 source functions")
   {
@@ -175,13 +176,13 @@ TEMPLATE_TEST_CASE("testing contuinity 3 implementations", "[pde]", double,
             source_string + "dim" + std::to_string(j) + ".dat";
         TestType const gold = read_scalar_from_txt_file(full_path);
         TestType const fx   = pde->sources[i].source_funcs[j](x)(0);
-        relaxed_compare(fx, gold);
+        REQUIRE(relaxed_compare(fx, gold));
       }
 
       TestType const gold =
           read_scalar_from_txt_file(source_string + "time.dat");
       TestType const fx = pde->sources[i].time_func(x(0));
-      relaxed_compare(fx, gold);
+      REQUIRE(relaxed_compare(fx, gold));
     }
   }
 
@@ -208,7 +209,7 @@ TEMPLATE_TEST_CASE("testing contuinity 6 implementations", "[pde]", double,
           base_dir + "initial_dim" + std::to_string(i) + ".dat");
 
       TestType const fx = pde->get_dimensions()[i].initial_condition(x)(0);
-      relaxed_compare(fx, gold);
+      REQUIRE(relaxed_compare(fx, gold));
     }
   }
 
@@ -219,12 +220,12 @@ TEMPLATE_TEST_CASE("testing contuinity 6 implementations", "[pde]", double,
       TestType const gold = read_scalar_from_txt_file(
           base_dir + "exact_dim" + std::to_string(i) + ".dat");
       TestType const fx = pde->exact_vector_funcs[i](x)(0);
-      relaxed_compare(fx, gold);
+      REQUIRE(relaxed_compare(fx, gold));
     }
     TestType const gold =
         read_scalar_from_txt_file(base_dir + "exact_time.dat");
     TestType const fx = pde->exact_time(x(0));
-    relaxed_compare(fx, gold);
+    REQUIRE(relaxed_compare(fx, gold));
   }
   SECTION("continuity 6 source functions")
   {
@@ -238,13 +239,13 @@ TEMPLATE_TEST_CASE("testing contuinity 6 implementations", "[pde]", double,
             source_string + "dim" + std::to_string(j) + ".dat";
         TestType const gold = read_scalar_from_txt_file(full_path);
         TestType const fx   = pde->sources[i].source_funcs[j](x)(0);
-        relaxed_compare(fx, gold);
+        REQUIRE(relaxed_compare(fx, gold));
       }
 
       TestType const gold =
           read_scalar_from_txt_file(source_string + "time.dat");
       TestType const fx = pde->sources[i].time_func(x(0));
-      relaxed_compare(fx, gold);
+      REQUIRE(relaxed_compare(fx, gold));
     }
   }
 

--- a/src/program_options.cpp
+++ b/src/program_options.cpp
@@ -57,9 +57,9 @@ options::options(int argc, char **argv)
     std::cerr << "Degree must be a natural number" << std::endl;
     valid = false;
   }
-  if (level < 1 && level != -1)
+  if (level < 2 && level != -1)
   {
-    std::cerr << "Level must be a natural number" << std::endl;
+    std::cerr << "Level must be a natural number greater than one" << std::endl;
     valid = false;
   }
   if (num_time_steps < 1)

--- a/src/quadrature_tests.cpp
+++ b/src/quadrature_tests.cpp
@@ -7,20 +7,6 @@
 TEMPLATE_TEST_CASE("legendre/legendre derivative function", "[matlab]", double,
                    float)
 {
-  // the relaxed comparison is due to:
-  // 1) difference in precision in calculations
-  // (c++ float/double vs matlab always double)
-  // 2) the reordered operations make very subtle differences
-  // requiring relaxed comparison for certain inputs
-  auto const relaxed_comparison = [](auto const first, auto const second) {
-    auto first_it = first.begin();
-    std::for_each(second.begin(), second.end(), [&first_it](auto &second_elem) {
-      REQUIRE(Approx(*first_it++)
-                  .epsilon(std::numeric_limits<TestType>::epsilon() * 1e2) ==
-              second_elem);
-    });
-  };
-
   SECTION("legendre(-1,0)")
   {
     fk::matrix<TestType> const poly_gold  = {{1.0}};
@@ -66,23 +52,14 @@ TEMPLATE_TEST_CASE("legendre/legendre derivative function", "[matlab]", double,
     int const degree         = 5;
     auto const [poly, deriv] = legendre(in, degree);
 
-    relaxed_comparison(poly, poly_gold);
-    relaxed_comparison(deriv, deriv_gold);
+    REQUIRE(relaxed_comparison<TestType>(poly, poly_gold, 1e2));
+    REQUIRE(relaxed_comparison<TestType>(deriv, deriv_gold, 1e2));
   }
 }
 
 TEMPLATE_TEST_CASE("legendre weights and roots function", "[matlab]", double,
                    float)
 {
-  auto const relaxed_comparison = [](auto const first, auto const second) {
-    auto first_it = first.begin();
-    std::for_each(second.begin(), second.end(), [&first_it](auto &second_elem) {
-      REQUIRE(Approx(*first_it++)
-                  .epsilon(std::numeric_limits<TestType>::epsilon() * 1e2) ==
-              second_elem);
-    });
-  };
-
   SECTION("legendre_weights(10, -1, 1)")
   {
     fk::matrix<TestType> const roots_gold =
@@ -98,8 +75,8 @@ TEMPLATE_TEST_CASE("legendre weights and roots function", "[matlab]", double,
     const int b                 = 1;
     auto const [roots, weights] = legendre_weights<TestType>(n, a, b);
 
-    relaxed_comparison(roots, roots_gold);
-    relaxed_comparison(weights, weights_gold);
+    REQUIRE(relaxed_comparison<TestType>(roots, roots_gold, 1e2));
+    REQUIRE(relaxed_comparison<TestType>(weights, weights_gold, 1e2));
   }
 
   SECTION("legendre_weights(32, -5, 2)")
@@ -117,7 +94,7 @@ TEMPLATE_TEST_CASE("legendre weights and roots function", "[matlab]", double,
     const int b                 = 2;
     auto const [roots, weights] = legendre_weights<TestType>(n, a, b);
 
-    relaxed_comparison(roots, roots_gold);
-    relaxed_comparison(weights, weights_gold);
+    REQUIRE(relaxed_comparison<TestType>(roots, roots_gold, 1e2));
+    REQUIRE(relaxed_comparison<TestType>(weights, weights_gold, 1e2));
   }
 }

--- a/src/time_advance_tests.cpp
+++ b/src/time_advance_tests.cpp
@@ -4,33 +4,12 @@
 #include "tests_general.hpp"
 #include "time_advance.hpp"
 #include "transformations.hpp"
-#include <numeric>
 #include <random>
 
 TEMPLATE_TEST_CASE("time advance - continuity 1", "[time_advance]", float,
                    double)
 
 {
-  auto const relaxed_comparison = [](auto const &first, auto const &second) {
-    auto const diff = first - second;
-
-    auto const abs_compare = [](TestType const a, TestType const b) {
-      return (std::abs(a) < std::abs(b));
-    };
-    TestType const result =
-        std::abs(*std::max_element(diff.begin(), diff.end(), abs_compare));
-    if constexpr (std::is_same<TestType, double>::value)
-    {
-      TestType const tol = std::numeric_limits<TestType>::epsilon() * 1e5;
-      REQUIRE(result <= tol);
-    }
-    else
-    {
-      TestType const tol = std::numeric_limits<TestType>::epsilon() * 1e3;
-      REQUIRE(result <= tol);
-    }
-  };
-
   int const test_steps = 5;
 
   SECTION("continuity1, level 2, degree 2, sparse grid")
@@ -106,7 +85,7 @@ TEMPLATE_TEST_CASE("time advance - continuity 1", "[time_advance]", float,
       fk::vector<TestType> const gold =
           fk::vector<TestType>(read_vector_from_txt_file(file_path));
 
-      relaxed_comparison(gold, system.batch_output);
+      REQUIRE(diff_comparison<TestType>(gold, system.batch_output));
     }
   }
 
@@ -183,7 +162,7 @@ TEMPLATE_TEST_CASE("time advance - continuity 1", "[time_advance]", float,
       fk::vector<TestType> const gold =
           fk::vector<TestType>(read_vector_from_txt_file(file_path));
 
-      relaxed_comparison(gold, system.batch_output);
+      REQUIRE(diff_comparison<TestType>(gold, system.batch_output));
     }
   }
   SECTION("continuity1, level 4, degree 3, sparse grid")
@@ -259,7 +238,7 @@ TEMPLATE_TEST_CASE("time advance - continuity 1", "[time_advance]", float,
       fk::vector<TestType> const gold =
           fk::vector<TestType>(read_vector_from_txt_file(file_path));
 
-      relaxed_comparison(gold, system.batch_output);
+      REQUIRE(diff_comparison<TestType>(gold, system.batch_output));
     }
   }
 }
@@ -268,26 +247,6 @@ TEMPLATE_TEST_CASE("time advance - continuity 2", "[time_advance]", float,
                    double)
 
 {
-  auto const relaxed_comparison = [](auto const &first, auto const &second) {
-    auto const diff = first - second;
-
-    auto const abs_compare = [](TestType const a, TestType const b) {
-      return (std::abs(a) < std::abs(b));
-    };
-    TestType const result =
-        std::abs(*std::max_element(diff.begin(), diff.end(), abs_compare));
-    if constexpr (std::is_same<TestType, double>::value)
-    {
-      TestType const tol = std::numeric_limits<TestType>::epsilon() * 1e5;
-      REQUIRE(result <= tol);
-    }
-    else
-    {
-      TestType const tol = std::numeric_limits<TestType>::epsilon() * 1e3;
-      REQUIRE(result <= tol);
-    }
-  };
-
   int const test_steps = 5;
   SECTION("continuity2, level 2, degree 2, sparse grid")
   {
@@ -362,7 +321,7 @@ TEMPLATE_TEST_CASE("time advance - continuity 2", "[time_advance]", float,
       fk::vector<TestType> const gold =
           fk::vector<TestType>(read_vector_from_txt_file(file_path));
 
-      relaxed_comparison(gold, system.batch_output);
+      REQUIRE(diff_comparison<TestType>(gold, system.batch_output));
     }
   }
 
@@ -439,7 +398,7 @@ TEMPLATE_TEST_CASE("time advance - continuity 2", "[time_advance]", float,
       fk::vector<TestType> const gold =
           fk::vector<TestType>(read_vector_from_txt_file(file_path));
 
-      relaxed_comparison(gold, system.batch_output);
+      REQUIRE(diff_comparison<TestType>(gold, system.batch_output));
     }
   }
   SECTION("continuity2, level 4, degree 3, sparse grid")
@@ -515,7 +474,7 @@ TEMPLATE_TEST_CASE("time advance - continuity 2", "[time_advance]", float,
       fk::vector<TestType> const gold =
           fk::vector<TestType>(read_vector_from_txt_file(file_path));
 
-      relaxed_comparison(gold, system.batch_output);
+      REQUIRE(diff_comparison<TestType>(gold, system.batch_output));
     }
   }
 }
@@ -523,26 +482,6 @@ TEMPLATE_TEST_CASE("time advance - continuity 2", "[time_advance]", float,
 TEMPLATE_TEST_CASE("time advance - continuity 3", "[time_advance]", float,
                    double)
 {
-  auto const relaxed_comparison = [](auto const &first, auto const &second) {
-    auto const diff = first - second;
-
-    auto const abs_compare = [](TestType const a, TestType const b) {
-      return (std::abs(a) < std::abs(b));
-    };
-    TestType const result =
-        std::abs(*std::max_element(diff.begin(), diff.end(), abs_compare));
-    if constexpr (std::is_same<TestType, double>::value)
-    {
-      TestType const tol = std::numeric_limits<TestType>::epsilon() * 1e5;
-      REQUIRE(result <= tol);
-    }
-    else
-    {
-      TestType const tol = std::numeric_limits<TestType>::epsilon() * 1e3;
-      REQUIRE(result <= tol);
-    }
-  };
-
   int const test_steps = 5;
   SECTION("continuity3, level 2, degree 2, sparse grid")
   {
@@ -617,7 +556,7 @@ TEMPLATE_TEST_CASE("time advance - continuity 3", "[time_advance]", float,
       fk::vector<TestType> const gold =
           fk::vector<TestType>(read_vector_from_txt_file(file_path));
 
-      relaxed_comparison(gold, system.batch_output);
+      REQUIRE(diff_comparison<TestType>(gold, system.batch_output));
     }
   }
 
@@ -694,7 +633,7 @@ TEMPLATE_TEST_CASE("time advance - continuity 3", "[time_advance]", float,
       fk::vector<TestType> const gold =
           fk::vector<TestType>(read_vector_from_txt_file(file_path));
 
-      relaxed_comparison(gold, system.batch_output);
+      REQUIRE(diff_comparison<TestType>(gold, system.batch_output));
     }
   }
 }
@@ -702,25 +641,6 @@ TEMPLATE_TEST_CASE("time advance - continuity 3", "[time_advance]", float,
 TEMPLATE_TEST_CASE("time advance - continuity 6", "[time_advance]", float,
                    double)
 {
-  auto const relaxed_comparison = [](auto const &first, auto const &second) {
-    auto const diff = first - second;
-
-    auto const abs_compare = [](TestType const a, TestType const b) {
-      return (std::abs(a) < std::abs(b));
-    };
-    TestType const result =
-        std::abs(*std::max_element(diff.begin(), diff.end(), abs_compare));
-    if constexpr (std::is_same<TestType, double>::value)
-    {
-      TestType const tol = std::numeric_limits<TestType>::epsilon() * 1e5;
-      REQUIRE(result <= tol);
-    }
-    else
-    {
-      TestType const tol = std::numeric_limits<TestType>::epsilon() * 1e3;
-      REQUIRE(result <= tol);
-    }
-  };
   int const test_steps = 5;
   SECTION("continuity6, level 2, degree 2, sparse grid")
   {
@@ -794,7 +714,7 @@ TEMPLATE_TEST_CASE("time advance - continuity 6", "[time_advance]", float,
       fk::vector<TestType> const gold =
           fk::vector<TestType>(read_vector_from_txt_file(file_path));
 
-      relaxed_comparison(gold, system.batch_output);
+      REQUIRE(diff_comparison<TestType>(gold, system.batch_output));
     }
   }
 
@@ -870,7 +790,7 @@ TEMPLATE_TEST_CASE("time advance - continuity 6", "[time_advance]", float,
       fk::vector<TestType> const gold =
           fk::vector<TestType>(read_vector_from_txt_file(file_path));
 
-      relaxed_comparison(gold, system.batch_output);
+      REQUIRE(diff_comparison<TestType>(gold, system.batch_output));
     }
   }
 }

--- a/src/transformations_tests.cpp
+++ b/src/transformations_tests.cpp
@@ -92,15 +92,6 @@ TEMPLATE_TEST_CASE("Combine dimensions", "[transformations]", double, float)
 TEMPLATE_TEST_CASE("forward multi-wavelet transform", "[transformations]",
                    double, float)
 {
-  auto const relaxed_comparison = [](auto const first, auto const second) {
-    auto first_it = first.begin();
-    std::for_each(second.begin(), second.end(), [&first_it](auto &second_elem) {
-      REQUIRE(Approx(*first_it++)
-                  .epsilon(std::numeric_limits<TestType>::epsilon() * 1e4) ==
-              second_elem);
-    });
-  };
-
   SECTION("transform(2, 2, -1, 1, double)")
   {
     int const degree     = 2;
@@ -120,7 +111,7 @@ TEMPLATE_TEST_CASE("forward multi-wavelet transform", "[transformations]",
 
     fk::vector<TestType> const test =
         forward_transform<TestType>(dim, double_it);
-    relaxed_comparison(gold, test);
+    REQUIRE(relaxed_comparison<TestType>(gold, test, 1e4));
   }
 
   SECTION("transform(3, 4, -2.0, 2.0, double plus)")
@@ -144,6 +135,6 @@ TEMPLATE_TEST_CASE("forward multi-wavelet transform", "[transformations]",
     fk::vector<TestType> const test =
         forward_transform<TestType>(dim, double_plus);
 
-    relaxed_comparison(gold, test);
+    REQUIRE(relaxed_comparison<TestType>(gold, test, 1e4));
   }
 }

--- a/testing/tests_general.hpp
+++ b/testing/tests_general.hpp
@@ -131,7 +131,7 @@ auto const cons_reduce_comparison(F const transform)
     auto accumulator = accumulator_init;
     // Confirm that both first_ptr and second_ptr are within
     // the bounds of their respective iterators
-    while (first_ptr < first_iter.end())
+    while (first_ptr < first_iter.end() && second_ptr < second_iter.end())
     {
       accumulator = transform(*first_ptr, *second_ptr, accumulator);
       first_ptr++;

--- a/testing/tests_general.hpp
+++ b/testing/tests_general.hpp
@@ -10,6 +10,7 @@
 #include "../src/pde.hpp"
 #include "../src/program_options.hpp"
 #include "catch.hpp"
+#include <numeric>
 #include <string>
 #include <vector>
 
@@ -67,4 +68,89 @@ dimension<P> make_dummy_dim(
 
 options make_options(std::vector<std::string> const arguments);
 
+// A function to construct a closure that will iterate over two iterators and
+// compare them using a provided lambda.
+// This is used to build functions like `relaxed_comparison` below.
+template<class F>
+inline auto const cons_relaxed_comparison(F const test)
+{
+  return [test](auto const &first_iter, auto const &second_iter) {
+    auto first_ptr = first_iter.begin();
+    for (auto second : second_iter)
+    {
+      // assert(first_ptr < first_iter.end());
+      if (!test(*first_ptr, second))
+      {
+        return false;
+      }
+      first_ptr++;
+    }
+    return true;
+  };
+}
+
+// the relaxed comparison is due to:
+// 1) difference in precision in calculations
+// (c++ float/double vs matlab always double)
+// 2) the reordered operations make very subtle differences
+// requiring relaxed comparison for certain inputs
+template<typename T>
+auto const relaxed_comparison =
+    [](auto const first, auto const second, auto const precision) {
+      return cons_relaxed_comparison(
+          [precision](auto const first, auto const second) {
+            return Approx(first).epsilon(std::numeric_limits<T>::epsilon() *
+                                         precision) == second;
+          })(first, second);
+    };
+
+// This is used for creating a function that reduces two iterators into an
+// accumulated value
+template<class F>
+auto const cons_reduce_comparison(F const transform)
+{
+  // A closure that iterates over the two iterators
+  //  and returns the accumulated value
+  return [transform](auto first_iter, auto second_iter, auto accumulator_init) {
+    auto first_ptr   = first_iter.begin();
+    auto second_ptr  = second_iter.begin();
+    auto accumulator = accumulator_init;
+    for (; first_ptr < first_iter.end();)
+    {
+      accumulator = transform(*first_ptr, *second_ptr, accumulator);
+      first_ptr++;
+      second_ptr++;
+    }
+    return accumulator;
+  };
+}
+
+// Confirm the difference between two iterators is below a tolerance
+template<typename T>
+auto const diff_comparison = [](auto const &first_iter,
+                                auto const &second_iter) {
+  // Create a function that will accumulate the greatest difference
+  // for each pair in the zipped iterators first_iter and second_iter
+  T const result = std::abs(cons_reduce_comparison(
+      [](auto const &first, auto const &second, auto const accumulator) {
+        auto const diff = std::abs(first - second);
+        if (diff > accumulator)
+        {
+          return diff;
+        }
+        return accumulator;
+      })(first_iter, second_iter, *first_iter.begin() - *second_iter.begin()));
+
+  // Return whether or not the difference is greater than the tolerance
+  if constexpr (std::is_same<T, double>::value)
+  {
+    T const tol = std::numeric_limits<T>::epsilon() * 1e5;
+    return result <= tol;
+  }
+  else
+  {
+    T const tol = std::numeric_limits<T>::epsilon() * 1e3;
+    return result <= tol;
+  }
+};
 #endif

--- a/testing/tests_general.hpp
+++ b/testing/tests_general.hpp
@@ -126,12 +126,13 @@ auto const cons_reduce_comparison(F const transform)
   //  and returns the accumulated value
   return [transform](auto const &first_iter, auto const &second_iter,
                      auto accumulator_init) {
+    // Create the iterators
     auto first_ptr   = first_iter.begin();
     auto second_ptr  = second_iter.begin();
     auto accumulator = accumulator_init;
     // Confirm that both first_ptr and second_ptr are within
     // the bounds of their respective iterators
-    for (; first_ptr < first_iter.end() && second_ptr < second_ptr.end();)
+    while (first_ptr < first_iter.end() && second_ptr < second_ptr.end())
     {
       accumulator = transform(*first_ptr, *second_ptr, accumulator);
       first_ptr++;

--- a/testing/tests_general.hpp
+++ b/testing/tests_general.hpp
@@ -144,30 +144,33 @@ auto const cons_reduce_comparison(F const transform)
 
 // Confirm the difference between two iterators is below a tolerance
 template<typename T>
-auto const diff_comparison = [](auto const &first_iter,
-                                auto const &second_iter) {
-  // Create a function that will accumulate the greatest difference
-  // for each pair in the zipped iterators first_iter and second_iter
-  T const result = std::abs(cons_reduce_comparison(
-      [](auto const &first, auto const &second, auto const accumulator) {
-        auto const diff = std::abs(first - second);
-        if (diff > accumulator)
-        {
-          return diff;
-        }
-        return accumulator;
-      })(first_iter, second_iter, *first_iter.begin() - *second_iter.begin()));
+auto const
+    diff_comparison = [](auto const &first_iter, auto const &second_iter) {
+      // The difference between the first objects in each iter
+      const auto initial_diff = *first_iter.begin() - *second_iter.begin();
 
-  // Return whether or not the difference is greater than the tolerance
-  if constexpr (std::is_same<T, double>::value)
-  {
-    T const tol = std::numeric_limits<T>::epsilon() * 1e5;
-    return result <= tol;
-  }
-  else
-  {
-    T const tol = std::numeric_limits<T>::epsilon() * 1e3;
-    return result <= tol;
-  }
-};
+      // Create a function that will accumulate the greatest difference
+      // for each pair in the zipped iterators first_iter and second_iter
+      T const result = std::abs(cons_reduce_comparison(
+          [](auto const &first, auto const &second, auto const accumulator) {
+            auto const diff = std::abs(first - second);
+            if (diff > accumulator)
+            {
+              return diff;
+            }
+            return accumulator;
+          })(first_iter, second_iter, initial_diff));
+
+      // Return whether or not the difference is greater than the tolerance
+      if constexpr (std::is_same<T, double>::value)
+      {
+        T const tol = std::numeric_limits<T>::epsilon() * 1e5;
+        return result <= tol;
+      }
+      else
+      {
+        T const tol = std::numeric_limits<T>::epsilon() * 1e3;
+        return result <= tol;
+      }
+    };
 #endif

--- a/testing/tests_general.hpp
+++ b/testing/tests_general.hpp
@@ -85,7 +85,6 @@ inline auto const cons_relaxed_comparison(F const test)
       // which I would prefer. However, this is just as safe,
       // it just looks quite a bit scarier.
       assert(first_ptr != first_iter.end());
-
       if (!test(*first_ptr, second))
       {
         return false;
@@ -132,7 +131,7 @@ auto const cons_reduce_comparison(F const transform)
     auto accumulator = accumulator_init;
     // Confirm that both first_ptr and second_ptr are within
     // the bounds of their respective iterators
-    while (first_ptr < first_iter.end() && second_ptr < second_ptr.end())
+    while (first_ptr < first_iter.end())
     {
       accumulator = transform(*first_ptr, *second_ptr, accumulator);
       first_ptr++;

--- a/testing/tests_general.hpp
+++ b/testing/tests_general.hpp
@@ -71,6 +71,9 @@ options make_options(std::vector<std::string> const arguments);
 // A function to construct a closure that will iterate over two iterators and
 // compare them using a provided lambda.
 // This is used to build functions like `relaxed_comparison` below.
+//
+// It runs the test function for each pair of objects in first and second iter,
+// and returns false if at any point the comparison is false
 template<class F>
 inline auto const cons_relaxed_comparison(F const test)
 {
@@ -94,6 +97,9 @@ inline auto const cons_relaxed_comparison(F const test)
 // (c++ float/double vs matlab always double)
 // 2) the reordered operations make very subtle differences
 // requiring relaxed comparison for certain inputs
+//
+// This works by iterating over each element in the first and second iterators,
+// and confirming that their values are each equal within a given precision
 template<typename T>
 auto const relaxed_comparison =
     [](auto const first, auto const second, auto const precision) {
@@ -105,7 +111,8 @@ auto const relaxed_comparison =
     };
 
 // This is used for creating a function that reduces two iterators into an
-// accumulated value
+// accumulated value.
+// This is used to implement diff comparison
 template<class F>
 auto const cons_reduce_comparison(F const transform)
 {


### PR DESCRIPTION
Get rid of / generalize `relaxed_comparison` as much as possible.
I'll clean up my changes to `testing/tests_general.hpp`, its pretty ugly right now.

I moved the `REQUIRE`s from inside the lambdas to where the lambdas are called, so you should be able to tell where the test actually failed.