### PR TITLE
Fixup/apply fmwt testing

### DIFF
--- a/src/basis_tests.cpp
+++ b/src/basis_tests.cpp
@@ -101,10 +101,12 @@ TEMPLATE_TEST_CASE("operator_two_scale function working appropriately",
                    "[transformations]", double)
 {
   auto const relaxed_comparison = [](auto const first, auto const second) {
-    auto first_it = first.begin();
-    std::for_each(second.begin(), second.end(), [&first_it](auto &second_elem) {
-      auto difference = std::abs(*first_it++ - second_elem);
-      REQUIRE(difference <= std::numeric_limits<TestType>::epsilon() * 1e4);
+    auto first_it                           = first.begin();
+    Catch::StringMaker<TestType>::precision = 15;
+    auto tol = std::numeric_limits<TestType>::epsilon() * 1e3;
+    std::for_each(second.begin(), second.end(), [&](auto &second_elem) {
+      auto const f1 = *first_it++;
+      REQUIRE_THAT(f1, Catch::Matchers::WithinAbs(second_elem, tol));
     });
   };
 
@@ -196,13 +198,13 @@ TEMPLATE_TEST_CASE("apply_fmwt", "[apply_fmwt]", double, float)
                                      auto const n, auto const max) {
     auto first_it                           = first.begin();
     Catch::StringMaker<TestType>::precision = 15;
-    std::for_each(
-        second.begin(), second.end(), [&first_it, &n, &max](auto &second_elem) {
-          auto const f1 = *first_it++;
-          auto tol =
-              std::numeric_limits<TestType>::epsilon() * n * n / 10.0 * max;
-          REQUIRE_THAT(f1, Catch::Matchers::WithinAbs(second_elem, tol));
-        });
+    // if the largest matrix we are testing below is 128x128, with a max
+    // value of 200, then this gives us ~ epsilon() * 3e3
+    auto tol = std::numeric_limits<TestType>::epsilon() * n * n / 10.0 * max;
+    std::for_each(second.begin(), second.end(), [&](auto &second_elem) {
+      auto const f1 = *first_it++;
+      REQUIRE_THAT(f1, Catch::Matchers::WithinAbs(second_elem, tol));
+    });
   };
 
   // Testing of various apply fmwt methods

--- a/src/basis_tests.cpp
+++ b/src/basis_tests.cpp
@@ -192,14 +192,17 @@ TEMPLATE_TEST_CASE("operator_two_scale function working appropriately",
 
 TEMPLATE_TEST_CASE("apply_fmwt", "[apply_fmwt]", double, float)
 {
-  auto const relaxed_comparison = [](auto const first, auto const second, auto const n,auto const max) {
-    auto first_it = first.begin();
+  auto const relaxed_comparison = [](auto const first, auto const second,
+                                     auto const n, auto const max) {
+    auto first_it                           = first.begin();
     Catch::StringMaker<TestType>::precision = 15;
-    std::for_each(second.begin(), second.end(), [&first_it,&n,&max](auto &second_elem) {
-      auto const f1   = *first_it++;
-      auto tol = std::numeric_limits<TestType>::epsilon()*n*n/10.0*max;		 
-      REQUIRE_THAT(f1, Catch::Matchers::WithinAbs(second_elem, tol));
-    });
+    std::for_each(
+        second.begin(), second.end(), [&first_it, &n, &max](auto &second_elem) {
+          auto const f1 = *first_it++;
+          auto tol =
+              std::numeric_limits<TestType>::epsilon() * n * n / 10.0 * max;
+          REQUIRE_THAT(f1, Catch::Matchers::WithinAbs(second_elem, tol));
+        });
   };
 
   // Testing of various apply fmwt methods
@@ -227,7 +230,7 @@ TEMPLATE_TEST_CASE("apply_fmwt", "[apply_fmwt]", double, float)
     auto const product_left2 = apply_left_fmwt<TestType>(fmwt, mat1, kdeg, lev);
     SECTION("degree = 2, lev 2 fmwt apply left - method 2")
     {
-      relaxed_comparison(product_left1, product_left2,n,distBounds);
+      relaxed_comparison(product_left1, product_left2, n, distBounds);
     }
 
     fk::matrix<TestType> fmwt_transpose =
@@ -238,7 +241,8 @@ TEMPLATE_TEST_CASE("apply_fmwt", "[apply_fmwt]", double, float)
         apply_left_fmwt_transposed<TestType>(fmwt, mat1, kdeg, lev);
     SECTION("degree = 2, lev 2 fmwt apply left transpose - method 2")
     {
-      relaxed_comparison(product_left_trans1, product_left_trans2,n,distBounds);
+      relaxed_comparison(product_left_trans1, product_left_trans2, n,
+                         distBounds);
     }
 
     auto const product_right1 = mat1 * fmwt;
@@ -247,7 +251,7 @@ TEMPLATE_TEST_CASE("apply_fmwt", "[apply_fmwt]", double, float)
 
     SECTION("degree = 2, lev 2 fmwt apply right - method 2")
     {
-      relaxed_comparison(product_right1, product_right2,n,distBounds);
+      relaxed_comparison(product_right1, product_right2, n, distBounds);
     }
 
     auto const product_right_trans1 = mat1 * fmwt_transpose;
@@ -255,7 +259,8 @@ TEMPLATE_TEST_CASE("apply_fmwt", "[apply_fmwt]", double, float)
         apply_right_fmwt_transposed<TestType>(fmwt, mat1, kdeg, lev);
     SECTION("degree = 2, lev 2 fmwt apply right transpose - method 2")
     {
-      relaxed_comparison(product_right_trans1, product_right_trans2,n,distBounds);
+      relaxed_comparison(product_right_trans1, product_right_trans2, n,
+                         distBounds);
     }
   }
 
@@ -280,7 +285,7 @@ TEMPLATE_TEST_CASE("apply_fmwt", "[apply_fmwt]", double, float)
     auto const product_left2 = apply_left_fmwt<TestType>(fmwt, mat1, kdeg, lev);
     SECTION("degree = 4, lev 5 fmwt apply left - method 2")
     {
-      relaxed_comparison(product_left1, product_left2,n,distBounds);
+      relaxed_comparison(product_left1, product_left2, n, distBounds);
     }
 
     fk::matrix<TestType> fmwt_transpose =
@@ -290,7 +295,8 @@ TEMPLATE_TEST_CASE("apply_fmwt", "[apply_fmwt]", double, float)
         apply_left_fmwt_transposed<TestType>(fmwt, mat1, kdeg, lev);
     SECTION("degree = 4, lev 5 fmwt apply left transpose - method 2")
     {
-      relaxed_comparison(product_left_trans1, product_left_trans2,n,distBounds);
+      relaxed_comparison(product_left_trans1, product_left_trans2, n,
+                         distBounds);
     }
 
     auto const product_right1 = mat1 * fmwt;
@@ -298,7 +304,7 @@ TEMPLATE_TEST_CASE("apply_fmwt", "[apply_fmwt]", double, float)
         apply_right_fmwt<TestType>(fmwt, mat1, kdeg, lev);
     SECTION("degree = 4, lev 5 fmwt apply right - method 2")
     {
-      relaxed_comparison(product_right1, product_right2,n,distBounds);
+      relaxed_comparison(product_right1, product_right2, n, distBounds);
     }
 
     auto const product_right_trans1 = mat1 * fmwt_transpose;
@@ -306,7 +312,8 @@ TEMPLATE_TEST_CASE("apply_fmwt", "[apply_fmwt]", double, float)
         apply_right_fmwt_transposed<TestType>(fmwt, mat1, kdeg, lev);
     SECTION("degree = 4, lev 5 fmwt apply right transpose - method 2")
     {
-      relaxed_comparison(product_right_trans1, product_right_trans2,n,distBounds);
+      relaxed_comparison(product_right_trans1, product_right_trans2, n,
+                         distBounds);
     }
   }
 }


### PR DESCRIPTION
Testing for apply_fmwt has been updated to compare with full multiplication.  This pull request closes issue #132 The tolerance of the difference between the two matrix multiplication methods is set to epsilon*n*n*max_value/10. Where the square matrix dimension is n and max_value is the maximum value of the coefficient matrix which fmwt is being multiplied against.