### PR TITLE
Fix/chunking errors (depends on #183)

### DIFF
--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -28,7 +28,7 @@ grid_limits columns_in_chunk(element_chunk const &g)
   int const min_col =
       (*std::min_element(g.begin(), g.end(),
                          [](auto const &a, auto const &b) {
-                           return a.second.start < b.second.stop;
+                           return a.second.start < b.second.start;
                          }))
           .second.start;
 

--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -54,24 +54,29 @@ rank_workspace<P>::rank_workspace(PDE<P> const &pde,
 
   int const max_elems =
       (*std::max_element(chunks.begin(), chunks.end(),
-                         [](const element_chunk &a, const element_chunk &b) {
+                         [](element_chunk const &a, element_chunk const &b) {
                            return a.size() < b.size();
                          }))
           .size();
 
-  int const max_conn = max_connected_in_chunk(*std::max_element(
+  auto const max_col_limits = columns_in_chunk(*std::max_element(
       chunks.begin(), chunks.end(),
-      [](const element_chunk &a, const element_chunk &b) {
-        return max_connected_in_chunk(a) < max_connected_in_chunk(b);
+      [](element_chunk const &a, element_chunk const &b) {
+        auto const cols_in_a = columns_in_chunk(a);
+        auto const cols_in_b = columns_in_chunk(b);
+        auto const num_a     = cols_in_a.stop - cols_in_a.start + 1;
+        auto const num_b     = cols_in_b.stop - cols_in_b.start + 1;
+        return num_a < num_b;
       }));
+  auto const max_cols       = max_col_limits.stop - max_col_limits.start + 1;
 
   int const max_total = num_elements_in_chunk(*std::max_element(
       chunks.begin(), chunks.end(),
-      [](const element_chunk &a, const element_chunk &b) {
+      [](element_chunk const &a, element_chunk const &b) {
         return num_elements_in_chunk(a) < num_elements_in_chunk(b);
       }));
 
-  batch_input.resize(elem_size * max_conn);
+  batch_input.resize(elem_size * max_cols);
   batch_output.resize(elem_size * max_elems);
   reduction_space.resize(elem_size * max_total * pde.num_terms);
 
@@ -80,7 +85,7 @@ rank_workspace<P>::rank_workspace(PDE<P> const &pde,
   batch_intermediate.resize(reduction_space.size() * num_workspaces);
 
   // unit vector for reduction
-  unit_vector_.resize(pde.num_terms * max_conn);
+  unit_vector_.resize(pde.num_terms * max_cols);
   fk::vector<P, mem_type::owner, resource::host> unit_vect(unit_vector_.size());
   std::fill(unit_vect.begin(), unit_vect.end(), 1.0);
   unit_vector_.transfer_from(unit_vect);
@@ -263,7 +268,10 @@ void copy_chunk_inputs(PDE<P> const &pde, element_subgrid const &grid,
   fk::vector<P, mem_type::view> const x_view(
       host_space.x, grid.to_local_col(x_range.start) * elem_size,
       (grid.to_local_col(x_range.stop) + 1) * elem_size - 1);
-  rank_space.batch_input.transfer_from(x_view);
+  fk::vector<P, mem_type::view, resource::device> in_view(
+      rank_space.batch_input, 0,
+      (x_range.stop - x_range.start + 1) * elem_size - 1);
+  in_view.transfer_from(x_view);
 }
 
 template<typename P>

--- a/src/chunk_tests.cpp
+++ b/src/chunk_tests.cpp
@@ -573,10 +573,10 @@ TEMPLATE_TEST_CASE("chunk data management functions", "[chunk]", float, double)
     copy_in_test(degree, level, *pde);
   }
 
-  SECTION("copy in deg 3/lev 2, continuity 6")
+  SECTION("copy in deg 7/lev 4, continuity 6")
   {
-    int const degree = 3;
-    int const level  = 2;
+    int const degree = 7;
+    int const level  = 4;
     auto pde = make_PDE<TestType>(PDE_opts::continuity_6, level, degree);
     copy_in_test(degree, level, *pde);
   }
@@ -597,7 +597,7 @@ TEMPLATE_TEST_CASE("chunk data management functions", "[chunk]", float, double)
     copy_out_test(degree, level, *pde);
   }
 
-  SECTION("copy out deg 3/lev 2, continuity 6")
+  SECTION("copy out deg 7/lev 4, continuity 6")
   {
     int const degree = 3;
     int const level  = 2;

--- a/src/chunk_tests.cpp
+++ b/src/chunk_tests.cpp
@@ -41,8 +41,7 @@ auto const validity_check_sub = [](std::vector<element_chunk> const &chunks,
 
 // check that a given chunk vector occupies between 49% and 101% of the limiit
 auto const size_check = [](std::vector<element_chunk> const &chunks,
-                           PDE<double> const &pde, int const limit_MB,
-                           bool const large_problem) {
+                           PDE<double> const &pde, int const limit_MB) {
   rank_workspace const work(pde, chunks);
   double const lower_bound        = static_cast<double>(limit_MB * 0.49);
   double const upper_bound        = static_cast<double>(limit_MB * 1.01);
@@ -50,6 +49,7 @@ auto const size_check = [](std::vector<element_chunk> const &chunks,
   auto const coefficients_size_MB = std::ceil(
       get_MB<double>(static_cast<uint64_t>(pde.get_coefficients(0, 0).size()) *
                      pde.num_terms * pde.num_dims));
+  bool const large_problem = chunks.size() > 2;
   if (large_problem)
   {
     REQUIRE(workspace_size + coefficients_size_MB > lower_bound);
@@ -128,45 +128,51 @@ TEST_CASE("chunk convenience functions", "[chunk]")
   }
 }
 
+auto const workspace_min  = 1000;
+auto const workspace_max  = 4000;
+auto const workspace_step = 1000;
+
 TEST_CASE("element chunk, continuity 2", "[chunk]")
 {
-  SECTION("1 rank, deg 5, level 6, 10-1000 MB (subgrid)")
+  SECTION("1 rank, deg 5, level 6, 1000-4000 MB (subgrid)")
   {
     int const degree = 5;
     int const level  = 6;
     int const ranks  = 1;
 
     auto const pde = make_PDE<double>(PDE_opts::continuity_2, level, degree);
-    bool const large_problem = false;
-    options const o          = make_options(
+
+    options const o = make_options(
         {"-l", std::to_string(level), "-d", std::to_string(degree)});
     element_table const table(o, pde->num_dims);
     auto const plan = get_plan(ranks, table);
 
-    for (int limit_MB = 10; limit_MB <= 1000; limit_MB *= 10)
+    for (int limit_MB = workspace_min; limit_MB <= workspace_max;
+         limit_MB += workspace_step)
     {
       int const num_chunks = get_num_chunks(plan.at(0), *pde, limit_MB);
       auto const chunks    = assign_elements(plan.at(0), num_chunks);
       assert(static_cast<int>(chunks.size()) == num_chunks);
       validity_check_sub(chunks, plan.at(0));
-      size_check(chunks, *pde, limit_MB, large_problem);
+      size_check(chunks, *pde, limit_MB);
     }
   }
 
-  SECTION("2 ranks, deg 5, level 6, 10-1000 MB (subgrid)")
+  SECTION("2 ranks, deg 5, level 6 (subgrid)")
   {
     int const degree = 5;
     int const level  = 6;
     int const ranks  = 2;
 
     auto const pde = make_PDE<double>(PDE_opts::continuity_2, level, degree);
-    bool const large_problem = false;
-    options const o          = make_options(
+
+    options const o = make_options(
         {"-l", std::to_string(level), "-d", std::to_string(degree)});
     element_table const table(o, pde->num_dims);
     auto const plan = get_plan(ranks, table);
 
-    for (int limit_MB = 10; limit_MB <= 1000; limit_MB *= 10)
+    for (int limit_MB = workspace_min; limit_MB <= workspace_max;
+         limit_MB += workspace_step)
     {
       for (auto const &[rank, grid] : plan)
       {
@@ -175,7 +181,7 @@ TEST_CASE("element chunk, continuity 2", "[chunk]")
         auto const chunks    = assign_elements(grid, num_chunks);
         assert(static_cast<int>(chunks.size()) == num_chunks);
         validity_check_sub(chunks, grid);
-        size_check(chunks, *pde, limit_MB, large_problem);
+        size_check(chunks, *pde, limit_MB);
       }
     }
   }
@@ -183,7 +189,7 @@ TEST_CASE("element chunk, continuity 2", "[chunk]")
 
 TEST_CASE("element chunk, continuity 3", "[chunk]")
 {
-  SECTION("1 rank, deg 5, level 6, 100-10000 MB (subgrid)")
+  SECTION("1 rank, deg 5, level 6 (subgrid)")
   {
     int const degree = 5;
     int const level  = 6;
@@ -191,13 +197,13 @@ TEST_CASE("element chunk, continuity 3", "[chunk]")
 
     auto const pde = make_PDE<double>(PDE_opts::continuity_3, level, degree);
 
-    bool const large_problem = true;
-    options const o          = make_options(
+    options const o = make_options(
         {"-l", std::to_string(level), "-d", std::to_string(degree)});
     element_table const table(o, pde->num_dims);
     auto const plan = get_plan(ranks, table);
 
-    for (int limit_MB = 10; limit_MB <= 1000; limit_MB *= 10)
+    for (int limit_MB = workspace_min; limit_MB <= workspace_max;
+         limit_MB += workspace_step)
     {
       for (auto const &[rank, grid] : plan)
       {
@@ -206,25 +212,26 @@ TEST_CASE("element chunk, continuity 3", "[chunk]")
         auto const chunks    = assign_elements(grid, num_chunks);
         assert(static_cast<int>(chunks.size()) == num_chunks);
         validity_check_sub(chunks, grid);
-        size_check(chunks, *pde, limit_MB, large_problem);
+        size_check(chunks, *pde, limit_MB);
       }
     }
   }
 
-  SECTION("2 ranks, deg 5, level 6, 10-1000 MB (subgrid)")
+  SECTION("2 ranks, deg 5, level 6 (subgrid)")
   {
     int const degree = 5;
     int const level  = 6;
     int const ranks  = 2;
 
     auto const pde = make_PDE<double>(PDE_opts::continuity_3, level, degree);
-    bool const large_problem = true;
-    options const o          = make_options(
+
+    options const o = make_options(
         {"-l", std::to_string(level), "-d", std::to_string(degree)});
     element_table const table(o, pde->num_dims);
     auto const plan = get_plan(ranks, table);
 
-    for (int limit_MB = 10; limit_MB <= 1000; limit_MB *= 10)
+    for (int limit_MB = workspace_min; limit_MB <= workspace_max;
+         limit_MB += workspace_step)
     {
       for (auto const &[rank, grid] : plan)
       {
@@ -233,25 +240,26 @@ TEST_CASE("element chunk, continuity 3", "[chunk]")
         auto const chunks    = assign_elements(grid, num_chunks);
         assert(static_cast<int>(chunks.size()) == num_chunks);
         validity_check_sub(chunks, grid);
-        size_check(chunks, *pde, limit_MB, large_problem);
+        size_check(chunks, *pde, limit_MB);
       }
     }
   }
 
-  SECTION("3 ranks, deg 5, level 6, 10-1000 MB (subgrid)")
+  SECTION("3 ranks, deg 5, level 6 (subgrid)")
   {
     int const degree = 5;
     int const level  = 6;
     int const ranks  = 3;
 
     auto const pde = make_PDE<double>(PDE_opts::continuity_3, level, degree);
-    bool const large_problem = true;
-    options const o          = make_options(
+
+    options const o = make_options(
         {"-l", std::to_string(level), "-d", std::to_string(degree)});
     element_table const table(o, pde->num_dims);
     auto const plan = get_plan(ranks, table);
 
-    for (int limit_MB = 10; limit_MB <= 1000; limit_MB *= 10)
+    for (int limit_MB = workspace_min; limit_MB <= workspace_max;
+         limit_MB += workspace_step)
     {
       for (auto const &[rank, grid] : plan)
       {
@@ -260,12 +268,12 @@ TEST_CASE("element chunk, continuity 3", "[chunk]")
         auto const chunks    = assign_elements(grid, num_chunks);
         assert(static_cast<int>(chunks.size()) == num_chunks);
         validity_check_sub(chunks, grid);
-        size_check(chunks, *pde, limit_MB, large_problem);
+        size_check(chunks, *pde, limit_MB);
       }
     }
   }
 
-  SECTION("1 rank, deg 4, level 6, 10-1000 MB (subgrid)")
+  SECTION("1 rank, deg 4, level 6 (subgrid)")
   {
     int const degree = 4;
     int const level  = 6;
@@ -273,13 +281,13 @@ TEST_CASE("element chunk, continuity 3", "[chunk]")
 
     auto const pde = make_PDE<double>(PDE_opts::continuity_3, level, degree);
 
-    bool const large_problem = true;
-    options const o          = make_options(
+    options const o = make_options(
         {"-l", std::to_string(level), "-d", std::to_string(degree)});
     element_table const table(o, pde->num_dims);
     auto const plan = get_plan(ranks, table);
 
-    for (int limit_MB = 10; limit_MB <= 1000; limit_MB *= 10)
+    for (int limit_MB = workspace_min; limit_MB <= workspace_max;
+         limit_MB += workspace_step)
     {
       for (auto const &[rank, grid] : plan)
       {
@@ -288,25 +296,26 @@ TEST_CASE("element chunk, continuity 3", "[chunk]")
         auto const chunks    = assign_elements(grid, num_chunks);
         assert(static_cast<int>(chunks.size()) == num_chunks);
         validity_check_sub(chunks, grid);
-        size_check(chunks, *pde, limit_MB, large_problem);
+        size_check(chunks, *pde, limit_MB);
       }
     }
   }
 
-  SECTION("2 ranks, deg 4, level 6, 10-1000 MB (subgrid)")
+  SECTION("2 ranks, deg 4, level 6 (subgrid)")
   {
     int const degree = 4;
     int const level  = 6;
     int const ranks  = 2;
 
     auto const pde = make_PDE<double>(PDE_opts::continuity_3, level, degree);
-    bool const large_problem = true;
-    options const o          = make_options(
+
+    options const o = make_options(
         {"-l", std::to_string(level), "-d", std::to_string(degree)});
     element_table const table(o, pde->num_dims);
     auto const plan = get_plan(ranks, table);
 
-    for (int limit_MB = 10; limit_MB <= 1000; limit_MB *= 10)
+    for (int limit_MB = workspace_min; limit_MB <= workspace_max;
+         limit_MB += workspace_step)
     {
       for (auto const &[rank, grid] : plan)
       {
@@ -315,25 +324,25 @@ TEST_CASE("element chunk, continuity 3", "[chunk]")
         auto const chunks    = assign_elements(grid, num_chunks);
         assert(static_cast<int>(chunks.size()) == num_chunks);
         validity_check_sub(chunks, grid);
-        size_check(chunks, *pde, limit_MB, large_problem);
+        size_check(chunks, *pde, limit_MB);
       }
     }
   }
 
-  SECTION("3 ranks, deg 4, level 6, 10-1000 MB (subgrid)")
+  SECTION("3 ranks, deg 4, level 6 (subgrid)")
   {
     int const degree = 4;
     int const level  = 6;
     int const ranks  = 3;
 
-    auto const pde = make_PDE<double>(PDE_opts::continuity_3, level, degree);
-    bool const large_problem = true;
-    options const o          = make_options(
+    auto const pde  = make_PDE<double>(PDE_opts::continuity_3, level, degree);
+    options const o = make_options(
         {"-l", std::to_string(level), "-d", std::to_string(degree)});
     element_table const table(o, pde->num_dims);
     auto const plan = get_plan(ranks, table);
 
-    for (int limit_MB = 10; limit_MB <= 1000; limit_MB *= 10)
+    for (int limit_MB = workspace_min; limit_MB <= workspace_max;
+         limit_MB += workspace_step)
     {
       for (auto const &[rank, grid] : plan)
       {
@@ -342,7 +351,7 @@ TEST_CASE("element chunk, continuity 3", "[chunk]")
         auto const chunks    = assign_elements(grid, num_chunks);
         assert(static_cast<int>(chunks.size()) == num_chunks);
         validity_check_sub(chunks, grid);
-        size_check(chunks, *pde, limit_MB, large_problem);
+        size_check(chunks, *pde, limit_MB);
       }
     }
   }
@@ -350,7 +359,7 @@ TEST_CASE("element chunk, continuity 3", "[chunk]")
 
 TEST_CASE("element chunk, continuity 6", "[chunk]")
 {
-  SECTION("1 rank, deg 3, level 4, 100-10000 MB (subgrid)")
+  SECTION("1 rank, deg 3, level 4 (subgrid)")
   {
     int const degree = 3;
     int const level  = 4;
@@ -358,13 +367,13 @@ TEST_CASE("element chunk, continuity 6", "[chunk]")
 
     auto const pde = make_PDE<double>(PDE_opts::continuity_6, level, degree);
 
-    bool const large_problem = true;
-    options const o          = make_options(
+    options const o = make_options(
         {"-l", std::to_string(level), "-d", std::to_string(degree)});
     element_table const table(o, pde->num_dims);
     auto const plan = get_plan(ranks, table);
 
-    for (int limit_MB = 100; limit_MB <= 10000; limit_MB *= 10)
+    for (int limit_MB = workspace_min; limit_MB <= workspace_max;
+         limit_MB += workspace_step)
     {
       for (auto const &[rank, grid] : plan)
       {
@@ -373,12 +382,12 @@ TEST_CASE("element chunk, continuity 6", "[chunk]")
         auto const chunks    = assign_elements(grid, num_chunks);
         assert(static_cast<int>(chunks.size()) == num_chunks);
         validity_check_sub(chunks, grid);
-        size_check(chunks, *pde, limit_MB, large_problem);
+        size_check(chunks, *pde, limit_MB);
       }
     }
   }
 
-  SECTION("2 ranks, deg 3, level 4, 100-10000 MB (subgrid)")
+  SECTION("2 ranks, deg 3, level 4 (subgrid)")
   {
     int const degree = 3;
     int const level  = 4;
@@ -386,13 +395,13 @@ TEST_CASE("element chunk, continuity 6", "[chunk]")
 
     auto const pde = make_PDE<double>(PDE_opts::continuity_6, level, degree);
 
-    bool const large_problem = true;
-    options const o          = make_options(
+    options const o = make_options(
         {"-l", std::to_string(level), "-d", std::to_string(degree)});
     element_table const table(o, pde->num_dims);
     auto const plan = get_plan(ranks, table);
 
-    for (int limit_MB = 100; limit_MB <= 10000; limit_MB *= 10)
+    for (int limit_MB = workspace_min; limit_MB <= workspace_max;
+         limit_MB += workspace_step)
     {
       for (auto const &[rank, grid] : plan)
       {
@@ -401,12 +410,12 @@ TEST_CASE("element chunk, continuity 6", "[chunk]")
         auto const chunks    = assign_elements(grid, num_chunks);
         assert(static_cast<int>(chunks.size()) == num_chunks);
         validity_check_sub(chunks, grid);
-        size_check(chunks, *pde, limit_MB, large_problem);
+        size_check(chunks, *pde, limit_MB);
       }
     }
   }
 
-  SECTION("11 ranks, deg 4, level 4, 100-10000 MB (subgrid)")
+  SECTION("11 ranks, deg 4, level 4 (subgrid)")
   {
     int const degree = 4;
     int const level  = 4;
@@ -414,13 +423,13 @@ TEST_CASE("element chunk, continuity 6", "[chunk]")
 
     auto const pde = make_PDE<double>(PDE_opts::continuity_6, level, degree);
 
-    bool const large_problem = true;
-    options const o          = make_options(
+    options const o = make_options(
         {"-l", std::to_string(level), "-d", std::to_string(degree)});
     element_table const table(o, pde->num_dims);
     auto const plan = get_plan(ranks, table);
 
-    for (int limit_MB = 100; limit_MB <= 10000; limit_MB *= 10)
+    for (int limit_MB = workspace_min; limit_MB <= workspace_max;
+         limit_MB += workspace_step)
     {
       for (auto const &[rank, grid] : plan)
       {
@@ -429,7 +438,7 @@ TEST_CASE("element chunk, continuity 6", "[chunk]")
         auto const chunks    = assign_elements(grid, num_chunks);
         assert(static_cast<int>(chunks.size()) == num_chunks);
         validity_check_sub(chunks, grid);
-        size_check(chunks, *pde, limit_MB, large_problem);
+        size_check(chunks, *pde, limit_MB);
       }
     }
   }
@@ -573,10 +582,10 @@ TEMPLATE_TEST_CASE("chunk data management functions", "[chunk]", float, double)
     copy_in_test(degree, level, *pde);
   }
 
-  SECTION("copy in deg 7/lev 4, continuity 6")
+  SECTION("copy in deg 3/lev 2, continuity 6")
   {
-    int const degree = 7;
-    int const level  = 4;
+    int const degree = 3;
+    int const level  = 2;
     auto pde = make_PDE<TestType>(PDE_opts::continuity_6, level, degree);
     copy_in_test(degree, level, *pde);
   }
@@ -597,7 +606,7 @@ TEMPLATE_TEST_CASE("chunk data management functions", "[chunk]", float, double)
     copy_out_test(degree, level, *pde);
   }
 
-  SECTION("copy out deg 7/lev 4, continuity 6")
+  SECTION("copy out deg 3/lev 2, continuity 6")
   {
     int const degree = 3;
     int const level  = 2;


### PR DESCRIPTION
Fix the logic error that caused `rank_space.batch_input` to be mis-sized, and extend tests to catch this problem.
Also closes #165 .