### PR TITLE
Refactor/standardize build gpu (depends on #172)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,6 @@ endif()
 
 if(ASGARD_USE_CUDA)
   find_package(CUDA 9.0 REQUIRED)
-  add_compile_definitions(ASGARD_USE_CUDA)
   include_directories(${CUDA_INCLUDE_DIRS})
 endif()
 
@@ -233,6 +232,7 @@ if (ASGARD_BUILD_TESTS)
   # Define ctest tests and their executables
   add_library (tests_general testing/tests_general.cpp)
   target_link_libraries (tests_general PUBLIC Catch PRIVATE pde program_options)
+  target_include_directories(tests_general PRIVATE ${CMAKE_BINARY_DIR})
   foreach (component IN LISTS components)
     add_executable (${component}-tests src/${component}_tests.cpp)
     target_include_directories (${component}-tests PRIVATE ${CMAKE_SOURCE_DIR}/testing)

--- a/src/build_info.hpp.in
+++ b/src/build_info.hpp.in
@@ -6,5 +6,6 @@
 #define BUILD_TIME "@BUILD_TIME@"
 
 #cmakedefine ASGARD_IO_HIGHFIVE
+#cmakedefine ASGARD_USE_CUDA
 #cmakedefine ASGARD_USE_OPENMP
 #cmakedefine ASGARD_USE_MPI

--- a/src/lib_dispatch.cpp
+++ b/src/lib_dispatch.cpp
@@ -1,4 +1,5 @@
 #include "lib_dispatch.hpp"
+#include "build_info.hpp"
 #include <iostream>
 #include <type_traits>
 

--- a/src/lib_dispatch_tests.cpp
+++ b/src/lib_dispatch_tests.cpp
@@ -1,3 +1,4 @@
+#include "build_info.hpp"
 #include "lib_dispatch.hpp"
 #include "tensors.hpp"
 #include "tests_general.hpp"

--- a/src/tensors.hpp
+++ b/src/tensors.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "build_info.hpp"
+
 #ifdef ASGARD_USE_CUDA
 #include <cuda_runtime.h>
 #endif


### PR DESCRIPTION
standardize how macros are defined with cmake - make cuda option follow pattern used in others (definition by cmake in `build_info.hpp`)