### PR TITLE
add tolerance to batch tests

### DIFF
--- a/src/batch_tests.cpp
+++ b/src/batch_tests.cpp
@@ -361,14 +361,19 @@ void test_batched_gemm(int const m, int const n, int const k, int const lda,
   };
   for (int i = 0; i < num_batch; ++i)
   {
+    // we use random vals for tests - multiply eps by this amount
+    // in comparisons to provide a wider tolerance, set 1/14
+    auto const eps_multiplier = 1e3;
     if constexpr (resrc == resource::host)
     {
-      REQUIRE(effect_c(matrices[2][i]) == effect_c(matrices[3][i]));
+      relaxed_comparison(effect_c(matrices[2][i]), effect_c(matrices[3][i]),
+                         eps_multiplier);
     }
     else
     {
       relaxed_comparison(effect_c(matrices[2][i].clone_onto_host()),
-                         effect_c(matrices[3][i].clone_onto_host()));
+                         effect_c(matrices[3][i].clone_onto_host()),
+                         eps_multiplier);
     }
   }
 }
@@ -579,14 +584,17 @@ void test_batched_gemv(int const m, int const n, int const lda,
 
   for (int i = 0; i < num_batch; ++i)
   {
+    // we use random vals for tests - multiply eps by this amount
+    // in comparisons to provide a wider tolerance, set 1/14
+    auto const eps_multiplier = 1e3;
     if constexpr (resrc == resource::host)
     {
-      REQUIRE(vectors[1][i] == vectors[2][i]);
+      relaxed_comparison(vectors[1][i], vectors[2][i], eps_multiplier);
     }
     else
     {
-      REQUIRE(vectors[1][i].clone_onto_host() ==
-              vectors[2][i].clone_onto_host());
+      relaxed_comparison(vectors[1][i].clone_onto_host(),
+                         vectors[2][i].clone_onto_host(), eps_multiplier);
     }
   }
 }


### PR DESCRIPTION
fix CI failing intermittently on tests with arithmetic on randomly generated matrices/vectors by adding a small tolerance.