### PR TITLE
Updated one of the stored octave scripts to be compatible with matlab

### DIFF
--- a/testing/scripts/coefficients/coeff_matrix.m
+++ b/testing/scripts/coefficients/coeff_matrix.m
@@ -328,14 +328,32 @@ Grad = Grad .* (abs(Grad) > tol );
 %          DeltaX * ...
 %          blkdiag( FMWT',FMWT');
 
-if type == 1 || type == 'grad'
-    mat = Grad;
+if isnumeric(type)
+    
+    if type == 1 
+        mat = Grad;
+    end
+    if type == 2 
+        mat = Mass;
+    end
+    if type == 3 
+        mat = Stif;
+    end
+    
+else
+    
+    if strcmp(type,'grad')
+        mat = Grad;
+    end
+    if strcmp(type,'mass')
+        mat = Mass;
+    end
+    if strcmp(type,'stif')
+        mat = Stif;
+    end
+    
 end
-if type == 2 || type == 'mass'
-    mat = Mass;
-end
-if type == 3 || type == 'stif'
-    mat = Stif;
-end
+
+
 
 end


### PR DESCRIPTION
Some of the hacking on the matlab functions to work around the issues associated with the `_updated` versions of the PDEs and `coeff_matrix` versus `coeff_matrix2` failed in matlab. This was due to a different way in why octave and matlab handle string comparisons. 

Let's do stuff in matlab from now on people.