### PR TITLE
WIP: refactor/batch

### DIFF
--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -261,6 +261,11 @@ batch<P, resrc>::batch(int const capacity, int const nrows, int const ncols,
   assert(nrows > 0);
   assert(ncols > 0);
   assert(stride > 0);
+
+  // FIXME removing separate allocation
+  // so, this needs to go along with assert checks
+  // on exec for nullptr
+  // essentially, RAII and this becomes unnecessary
   for (P *&ptr : (*this))
   {
     ptr = nullptr;

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -237,6 +237,15 @@ batch_chain<P, resrc, method>::batch_chain(
 }
 
 template<typename P, resource resrc, chain_method method>
+template<chain_method, typename>
+batch_chain<P, resrc, method>::batch_chain(PDE<P> const &pde,
+                                           element_table const &elem_table,
+                                           device_workspace<P> const &workspace,
+                                           element_subgrid const &subgrid,
+                                           element_chunk const &chunk)
+{}
+
+template<typename P, resource resrc, chain_method method>
 void batch_chain<P, resrc, method>::execute() const
 {
   assert(left.size() == right.size());
@@ -1302,3 +1311,59 @@ template class batch_chain<double, resource::device, chain_method::advance>;
 template class batch_chain<double, resource::host, chain_method::advance>;
 template class batch_chain<float, resource::device, chain_method::advance>;
 template class batch_chain<float, resource::host, chain_method::advance>;
+
+template batch_chain<float, resource::host, chain_method::realspace>::
+    batch_chain(
+        std::vector<fk::matrix<float, mem_type::const_view,
+                               resource::host>> const &matrices,
+        fk::vector<float, mem_type::const_view, resource::host> const &x,
+        std::array<fk::vector<float, mem_type::view, resource::host>, 2>
+            &workspace,
+        fk::vector<float, mem_type::view, resource::host> &final_output);
+
+template batch_chain<double, resource::host, chain_method::realspace>::
+    batch_chain(
+        std::vector<fk::matrix<double, mem_type::const_view,
+                               resource::host>> const &matrices,
+        fk::vector<double, mem_type::const_view, resource::host> const &x,
+        std::array<fk::vector<double, mem_type::view, resource::host>, 2>
+            &workspace,
+        fk::vector<double, mem_type::view, resource::host> &final_output);
+
+template batch_chain<float, resource::device, chain_method::realspace>::
+    batch_chain(
+        std::vector<fk::matrix<float, mem_type::const_view,
+                               resource::device>> const &matrices,
+        fk::vector<float, mem_type::const_view, resource::device> const &x,
+        std::array<fk::vector<float, mem_type::view, resource::device>, 2>
+            &workspace,
+        fk::vector<float, mem_type::view, resource::device> &final_output);
+
+template batch_chain<double, resource::device, chain_method::realspace>::
+    batch_chain(
+        std::vector<fk::matrix<double, mem_type::const_view,
+                               resource::device>> const &matrices,
+        fk::vector<double, mem_type::const_view, resource::device> const &x,
+        std::array<fk::vector<double, mem_type::view, resource::device>, 2>
+            &workspace,
+        fk::vector<double, mem_type::view, resource::device> &final_output);
+
+template batch_chain<float, resource::device, chain_method::advance>::
+    batch_chain(PDE<float> const &pde, element_table const &elem_table,
+                device_workspace<float> const &workspace,
+                element_subgrid const &subgrid, element_chunk const &chunk);
+
+template batch_chain<double, resource::device, chain_method::advance>::
+    batch_chain(PDE<double> const &pde, element_table const &elem_table,
+                device_workspace<double> const &workspace,
+                element_subgrid const &subgrid, element_chunk const &chunk);
+
+template batch_chain<float, resource::host, chain_method::advance>::batch_chain(
+    PDE<float> const &pde, element_table const &elem_table,
+    host_workspace<float> const &workspace, element_subgrid const &subgrid,
+    element_chunk const &chunk);
+
+template batch_chain<double, resource::host, chain_method::advance>::
+    batch_chain(PDE<double> const &pde, element_table const &elem_table,
+                host_workspace<double> const &workspace,
+                element_subgrid const &subgrid, element_chunk const &chunk);

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -82,8 +82,9 @@ int calculate_workspace_length(
    each stage is the output of the previous. The initial input is the vector
    "x". The output of each stage is a vector. The output of the final stage is
    the solution to the problem. */
-template<typename P, resource resrc>
-batch_chain<P, resrc>::batch_chain(
+template<typename P, resource resrc, chain_method method>
+template<chain_method, typename>
+batch_chain<P, resrc, method>::batch_chain(
     std::vector<fk::matrix<P, mem_type::const_view, resrc>> const &matrices,
     fk::vector<P, mem_type::const_view, resrc> const &x,
     std::array<fk::vector<P, mem_type::view, resrc>, 2> &workspace,
@@ -235,8 +236,8 @@ batch_chain<P, resrc>::batch_chain(
   return;
 }
 
-template<typename P, resource resrc>
-void batch_chain<P, resrc>::execute_batch_chain()
+template<typename P, resource resrc, chain_method method>
+void batch_chain<P, resrc, method>::execute() const
 {
   assert(left.size() == right.size());
   assert(right.size() == product.size());
@@ -1292,7 +1293,12 @@ template int calculate_workspace_length<float, resource::host>(
         &matrices,
     int const x_size);
 
-template class batch_chain<double, resource::device>;
-template class batch_chain<double, resource::host>;
-template class batch_chain<float, resource::device>;
-template class batch_chain<float, resource::host>;
+template class batch_chain<double, resource::device, chain_method::realspace>;
+template class batch_chain<double, resource::host, chain_method::realspace>;
+template class batch_chain<float, resource::device, chain_method::realspace>;
+template class batch_chain<float, resource::host, chain_method::realspace>;
+
+template class batch_chain<double, resource::device, chain_method::advance>;
+template class batch_chain<double, resource::host, chain_method::advance>;
+template class batch_chain<float, resource::device, chain_method::advance>;
+template class batch_chain<float, resource::host, chain_method::advance>;

--- a/src/batch.hpp
+++ b/src/batch.hpp
@@ -87,6 +87,9 @@ kron m_end ) * x
 
 */
 
+// FIXME add nontype template param - enum - single/multiple - and SFINAE
+// construction == allocation
+// kronmult to batch sets - fold into constructor I think
 template<typename P, resource resrc>
 class batch_chain
 {

--- a/src/batch.hpp
+++ b/src/batch.hpp
@@ -90,18 +90,35 @@ kron m_end ) * x
 // FIXME add nontype template param - enum - single/multiple - and SFINAE
 // construction == allocation
 // kronmult to batch sets - fold into constructor I think
-template<typename P, resource resrc>
+
+// which of the kronecker-product based algorithms the batch chain supports
+enum class chain_method
+{
+  realspace, // for realspace transform
+  advance    // for time advance
+};
+
+template<chain_method method>
+using enable_for_realspace =
+    std::enable_if_t<method == chain_method::realspace>;
+
+template<chain_method method>
+using enable_for_advance = std::enable_if_t<method == chain_method::advance>;
+
+template<typename P, resource resrc,
+         chain_method method = chain_method::realspace>
 class batch_chain
 {
 public:
-  /* allocates batches and assigns data */
+  /* allocates batches and assigns data - realspace transform constructor */
+  template<chain_method m_ = method, typename = enable_for_realspace<m_>>
   batch_chain(
       std::vector<fk::matrix<P, mem_type::const_view, resrc>> const &matrices,
       fk::vector<P, mem_type::const_view, resrc> const &x,
       std::array<fk::vector<P, mem_type::view, resrc>, 2> &workspace,
       fk::vector<P, mem_type::view, resrc> &final_output);
 
-  void execute_batch_chain();
+  void execute() const;
 
 private:
   std::vector<batch<P, resrc>> left;

--- a/src/batch.hpp
+++ b/src/batch.hpp
@@ -118,6 +118,12 @@ public:
       std::array<fk::vector<P, mem_type::view, resrc>, 2> &workspace,
       fk::vector<P, mem_type::view, resrc> &final_output);
 
+  // time advance constructor
+  template<chain_method m_ = method, typename = enable_for_advance<m_>>
+  batch_chain(PDE<P> const &pde, element_table const &elem_table,
+              device_workspace<P> const &workspace,
+              element_subgrid const &subgrid, element_chunk const &chunk);
+
   void execute() const;
 
 private:

--- a/src/batch_tests.cpp
+++ b/src/batch_tests.cpp
@@ -26,8 +26,8 @@ void test_kron(
   fk::vector<P, mem_type::owner, resrc> real_space_owner(correct.size());
   fk::vector<P, mem_type::view, resrc> real_space(real_space_owner);
 
-  batch_chain<P, resrc> chain(matrices, x_view, workspace, real_space);
-  chain.execute_batch_chain();
+  batch_chain<P, resrc> const chain(matrices, x_view, workspace, real_space);
+  chain.execute();
 
   if constexpr (resrc == resource::device)
   {

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -35,6 +35,7 @@ void explicit_time_advance(PDE<P> const &pde, element_table const &table,
   element_subgrid const &grid = plan.at(my_rank);
   int const elem_size         = element_segment_size(pde);
 
+  // FIXME remove prealloc and clearing
   // allocate batches
   // max number of elements in any chunk
   int const max_elems = num_elements_in_chunk(*std::max_element(

--- a/src/transformations.cpp
+++ b/src/transformations.cpp
@@ -179,9 +179,9 @@ void wavelet_to_realspace(
   /* clear out the vector */
   real_space.scale(0);
 
-  for (auto &link : chain)
+  for (auto const &link : chain)
   {
-    link.execute_batch_chain();
+    link.execute();
     real_space = real_space + real_space_accumulator;
   }
 


### PR DESCRIPTION
use the same machinery for batch building/execution in time advance and realspace conversion where possible.

clean up batch set interface and enforce RAII if no performance penalty.

closes #85 .