### PR TITLE
CMake: adjust logic to use Cray LibSci instead of OpenBLAS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,14 @@
-cmake_minimum_required (VERSION 3.13)
+cmake_minimum_required (VERSION 3.13) # remove cray check below when >= 3.16
 project (asgard
   VERSION 0.1.0
   LANGUAGES CXX
 )
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL "CrayLinuxEnvironment")
+  if (CMAKE_VERSION VERSION_LESS "3.16")
+    message (WARNING "To use Cray LibSci instead of building OpenBLAS, you must use CMake >= 3.16.")
+  endif ()
+endif ()
 
 ###############################################################################
 ## Set up the compiler and general global build options
@@ -39,12 +45,6 @@ endif()
 if (NOT ASGARD_LAPACK_PATH AND ASGARD_BLAS_PATH)
   set (ASGARD_LAPACK_PATH ${ASGARD_BLAS_PATH})
 endif()
-
-if(${CMAKE_SYSTEM_NAME} STREQUAL "CrayLinuxEnvironment")
-  if (CMAKE_VERSION VERSION_LESS "3.16")
-    message (WARNING "To use Cray LibSci instead of building OpenBLAS, you must use CMake >= 3.16.")
-  endif ()
-endif ()
 
 ###############################################################################
 ## Pull in external support as needed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,12 @@ if (NOT ASGARD_LAPACK_PATH AND ASGARD_BLAS_PATH)
   set (ASGARD_LAPACK_PATH ${ASGARD_BLAS_PATH})
 endif()
 
+if(${CMAKE_SYSTEM_NAME} STREQUAL "CrayLinuxEnvironment")
+  if (CMAKE_VERSION VERSION_LESS "3.16")
+    message (WARNING "To use Cray LibSci instead of building OpenBLAS, you must use CMake >= 3.16.")
+  endif ()
+endif ()
+
 ###############################################################################
 ## Pull in external support as needed
 ###############################################################################

--- a/contrib/contrib.cmake
+++ b/contrib/contrib.cmake
@@ -70,15 +70,16 @@ if (NOT ASGARD_BUILD_OPENBLAS)
       PATH_SUFFIXES lib lib64 NO_DEFAULT_PATH)
     if (LAPACK_LIB AND BLAS_LIB)
       set (LINALG_LIBS ${LAPACK_LIB} ${BLAS_LIB})
+      set (LINALG_LIBS_FOUND TRUE)
     endif ()
   endif ()
 
   # search for blas/lapack packages providing cmake/pkgconfig
-  if (NOT LINALG_LIBS)
+  if (NOT LINALG_LIBS_FOUND)
     find_package (LAPACK QUIET)
     find_package (BLAS QUIET)
-    if (LAPACK_FOUND)
     #if (LAPACK_FOUND AND BLAS_FOUND)
+    if (LAPACK_FOUND)
       # CMake 3.16 fixed LAPACK and BLAS detection on Cray systems, and
       # intentionally sets LAPACK_LIBRARIES and BLAS_LIBRARIES to empty
       # strings, trusting that the compiler wrapper will link the correct
@@ -87,30 +88,31 @@ if (NOT ASGARD_BUILD_OPENBLAS)
       # LAPACK_FOUND is true, then LINALG_LIBS becomes itself an empty string
       # on Cray systems, and as a result will build OpenBLAS (which we don't
       # want).
-      if (LAPACK_LIBRARIES AND BLAS_LIBRARIES)
-        set (LINALG_LIBS ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
-      endif ()
+      # So indicate that it was found, but the libraries remain empty for CMake
+      set (LINALG_LIBS_FOUND TRUE)
+      set (LINALG_LIBS ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
     endif ()
   endif ()
 
   # search for blas/lapack libraries
-  if (NOT LINALG_LIBS AND NOT LAPACK_FOUND)
+  if (NOT LINALG_LIBS_FOUND)
     find_library (LAPACK_LIB lapack openblas)
     find_library (BLAS_LIB blas openblas)
     if (LAPACK_LIB AND BLAS_LIB)
       set (LINALG_LIBS ${LAPACK_LIB} ${BLAS_LIB})
+      set (LINALG_LIBS_FOUND TRUE)
     endif()
   endif ()
 
   if (LINALG_LIBS)
     message (STATUS "LINALG libraries found: ${LINALG_LIBS}")
-  elseif (LAPACK_FOUND AND NOT LINALG_LIBS)
+  elseif (LINALG_LIBS_FOUND AND NOT LINALG_LIBS)
     message (STATUS "LINALG libraries found, relying on compiler wrappers")
   endif ()
 endif ()
 
 # if cmake couldn't find other blas/lapack, or the user asked to build openblas
-if (NOT LINALG_LIBS AND NOT LAPACK_FOUND)
+if (NOT LINALG_LIBS_FOUND)
   # first check if it has already been built
   set (OpenBLAS_PATH ${CMAKE_SOURCE_DIR}/contrib/blas/openblas)
   find_library (LINALG_LIBS openblas PATHS ${OpenBLAS_PATH}/lib)


### PR DESCRIPTION
CMake plays funny tricks on the `find_package(LAPACK)` and `find_package(BLAS)`
commands when trying to detect Cray LibSci. So the CMake logic needed to be
adjusted to handle this case, in order to avoid building OpenBLAS.