### PR TITLE
Cleanup/legendre weights

### DIFF
--- a/src/basis_tests.cpp
+++ b/src/basis_tests.cpp
@@ -101,6 +101,7 @@ TEMPLATE_TEST_CASE("operator_two_scale function working appropriately",
                    "[transformations]", double)
 {
   auto const relaxed_comparison = [](auto const first, auto const second) {
+    Catch::StringMaker<double>::precision = 19;
     auto first_it = first.begin();
     std::for_each(second.begin(), second.end(), [&first_it](auto &second_elem) {
       auto difference = std::abs(*first_it++ - second_elem);

--- a/src/basis_tests.cpp
+++ b/src/basis_tests.cpp
@@ -101,7 +101,6 @@ TEMPLATE_TEST_CASE("operator_two_scale function working appropriately",
                    "[transformations]", double)
 {
   auto const relaxed_comparison = [](auto const first, auto const second) {
-    Catch::StringMaker<double>::precision = 19;
     auto first_it = first.begin();
     std::for_each(second.begin(), second.end(), [&first_it](auto &second_elem) {
       auto difference = std::abs(*first_it++ - second_elem);

--- a/src/quadrature.cpp
+++ b/src/quadrature.cpp
@@ -122,90 +122,105 @@ legendre(fk::vector<P> const domain, int const degree)
 // From the matlab:
 
 //% lgwt.m
-//% This script is for computing definite integrals using Legendre-Gauss
-//% Quadrature. Computes the Legendre-Gauss nodes and weights  on an interval
-//% [a,b] with truncation order N
+//% This script is for computing the Legendre-Gauss nodes (roots on x) and weights  
+//% on an interval
+//% [interval_start,interval_end] for Legendre polynomial degree polynomial_degree
+//% These are later used for computing definite integrals using Legendre-Gauss
+//% Quadrature.
 //%
-//% Suppose you have a continuous function f(x) which is defined on [a,b]
-//% which you can evaluate at any x in [a,b]. Simply evaluate it at all of
+//% Suppose you have a continuous function f(x) which is defined on 
+//% [interval_start,interval_end]
+//% which you can evaluate at any x in [interval_start, interval_end]. 
+//% Simply evaluate it at all of
 //% the values contained in the x vector to obtain a vector f. Then compute
 //% the definite integral using sum(f.*w);
 //%
 //% Written by Greg von Winckel - 02/25/2004
 
-// return[0] are the roots, return[1] are the weights
+// return[0] are the x_roots, return[1] are the weights
 
-// FIXME we need to rename "xu", "y", "y0", etc., with meaningful
-// variable names. need to discuss w tim.
 template<typename P>
 std::array<fk::vector<P>, 2>
-legendre_weights(const int order, const int interval_start,
+legendre_weights(const int polynomial_degree, const int interval_start,
                  const int interval_end)
 {
-  assert(order > 0);
+  assert(polynomial_degree > 0);
   assert(interval_start < interval_end);
 
   // prepare out vectors
-  fk::vector<P> roots(order);
-  fk::vector<P> weights(order);
+  // the number of roots of a Legendre polynomial is equal to its degree
+  fk::vector<P> x_roots(polynomial_degree);
+  fk::vector<P> weights(polynomial_degree);
 
-  // xu=linspace(-1,1,N1)';
-  fk::vector<P> const xu =
-      linspace(static_cast<P>(-1.0), static_cast<P>(1.0), order);
+  // x_linspace=linspace(-1,1,polynomial_degree)';
+  // This is a linearly spaced vector used to compose the initial guess
+  // of the roots next
+  fk::vector<P> const x_linspace =
+      linspace(static_cast<P>(-1.0), static_cast<P>(1.0), polynomial_degree);
 
-  //% Initial guess
-  // y=cos((2*(0:N)'+1)*pi/(2*N+2))+(0.27/N1)*sin(pi*xu*N/N2);
-  fk::vector<P> y =
-      linspace(static_cast<P>(0.0), static_cast<P>((order - 1)), order);
-  std::transform(y.begin(), y.end(), y.begin(), [&](P &elem) {
+  //% Initial guess at the roots for the Legendre polynomial of degree
+  // polynomial_degree
+  // y=cos((2*(0:N)'+1)*pi/(2*N+2))+(0.27/N1)*sin(pi*x_linspace*N/N2);
+  // It is unkown where this guess comes from, but seems to work well
+  // The above operation is split into two pieces, the cos term and
+  // then the sin term then they are added together
+  x_roots =
+      linspace(static_cast<P>(0.0), static_cast<P>((polynomial_degree - 1)), polynomial_degree);
+  std::transform(x_roots.begin(), x_roots.end(), x_roots.begin(), [&](P &elem) {
     return std::cos((2 * elem + 1) * M_PI /
-                    static_cast<P>((2 * (order - 1) + 2)));
+                    static_cast<P>((2 * (polynomial_degree - 1) + 2)));
   });
 
-  fk::vector<P> y2(xu);
-  std::transform(y2.begin(), y2.end(), y2.begin(), [&](P &elem) {
-    return (static_cast<P>(0.27) / order) *
-           std::sin(M_PI * elem * (order - 1) / (order + 1));
+  fk::vector<P> x_roots2(x_linspace);
+  std::transform(x_roots2.begin(), x_roots2.end(), x_roots2.begin(), [&](P &elem) {
+    return (static_cast<P>(0.27) / polynomial_degree) *
+           std::sin(M_PI * elem * (polynomial_degree - 1) / (polynomial_degree + 1));
   });
 
-  y = y + y2;
+  x_roots = x_roots + x_roots2;
 
   //% Legendre-Gauss Vandermonde Matrix
+  //% Legendre polynomial values for poly degree 0 to polynomial_degree_plus_one
+  //% at the (estimated) zeros of the polynomial of degree polynomial_degree
   // L=zeros(N1,N2);
-  fk::matrix<P> legendre_gauss(order, (order + 1));
-  fk::vector<P> legendre_p(order);
+  fk::matrix<P> legendre_y_values(polynomial_degree, (polynomial_degree + 1));
+  // The y values of the derivative of the legendre polynomial
+  // of degree equals polynomial_degree at each of the (estimated) root locations
+  fk::vector<P> legendre_prime_y_values(polynomial_degree);
 
-  //% Compute the zeros of the N+1 Legendre Polynomial
+  // Set x_roots_initial to a value that will fail the 
+  // closeness comparison for the Newton iteration
   // y0=2
-  fk::vector<P> y0(order);
-  std::fill(y0.begin(), y0.end(), static_cast<P>(2.0));
+  fk::vector<P> x_roots_initial(polynomial_degree);
+  std::fill(x_roots_initial.begin(), x_roots_initial.end(), static_cast<P>(2.0));
   P const eps = std::numeric_limits<P>::epsilon();
 
+  //% Compute the zeros of the N+1 Legendre Polynomial
   //% Iterate until new points are uniformly within epsilon of old points
   // while max(abs(y-y0))>eps
-  fk::vector<P> diff(order);
+  fk::vector<P> diff(polynomial_degree);
   auto const abs_diff = [&](P const &y_elem, P const &y0_elem) {
     return std::fabs(y_elem - y0_elem);
   };
-  std::transform(y.begin(), y.end(), y0.begin(), diff.begin(), abs_diff);
+  std::transform(x_roots.begin(), x_roots.end(), x_roots_initial.begin(), diff.begin(), abs_diff);
 
   while (*std::max_element(diff.begin(), diff.end()) > eps)
   {
     // L(:,1)=1;
-    legendre_gauss.update_col(
-        0, std::vector<P>(legendre_gauss.nrows(), static_cast<P>(1.0)));
+    legendre_y_values.update_col(
+        0, std::vector<P>(legendre_y_values.nrows(), static_cast<P>(1.0)));
 
     // L(:,2)=y;
-    legendre_gauss.update_col(1, y);
+    legendre_y_values.update_col(1, x_roots);
 
     // for k=2:N1
     // we set the i+1th column of L at each iter
-    for (int i = 1; i < order; ++i)
+    for (int i = 1; i < polynomial_degree; ++i)
     {
       fk::vector<P> const prev =
-          legendre_gauss.extract_submatrix(0, i - 1, legendre_gauss.nrows(), 1);
+          legendre_y_values.extract_submatrix(0, i - 1, legendre_y_values.nrows(), 1);
       fk::vector<P> const current =
-          legendre_gauss.extract_submatrix(0, i, legendre_gauss.nrows(), 1);
+          legendre_y_values.extract_submatrix(0, i, legendre_y_values.nrows(), 1);
 
       fk::vector<P> next(current.size());
 
@@ -215,67 +230,68 @@ legendre_weights(const int order, const int interval_start,
       P scale = (static_cast<P>(2.0) * (i + 1) - 1);
       for (int j = 0; j < next.size(); ++j)
       {
-        next(j) = ((y(j) * scale * current(j)) - (prev(j) * i)) /
+        next(j) = ((x_roots(j) * scale * current(j)) - (prev(j) * i)) /
                   static_cast<P>(i + 1);
       }
-      legendre_gauss.update_col(i + 1, next);
+      legendre_y_values.update_col(i + 1, next);
     }
 
     // Lp=(N2)*( L(:,N1)-y.*L(:,N2) )./(1-y.^2);
-    fk::vector<P> const legendre_n1 = legendre_gauss.extract_submatrix(
-        0, order - 1, legendre_gauss.nrows(), 1);
-    fk::vector<P> legendre_n2 = legendre_gauss.extract_submatrix(
-        0, (order + 1) - 1, legendre_gauss.nrows(), 1);
+    fk::vector<P> const legendre_n1 = legendre_y_values.extract_submatrix(
+        0, polynomial_degree - 1, legendre_y_values.nrows(), 1);
+    fk::vector<P> legendre_n2 = legendre_y_values.extract_submatrix(
+        0, (polynomial_degree + 1) - 1, legendre_y_values.nrows(), 1);
     fk::vector<P> legendre_n2_scaled(legendre_n2.size());
-    std::transform(legendre_n2.begin(), legendre_n2.end(), y.begin(),
+    std::transform(legendre_n2.begin(), legendre_n2.end(), x_roots.begin(),
                    legendre_n2_scaled.begin(), std::multiplies<P>());
     fk::vector<P> const y_operand = [&] {
-      fk::vector<P> copy_y(y.size());
+      fk::vector<P> copy_y(x_roots.size());
       std::transform(
-          y.begin(), y.end(), y.begin(), copy_y.begin(),
+          x_roots.begin(), x_roots.end(), x_roots.begin(), copy_y.begin(),
           [](P &y, P &y_same) { return static_cast<P>(1.0) - y * y_same; });
       return copy_y;
     }();
-    legendre_p = (legendre_n1 - legendre_n2_scaled) * (order + 1);
+    legendre_prime_y_values = (legendre_n1 - legendre_n2_scaled) * (polynomial_degree + 1);
     auto const element_division = [](P const &one, P const &two) {
       return one / two;
     };
-    std::transform(legendre_p.begin(), legendre_p.end(), y_operand.begin(),
-                   legendre_p.begin(), element_division);
+    std::transform(legendre_prime_y_values.begin(), legendre_prime_y_values.end(), y_operand.begin(),
+                   legendre_prime_y_values.begin(), element_division);
 
-    y0 = y;
+    x_roots_initial = x_roots;
 
     // y=y0-L(:,N2)./Lp;
-    std::transform(legendre_n2.begin(), legendre_n2.end(), legendre_p.begin(),
+    std::transform(legendre_n2.begin(), legendre_n2.end(), legendre_prime_y_values.begin(),
                    legendre_n2.begin(), element_division);
-    y = y0 - legendre_n2;
+    x_roots = x_roots_initial - legendre_n2;
 
     // diff = abs(y-y0)
-    std::transform(y.begin(), y.end(), y0.begin(), diff.begin(), abs_diff);
+    std::transform(x_roots.begin(), x_roots.end(), x_roots_initial.begin(), diff.begin(), abs_diff);
   }
 
   //% Linear map from[-1,1] to [a,b]
   // x=(a*(1-y)+b*(1+y))/2;
-  std::transform(y.begin(), y.end(), roots.begin(), [&](P &elem) {
+  std::transform(x_roots.begin(), x_roots.end(), x_roots.begin(), [&](P &elem) {
     return (interval_start * (1 - elem) + interval_end * (1 + elem)) / 2;
   });
 
   //% Compute the weights
   // w=(b-a)./((1-y.^2).*Lp.^2)*(N2/N1)^2;
-  std::transform(y.begin(), y.end(), legendre_p.begin(), weights.begin(),
+  legendre_prime_y_values.print("legendre_prime");
+  std::transform(x_roots.begin(), x_roots.end(), legendre_prime_y_values.begin(), weights.begin(),
                  [&](P &y_elem, P &lp_elem) {
                    return (interval_end - interval_start) /
                           ((static_cast<P>(1.0) - y_elem * y_elem) * lp_elem *
                            lp_elem) *
-                          std::pow(static_cast<P>((order + 1)) / order, 2);
+                          std::pow(static_cast<P>((polynomial_degree + 1)) / polynomial_degree, 2);
                  });
 
   // x=x(end:-1:1);
   // w=w(end:-1:1);
-  std::reverse(roots.begin(), roots.end());
+  std::reverse(x_roots.begin(), x_roots.end());
   std::reverse(weights.begin(), weights.end());
 
-  return std::array<fk::vector<P>, 2>{roots, weights};
+  return std::array<fk::vector<P>, 2>{x_roots, weights};
 }
 
 // explicit instatiations

--- a/src/quadrature.cpp
+++ b/src/quadrature.cpp
@@ -186,7 +186,7 @@ legendre_weights(const int polynomial_degree, const int interval_start,
   //% Legendre polynomial values for poly degree 0 to polynomial_degree_plus_one
   //% at the (estimated) zeros of the polynomial of degree polynomial_degree
   // legendre_y_values=zeros(polynomial_degree,polynomial_degree+2);
-  fk::matrix<P> legendre_y_values(polynomial_degree, (polynomial_degree + 2));
+  fk::matrix<P> legendre_y_values(polynomial_degree, (polynomial_degree + 1));
   // The y values of the derivative of the legendre polynomial
   // of degree equals polynomial_degree at each of the (estimated) root
   // locations
@@ -229,7 +229,7 @@ legendre_weights(const int polynomial_degree, const int interval_start,
     // for i=1:polynomial_degree-1
     // Set values of Legendre polynomial P_i
     // we set the i+1th column of L at each iter
-    for (int i = 1; i < (polynomial_degree + 1); ++i)
+    for (int i = 1; i < (polynomial_degree); ++i)
     {
       // Legendre polynomials P_i-1 and P_i are used in a recurrence relation to
       // produce P_i+1
@@ -255,15 +255,15 @@ legendre_weights(const int polynomial_degree, const int interval_start,
       }
       legendre_y_values.update_col(i + 1, next);
     }
-    // P'_i(x_roots) = ((i+1)*x_roots*P_i(x_roots) -
-    // (i+1)*P_i+1(x_roots))/(1-x_roots.^2) Here we want to produce
+    // P'_i(x_roots) = i*(P_i-1(x_roots) -
+    // x_roots*P_i(x_roots))/(1-x_roots.^2) Here we want to produce
     // P'_polynomial_degree(x_roots) so P_polynomial_degree and
     // P_polynomial_degree-1 are needed
     fk::vector<P> legendre_polynomial_degree =
         legendre_y_values.extract_submatrix(0, polynomial_degree,
                                             legendre_y_values.nrows(), 1);
-    fk::vector<P> legendre_polynomial_degree_plus_one =
-        legendre_y_values.extract_submatrix(0, polynomial_degree + 1,
+    fk::vector<P> legendre_polynomial_degree_minus_one =
+        legendre_y_values.extract_submatrix(0, polynomial_degree - 1,
                                             legendre_y_values.nrows(), 1);
     // legendre_polynomial_scaled = P_i(x_roots)*x_roots
     fk::vector<P> legendre_polynomial_degree_scaled(
@@ -283,9 +283,10 @@ legendre_weights(const int polynomial_degree, const int interval_start,
     // calculation of part of legendre_prime_y_values
     // P'i(x_roots) = ((i+1)*x_roots*P_i(x_roots) - (i+1)*P_i+1(x_roots))
     // division by (1-x_roots^2) next
-    legendre_prime_y_values = (legendre_polynomial_degree_scaled -
-                               legendre_polynomial_degree_plus_one) *
-                              (polynomial_degree + 1);
+    legendre_prime_y_values = (legendre_polynomial_degree_minus_one
+        - legendre_polynomial_degree_scaled
+                               ) *
+                              (polynomial_degree);
     auto const element_division = [](P const &one, P const &two) {
       return one / two;
     };

--- a/src/quadrature.cpp
+++ b/src/quadrature.cpp
@@ -123,9 +123,9 @@ legendre(fk::vector<P> const domain, int const degree)
 
 //% lgwt.m
 //% This script is for computing the Legendre-Gauss nodes (roots on x) and
-//weights % on an interval % [interval_start,interval_end] for Legendre
-//polynomial degree polynomial_degree % These are later used for computing
-//definite integrals using Legendre-Gauss % Quadrature.
+// weights % on an interval % [interval_start,interval_end] for Legendre
+// polynomial degree polynomial_degree % These are later used for computing
+// definite integrals using Legendre-Gauss % Quadrature.
 //%
 //% Suppose you have a continuous function f(x) which is defined on
 //% [interval_start,interval_end]
@@ -283,9 +283,8 @@ legendre_weights(const int polynomial_degree, const int interval_start,
     // calculation of part of legendre_prime_y_values
     // P'i(x_roots) = ((i+1)*x_roots*P_i(x_roots) - (i+1)*P_i+1(x_roots))
     // division by (1-x_roots^2) next
-    legendre_prime_y_values = (legendre_polynomial_degree_minus_one
-        - legendre_polynomial_degree_scaled
-                               ) *
+    legendre_prime_y_values = (legendre_polynomial_degree_minus_one -
+                               legendre_polynomial_degree_scaled) *
                               (polynomial_degree);
     auto const element_division = [](P const &one, P const &two) {
       return one / two;

--- a/src/quadrature.cpp
+++ b/src/quadrature.cpp
@@ -122,15 +122,14 @@ legendre(fk::vector<P> const domain, int const degree)
 // From the matlab:
 
 //% lgwt.m
-//% This script is for computing the Legendre-Gauss nodes (roots on x) and weights  
-//% on an interval
-//% [interval_start,interval_end] for Legendre polynomial degree polynomial_degree
-//% These are later used for computing definite integrals using Legendre-Gauss
-//% Quadrature.
+//% This script is for computing the Legendre-Gauss nodes (roots on x) and
+//weights % on an interval % [interval_start,interval_end] for Legendre
+//polynomial degree polynomial_degree % These are later used for computing
+//definite integrals using Legendre-Gauss % Quadrature.
 //%
-//% Suppose you have a continuous function f(x) which is defined on 
+//% Suppose you have a continuous function f(x) which is defined on
 //% [interval_start,interval_end]
-//% which you can evaluate at any x in [interval_start, interval_end]. 
+//% which you can evaluate at any x in [interval_start, interval_end].
 //% Simply evaluate it at all of
 //% the values contained in the x vector to obtain a vector f. Then compute
 //% the definite integral using sum(f.*w);
@@ -147,87 +146,108 @@ legendre_weights(const int polynomial_degree, const int interval_start,
   assert(polynomial_degree > 0);
   assert(interval_start < interval_end);
 
-  // prepare out vectors
+  // prepare output vectors
   // the number of roots of a Legendre polynomial is equal to its degree
   fk::vector<P> x_roots(polynomial_degree);
   fk::vector<P> weights(polynomial_degree);
 
   // x_linspace=linspace(-1,1,polynomial_degree)';
   // This is a linearly spaced vector used to compose the initial guess
-  // of the roots next
+  // of the roots x_roots done next
   fk::vector<P> const x_linspace =
       linspace(static_cast<P>(-1.0), static_cast<P>(1.0), polynomial_degree);
 
   //% Initial guess at the roots for the Legendre polynomial of degree
   // polynomial_degree
-  // y=cos((2*(0:N)'+1)*pi/(2*N+2))+(0.27/N1)*sin(pi*x_linspace*N/N2);
+  // x_roots=cos((2*(0:polynomial_degree-1)'+1)*pi/(2*(polynomial_degree-1)+2))+(0.27/polynomial_degree)*sin(pi*x_linspace*((polynomial_degree-1)/(polynomial_degree+1);
   // It is unkown where this guess comes from, but seems to work well
-  // The above operation is split into two pieces, the cos term and
-  // then the sin term then they are added together
+  // The above operation is split into two pieces, the cos term (performed on
+  // x_roots) and then the sin term (performed on x_roots2) then they are added
+  // together
   x_roots =
-      linspace(static_cast<P>(0.0), static_cast<P>((polynomial_degree - 1)), polynomial_degree);
+      linspace(static_cast<P>(0.0), static_cast<P>((polynomial_degree - 1)),
+               polynomial_degree);
   std::transform(x_roots.begin(), x_roots.end(), x_roots.begin(), [&](P &elem) {
     return std::cos((2 * elem + 1) * M_PI /
                     static_cast<P>((2 * (polynomial_degree - 1) + 2)));
   });
 
   fk::vector<P> x_roots2(x_linspace);
-  std::transform(x_roots2.begin(), x_roots2.end(), x_roots2.begin(), [&](P &elem) {
-    return (static_cast<P>(0.27) / polynomial_degree) *
-           std::sin(M_PI * elem * (polynomial_degree - 1) / (polynomial_degree + 1));
-  });
+  std::transform(x_roots2.begin(), x_roots2.end(), x_roots2.begin(),
+                 [&](P &elem) {
+                   return (static_cast<P>(0.27) / polynomial_degree) *
+                          std::sin(M_PI * elem * (polynomial_degree - 1) /
+                                   (polynomial_degree + 1));
+                 });
 
   x_roots = x_roots + x_roots2;
 
   //% Legendre-Gauss Vandermonde Matrix
   //% Legendre polynomial values for poly degree 0 to polynomial_degree_plus_one
   //% at the (estimated) zeros of the polynomial of degree polynomial_degree
-  // L=zeros(N1,N2);
-  fk::matrix<P> legendre_y_values(polynomial_degree, (polynomial_degree + 1));
+  // legendre_y_values=zeros(polynomial_degree,polynomial_degree+2);
+  fk::matrix<P> legendre_y_values(polynomial_degree, (polynomial_degree + 2));
   // The y values of the derivative of the legendre polynomial
-  // of degree equals polynomial_degree at each of the (estimated) root locations
+  // of degree equals polynomial_degree at each of the (estimated) root
+  // locations
   fk::vector<P> legendre_prime_y_values(polynomial_degree);
 
-  // Set x_roots_initial to a value that will fail the 
+  // Set x_roots_initial to a value that will fail the
   // closeness comparison for the Newton iteration
-  // y0=2
+  // x_roots_initial=2
   fk::vector<P> x_roots_initial(polynomial_degree);
-  std::fill(x_roots_initial.begin(), x_roots_initial.end(), static_cast<P>(2.0));
+  std::fill(x_roots_initial.begin(), x_roots_initial.end(),
+            static_cast<P>(2.0));
   P const eps = std::numeric_limits<P>::epsilon();
 
-  //% Compute the zeros of the N+1 Legendre Polynomial
+  // This piece of the code uses Newton's method to solve for the
+  // Legendre polynomial roots
+  // x_roots = x_roots_initial - f(x_roots_initial)/f'(x_roots_initial)
+  // where the function f is the legendre polynomial of degree polynomial_degree
   //% Iterate until new points are uniformly within epsilon of old points
-  // while max(abs(y-y0))>eps
+  // Recursion formulae for Legendre polynomials as wellas the derivative
+  // are used
+  // while max(abs(x_roots-x_roots_initial))>eps
   fk::vector<P> diff(polynomial_degree);
   auto const abs_diff = [&](P const &y_elem, P const &y0_elem) {
     return std::fabs(y_elem - y0_elem);
   };
-  std::transform(x_roots.begin(), x_roots.end(), x_roots_initial.begin(), diff.begin(), abs_diff);
+  std::transform(x_roots.begin(), x_roots.end(), x_roots_initial.begin(),
+                 diff.begin(), abs_diff);
 
   while (*std::max_element(diff.begin(), diff.end()) > eps)
   {
-    // L(:,1)=1;
+    // Set values of Legendre polynomial P0 = 1;
+    // legendre_y_values column 0
     legendre_y_values.update_col(
         0, std::vector<P>(legendre_y_values.nrows(), static_cast<P>(1.0)));
 
-    // L(:,2)=y;
+    // Set values of Legendre polynomial P1 = x_roots;
+    // legendre_y_values column 1
     legendre_y_values.update_col(1, x_roots);
 
-    // for k=2:N1
+    // for i=1:polynomial_degree-1
+    // Set values of Legendre polynomial P_i
     // we set the i+1th column of L at each iter
-    for (int i = 1; i < polynomial_degree; ++i)
+    for (int i = 1; i < (polynomial_degree + 1); ++i)
     {
-      fk::vector<P> const prev =
-          legendre_y_values.extract_submatrix(0, i - 1, legendre_y_values.nrows(), 1);
-      fk::vector<P> const current =
-          legendre_y_values.extract_submatrix(0, i, legendre_y_values.nrows(), 1);
+      // Legendre polynomials P_i-1 and P_i are used in a recurrence relation to
+      // produce P_i+1
+      // prev is P_i-1(x_roots) and current is P_i(x_roots)
+      // next is P_i+1(x_roots)
+      fk::vector<P> const prev = legendre_y_values.extract_submatrix(
+          0, i - 1, legendre_y_values.nrows(), 1);
+      fk::vector<P> const current = legendre_y_values.extract_submatrix(
+          0, i, legendre_y_values.nrows(), 1);
 
       fk::vector<P> next(current.size());
 
       // this loop for setting the next column is a little obscure, but doing
       // step by step with transforms was prohibitively slow when we invoke this
       // function from multiwavelet gen.
-      P scale = (static_cast<P>(2.0) * (i + 1) - 1);
+      // P_i+1(x_roots) = ((2*i+1)*x_roots*P_i(x_roots) -
+      // i*P_i-1(x_roots))/(i+1)
+      P scale = (static_cast<P>(2.0 * i) + 1);
       for (int j = 0; j < next.size(); ++j)
       {
         next(j) = ((x_roots(j) * scale * current(j)) - (prev(j) * i)) /
@@ -235,56 +255,75 @@ legendre_weights(const int polynomial_degree, const int interval_start,
       }
       legendre_y_values.update_col(i + 1, next);
     }
-
-    // Lp=(N2)*( L(:,N1)-y.*L(:,N2) )./(1-y.^2);
-    fk::vector<P> const legendre_n1 = legendre_y_values.extract_submatrix(
-        0, polynomial_degree - 1, legendre_y_values.nrows(), 1);
-    fk::vector<P> legendre_n2 = legendre_y_values.extract_submatrix(
-        0, (polynomial_degree + 1) - 1, legendre_y_values.nrows(), 1);
-    fk::vector<P> legendre_n2_scaled(legendre_n2.size());
-    std::transform(legendre_n2.begin(), legendre_n2.end(), x_roots.begin(),
-                   legendre_n2_scaled.begin(), std::multiplies<P>());
-    fk::vector<P> const y_operand = [&] {
+    // P'_i(x_roots) = ((i+1)*x_roots*P_i(x_roots) -
+    // (i+1)*P_i+1(x_roots))/(1-x_roots.^2) Here we want to produce
+    // P'_polynomial_degree(x_roots) so P_polynomial_degree and
+    // P_polynomial_degree-1 are needed
+    fk::vector<P> legendre_polynomial_degree =
+        legendre_y_values.extract_submatrix(0, polynomial_degree,
+                                            legendre_y_values.nrows(), 1);
+    fk::vector<P> legendre_polynomial_degree_plus_one =
+        legendre_y_values.extract_submatrix(0, polynomial_degree + 1,
+                                            legendre_y_values.nrows(), 1);
+    // legendre_polynomial_scaled = P_i(x_roots)*x_roots
+    fk::vector<P> legendre_polynomial_degree_scaled(
+        legendre_polynomial_degree.size());
+    std::transform(legendre_polynomial_degree.begin(),
+                   legendre_polynomial_degree.end(), x_roots.begin(),
+                   legendre_polynomial_degree_scaled.begin(),
+                   std::multiplies<P>());
+    // x_roots_denominator = (1-x_roots^2)
+    fk::vector<P> const x_roots_denominator = [&] {
       fk::vector<P> copy_y(x_roots.size());
       std::transform(
           x_roots.begin(), x_roots.end(), x_roots.begin(), copy_y.begin(),
           [](P &y, P &y_same) { return static_cast<P>(1.0) - y * y_same; });
       return copy_y;
     }();
-    legendre_prime_y_values = (legendre_n1 - legendre_n2_scaled) * (polynomial_degree + 1);
+    // calculation of part of legendre_prime_y_values
+    // P'i(x_roots) = ((i+1)*x_roots*P_i(x_roots) - (i+1)*P_i+1(x_roots))
+    // division by (1-x_roots^2) next
+    legendre_prime_y_values = (legendre_polynomial_degree_scaled -
+                               legendre_polynomial_degree_plus_one) *
+                              (polynomial_degree + 1);
     auto const element_division = [](P const &one, P const &two) {
       return one / two;
     };
-    std::transform(legendre_prime_y_values.begin(), legendre_prime_y_values.end(), y_operand.begin(),
+    // Finishes calculation for legendre_prime_y_values
+    // P'i(x_roots) = ((i+1)*x_roots*P_i(x_roots) - (i+1)*P_i+1(x_roots))
+    // division by (1-x_roots^2)
+    std::transform(legendre_prime_y_values.begin(),
+                   legendre_prime_y_values.end(), x_roots_denominator.begin(),
                    legendre_prime_y_values.begin(), element_division);
 
     x_roots_initial = x_roots;
 
-    // y=y0-L(:,N2)./Lp;
-    std::transform(legendre_n2.begin(), legendre_n2.end(), legendre_prime_y_values.begin(),
-                   legendre_n2.begin(), element_division);
-    x_roots = x_roots_initial - legendre_n2;
+    // x_roots=x_roots_initial-legendre_polynomial_degree./legendre_prime_y_values;
+    std::transform(legendre_polynomial_degree.begin(),
+                   legendre_polynomial_degree.end(),
+                   legendre_prime_y_values.begin(),
+                   legendre_polynomial_degree.begin(), element_division);
+    x_roots = x_roots_initial - legendre_polynomial_degree;
 
-    // diff = abs(y-y0)
-    std::transform(x_roots.begin(), x_roots.end(), x_roots_initial.begin(), diff.begin(), abs_diff);
+    // diff = abs(x_roots-x_roots_initial)
+    std::transform(x_roots.begin(), x_roots.end(), x_roots_initial.begin(),
+                   diff.begin(), abs_diff);
   }
 
-  //% Linear map from[-1,1] to [a,b]
-  // x=(a*(1-y)+b*(1+y))/2;
+  //% Compute the weights
+  // w=(interval_end-interval_start)./((1-x_roots^2).*legendre_prime_y_values.^2);
+  std::transform(
+      x_roots.begin(), x_roots.end(), legendre_prime_y_values.begin(),
+      weights.begin(), [&](P &y_elem, P &lp_elem) {
+        return (interval_end - interval_start) /
+               ((static_cast<P>(1.0) - y_elem * y_elem) * lp_elem * lp_elem);
+      });
+
+  //% Linear map from[-1,1] to [interval_start,interval_end]
+  // x_roots=(interval_start*(1-x_roots)+interval_end*(1+x_roots))/2;
   std::transform(x_roots.begin(), x_roots.end(), x_roots.begin(), [&](P &elem) {
     return (interval_start * (1 - elem) + interval_end * (1 + elem)) / 2;
   });
-
-  //% Compute the weights
-  // w=(b-a)./((1-y.^2).*Lp.^2)*(N2/N1)^2;
-  legendre_prime_y_values.print("legendre_prime");
-  std::transform(x_roots.begin(), x_roots.end(), legendre_prime_y_values.begin(), weights.begin(),
-                 [&](P &y_elem, P &lp_elem) {
-                   return (interval_end - interval_start) /
-                          ((static_cast<P>(1.0) - y_elem * y_elem) * lp_elem *
-                           lp_elem) *
-                          std::pow(static_cast<P>((polynomial_degree + 1)) / polynomial_degree, 2);
-                 });
 
   // x=x(end:-1:1);
   // w=w(end:-1:1);

--- a/src/quadrature_tests.cpp
+++ b/src/quadrature_tests.cpp
@@ -107,15 +107,18 @@ TEMPLATE_TEST_CASE("legendre weights and roots function", "[matlab]", double,
     fk::matrix<TestType> const roots_gold =
         fk::matrix<TestType>(read_matrix_from_txt_file(
             "../testing/generated-inputs/quadrature/lgwt_roots_32_neg5_2.dat"));
-
+    roots_gold.print("roots_gold");
     fk::matrix<TestType> const weights_gold = fk::matrix<
         TestType>(read_matrix_from_txt_file(
         "../testing/generated-inputs/quadrature/lgwt_weights_32_neg5_2.dat"));
+    weights_gold.print("weights_gold");
 
     const int n                 = 32;
     const int a                 = -5;
     const int b                 = 2;
     auto const [roots, weights] = legendre_weights<TestType>(n, a, b);
+    roots.print("roots");
+    weights.print("weights");
 
     relaxed_comparison(roots, roots_gold);
     relaxed_comparison(weights, weights_gold);

--- a/src/quadrature_tests.cpp
+++ b/src/quadrature_tests.cpp
@@ -97,7 +97,6 @@ TEMPLATE_TEST_CASE("legendre weights and roots function", "[matlab]", double,
     const int a                 = -1;
     const int b                 = 1;
     auto const [roots, weights] = legendre_weights<TestType>(n, a, b);
-
     relaxed_comparison(roots, roots_gold);
     relaxed_comparison(weights, weights_gold);
   }
@@ -107,18 +106,14 @@ TEMPLATE_TEST_CASE("legendre weights and roots function", "[matlab]", double,
     fk::matrix<TestType> const roots_gold =
         fk::matrix<TestType>(read_matrix_from_txt_file(
             "../testing/generated-inputs/quadrature/lgwt_roots_32_neg5_2.dat"));
-    roots_gold.print("roots_gold");
     fk::matrix<TestType> const weights_gold = fk::matrix<
         TestType>(read_matrix_from_txt_file(
         "../testing/generated-inputs/quadrature/lgwt_weights_32_neg5_2.dat"));
-    weights_gold.print("weights_gold");
 
     const int n                 = 32;
     const int a                 = -5;
     const int b                 = 2;
     auto const [roots, weights] = legendre_weights<TestType>(n, a, b);
-    roots.print("roots");
-    weights.print("weights");
 
     relaxed_comparison(roots, roots_gold);
     relaxed_comparison(weights, weights_gold);


### PR DESCRIPTION
This branch closes issue #43 . The indexing in Matlab which starts at 1 seems to have created some confusion related to the Legendre polynomial recurrence indexing schemes. This was carried over to the c++ during translation of the Matlab. This is now cleared up with clear variable names and comments to explain what is being done.