### PR TITLE
set omp_num_threads for tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,6 +257,7 @@ if (ASGARD_BUILD_TESTS)
       add_test (NAME ${component}-test-mpi
                 COMMAND mpirun -n ${test_ranks} ${component}-tests
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} )
+      set_tests_properties(${component}-test-mpi PROPERTIES ENVIRONMENT "OPENMP_NUM_THREADS=2")
       endif()
     endif ()
 
@@ -269,6 +270,7 @@ if (ASGARD_BUILD_TESTS)
     add_test (NAME ${component}-test
               COMMAND ${component}-tests
               WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} )
+    set_tests_properties(${component}-test PROPERTIES ENVIRONMENT "OPENMP_NUM_THREADS=8")
   endforeach ()
 
 


### PR DESCRIPTION
the tests in CI were thrashing each other, so we're restricting OpenMP appropriately