### PR TITLE
clarify time advance naming

### DIFF
--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -113,10 +113,9 @@ scale_sources(PDE<P> const &pde,
 template<typename P>
 static void
 apply_A(PDE<P> const &pde, element_table const &elem_table,
-               element_subgrid const &grid,
-               std::vector<element_chunk> const &chunks,
-               host_workspace<P> &host_space, rank_workspace<P> &rank_space,
-               std::vector<batch_operands_set<P>> &batches)
+        element_subgrid const &grid, std::vector<element_chunk> const &chunks,
+        host_workspace<P> &host_space, rank_workspace<P> &rank_space,
+        std::vector<batch_operands_set<P>> &batches)
 {
   fm::scal(static_cast<P>(0.0), host_space.fx);
 

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -46,7 +46,7 @@ void explicit_time_advance(PDE<P> const &pde, element_table const &table,
   std::vector<batch_operands_set<P>> batches =
       allocate_batches<P>(pde, max_elems);
 
-  apply_explicit(pde, table, grid, chunks, host_space, rank_space, batches);
+  apply_A(pde, table, grid, chunks, host_space, rank_space, batches);
   reduce_results(host_space.fx, host_space.reduced_fx, plan, my_rank);
   scale_sources(pde, unscaled_sources, host_space.scaled_source, time);
   fm::axpy(host_space.scaled_source, host_space.reduced_fx);
@@ -56,7 +56,7 @@ void explicit_time_advance(PDE<P> const &pde, element_table const &table,
   P const fx_scale_1 = a21 * dt;
   fm::axpy(host_space.result_1, host_space.x, fx_scale_1);
 
-  apply_explicit(pde, table, grid, chunks, host_space, rank_space, batches);
+  apply_A(pde, table, grid, chunks, host_space, rank_space, batches);
   reduce_results(host_space.fx, host_space.reduced_fx, plan, my_rank);
   scale_sources(pde, unscaled_sources, host_space.scaled_source,
                 time + c2 * dt);
@@ -71,7 +71,7 @@ void explicit_time_advance(PDE<P> const &pde, element_table const &table,
   fm::axpy(host_space.result_1, host_space.x, fx_scale_2a);
   fm::axpy(host_space.result_2, host_space.x, fx_scale_2b);
 
-  apply_explicit(pde, table, grid, chunks, host_space, rank_space, batches);
+  apply_A(pde, table, grid, chunks, host_space, rank_space, batches);
   reduce_results(host_space.fx, host_space.reduced_fx, plan, my_rank);
   scale_sources(pde, unscaled_sources, host_space.scaled_source,
                 time + c3 * dt);
@@ -112,7 +112,7 @@ scale_sources(PDE<P> const &pde,
 // gemm (explicit time advance).
 template<typename P>
 static void
-apply_explicit(PDE<P> const &pde, element_table const &elem_table,
+apply_A(PDE<P> const &pde, element_table const &elem_table,
                element_subgrid const &grid,
                std::vector<element_chunk> const &chunks,
                host_workspace<P> &host_space, rank_workspace<P> &rank_space,


### PR DESCRIPTION
clarify: `apply_explicit` -> `apply_system`.

didn't touch the naming of chunk data management functions; there is a PR in the pipeline #199 that addresses those.

closes #141 if you're happy with the name @dlg0 .
