### PR TITLE
Hardening/two raised to

### DIFF
--- a/src/basis.cpp
+++ b/src/basis.cpp
@@ -1,5 +1,6 @@
 #include "basis.hpp"
 
+#include "fast_math.hpp"
 #include "matlab_utilities.hpp"
 #include "quadrature.hpp"
 #include "tensors.hpp"
@@ -34,7 +35,7 @@ std::array<fk::matrix<P>, 6> generate_multi_wavelets(int const degree)
   // Negative one to zero --zero to one -- and negative one to one
   // since this is done on the "reference element" -1 to 1
   // the intervals are fixed to be (-1,0), (0,1), and (-1,1)
-  int const stepping = two_raised_to(6);
+  int const stepping = fm::two_raised_to(6);
   P const neg1       = -1.0;
   P const zero       = 0.0;
   P const one        = 1.0;
@@ -366,7 +367,7 @@ fk::matrix<R> operator_two_scale(int const degree, int const num_levels)
   assert(degree > 0);
   assert(num_levels > 0);
 
-  int const max_level = two_raised_to(num_levels);
+  int const max_level = fm::two_raised_to(num_levels);
 
   // this is to get around unused warnings
   // because can't unpack only some args w structured binding (until c++20)
@@ -405,7 +406,7 @@ fk::matrix<R> operator_two_scale(int const degree, int const num_levels)
     }
     else
     {
-      int const cn = two_raised_to(n - j + 1.0) * degree;
+      int const cn = fm::two_raised_to(n - j + 1.0) * degree;
 
       std::fill(cfmwt.begin(), cfmwt.end(), 0.0);
       cfmwt.set_submatrix(cn, cn, eye<R>(degree * max_level - cn));

--- a/src/coefficients.cpp
+++ b/src/coefficients.cpp
@@ -1,5 +1,6 @@
 #include "coefficients.hpp"
 
+#include "fast_math.hpp"
 #include "matlab_utilities.hpp"
 #include "pde.hpp"
 #include "quadrature.hpp"
@@ -69,7 +70,7 @@ template<typename P>
 static std::array<fk::matrix<int>, 2>
 flux_or_boundary_indices(dimension<P> const &dim, int const index)
 {
-  int const two_to_lev             = two_raised_to(dim.get_level());
+  int const two_to_lev             = fm::two_raised_to(dim.get_level());
   int const previous_index         = (index - 1) * dim.get_degree();
   int const current_index          = index * dim.get_degree();
   int const next_index             = (index + 1) * dim.get_degree();
@@ -140,7 +141,7 @@ static fk::matrix<double>
 get_flux_operator(dimension<P> const &dim, term<P> const term_1D,
                   double const normalize, int const index)
 {
-  int const two_to_lev = two_raised_to(dim.get_level());
+  int const two_to_lev = fm::two_raised_to(dim.get_level());
   // compute the trace values (values at the left and right of each element for
   // all k) trace_left is 1 by degree trace_right is 1 by degree
   fk::matrix<double> const trace_left =
@@ -240,7 +241,7 @@ generate_coefficients(dimension<P> const &dim, term<P> const term_1D,
 {
   assert(time >= 0.0);
   // setup jacobi of variable x and define coeff_mat
-  int const two_to_level = two_raised_to(dim.get_level());
+  int const two_to_level = fm::two_raised_to(dim.get_level());
   double const normalized_domain =
       (dim.domain_max - dim.domain_min) / two_to_level;
   int const degrees_freedom_1d = dim.get_degree() * two_to_level;

--- a/src/element_table.cpp
+++ b/src/element_table.cpp
@@ -1,5 +1,6 @@
 #include "element_table.hpp"
 
+#include "fast_math.hpp"
 #include "matlab_utilities.hpp"
 #include "program_options.hpp"
 #include "tensors.hpp"
@@ -98,7 +99,7 @@ element_table::get_cell_index_set(fk::vector<int> const level_tuple)
     fk::vector<int> v(level_tuple.size());
     std::transform(
         level_tuple.begin(), level_tuple.end(), v.begin(),
-        [](int level) { return two_raised_to(std::max(0, level - 1)); });
+        [](int level) { return fm::two_raised_to(std::max(0, level - 1)); });
     return v;
   }();
 

--- a/src/fast_math.hpp
+++ b/src/fast_math.hpp
@@ -2,13 +2,15 @@
 #include "lib_dispatch.hpp"
 #include "tensors.hpp"
 
-// // a non-matlab one-liner that had no better home - compute 2^arg
-// inline int two_raised_to(int exponent) { return 1 << exponent; }
-
 namespace fm
 {
 // a non-matlab one-liner that had no better home - compute 2^arg
-inline int two_raised_to(int exponent) { return 1 << exponent; }
+inline int two_raised_to(int exponent)
+{
+  assert(exponent >= 0);
+  return 1 << exponent;
+}
+
 // axpy - y = a*x
 template<typename P, mem_type mem, mem_type omem>
 fk::vector<P, mem> &

--- a/src/fast_math.hpp
+++ b/src/fast_math.hpp
@@ -2,6 +2,9 @@
 #include "lib_dispatch.hpp"
 #include "tensors.hpp"
 
+// a non-matlab one-liner that had no better home - compute 2^arg
+inline int two_raised_to(int exponent) { return 1 << exponent; }
+
 namespace fm
 {
 // axpy - y = a*x

--- a/src/fast_math.hpp
+++ b/src/fast_math.hpp
@@ -2,11 +2,13 @@
 #include "lib_dispatch.hpp"
 #include "tensors.hpp"
 
-// a non-matlab one-liner that had no better home - compute 2^arg
-inline int two_raised_to(int exponent) { return 1 << exponent; }
+// // a non-matlab one-liner that had no better home - compute 2^arg
+// inline int two_raised_to(int exponent) { return 1 << exponent; }
 
 namespace fm
 {
+// a non-matlab one-liner that had no better home - compute 2^arg
+inline int two_raised_to(int exponent) { return 1 << exponent; }
 // axpy - y = a*x
 template<typename P, mem_type mem, mem_type omem>
 fk::vector<P, mem> &

--- a/src/fast_math_tests.cpp
+++ b/src/fast_math_tests.cpp
@@ -1,6 +1,18 @@
 #include "fast_math.hpp"
 #include "tensors.hpp"
 #include "tests_general.hpp"
+#include <cmath>
+
+TEST_CASE("fm::two_raised_to", "[fast_math]")
+{
+  SECTION("pow")
+  {
+    for (int i = 1; i < 31; i++)
+    {
+      REQUIRE(fm::two_raised_to(i) == pow(2, i));
+    }
+  }
+}
 
 TEMPLATE_TEST_CASE("fm::gemm", "[fast_math]", float, double, int)
 {
@@ -39,6 +51,7 @@ TEMPLATE_TEST_CASE("fm::gemm", "[fast_math]", float, double, int)
     fm::gemm(in1_t, in2, result, trans_A);
     REQUIRE(result == ans);
   }
+
   SECTION("transpose b")
   {
     fk::matrix<TestType> const in2_t = fk::matrix<TestType>(in2).transpose();

--- a/src/fast_math_tests.cpp
+++ b/src/fast_math_tests.cpp
@@ -7,7 +7,7 @@ TEST_CASE("fm::two_raised_to", "[fast_math]")
 {
   SECTION("pow")
   {
-    for (int i = 1; i < 31; i++)
+    for (int i = 0; i < 31; i++)
     {
       REQUIRE(fm::two_raised_to(i) == pow(2, i));
     }

--- a/src/matlab_utilities.hpp
+++ b/src/matlab_utilities.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "fast_math.hpp"
 #include "tensors.hpp"
 #include <algorithm>
 #include <functional>
@@ -134,9 +135,6 @@ fk::matrix<P> horz_matrix_concat(std::vector<fk::matrix<P>> const matrices);
 
 // limited subset of matbal meshgrid
 fk::matrix<int> meshgrid(int const start, int const length);
-
-// a non-matlab one-liner that had no better home - compute 2^arg
-inline int two_raised_to(int exponent) { return 1 << exponent; }
 
 // suppress implicit instantiations
 extern template fk::vector<float> linspace(float const start, float const end,

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "../basis.hpp"
+#include "../fast_math.hpp"
 #include "../matlab_utilities.hpp"
 #include "../tensors.hpp"
 //
@@ -74,7 +75,7 @@ public:
         domain_max(domain_max), initial_condition(initial_condition),
         name(name), level_(level), degree_(degree)
   {
-    int const dofs = degree_ * two_raised_to(level_);
+    int const dofs = degree_ * fm::two_raised_to(level_);
     to_basis_operator_.clear_and_resize(dofs, dofs) =
         operator_two_scale<double>(degree_, level_);
     from_basis_operator_.clear_and_resize(dofs, dofs) =
@@ -97,7 +98,7 @@ private:
   {
     assert(level > 0);
     level_         = level;
-    int const dofs = degree_ * two_raised_to(level_);
+    int const dofs = degree_ * fm::two_raised_to(level_);
     to_basis_operator_.clear_and_resize(dofs, dofs) =
         operator_two_scale<double>(degree_, level_);
     from_basis_operator_.clear_and_resize(dofs, dofs) =
@@ -108,7 +109,7 @@ private:
   {
     assert(degree > 0);
     degree_        = degree;
-    int const dofs = degree_ * two_raised_to(level_);
+    int const dofs = degree_ * fm::two_raised_to(level_);
     to_basis_operator_.clear_and_resize(dofs, dofs) =
         operator_two_scale<double>(degree_, level_);
     from_basis_operator_.clear_and_resize(dofs, dofs) =

--- a/src/transformations.hpp
+++ b/src/transformations.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "element_table.hpp"
+#include "fast_math.hpp"
 #include "pde.hpp"
 #include "quadrature.hpp"
 #include "tensors.hpp"
@@ -43,7 +44,7 @@ fk::vector<P> forward_transform(dimension<P> const &dim, F function)
 
   // get grid spacing.
   // hate this name TODO
-  int const n                  = two_raised_to(num_levels);
+  int const n                  = fm::two_raised_to(num_levels);
   int const degrees_freedom_1d = degree * n;
 
   // get the Legendre basis function evaluated at the Legendre-Gauss nodes   //


### PR DESCRIPTION
Moved `two_raised_to` to `fm` namespace in `fast_math` component and added a test.

closes #96 