### PR TITLE
Feature/faster batching

### DIFF
--- a/contrib/contrib.cmake
+++ b/contrib/contrib.cmake
@@ -141,7 +141,7 @@ if (NOT LINALG_LIBS_FOUND)
       PREFIX contrib/blas/openblas
       URL https://github.com/xianyi/OpenBLAS/archive/v0.3.4.tar.gz
       DOWNLOAD_NO_PROGRESS 1
-      CONFIGURE_COMMAND ""
+      CONFIGURE_COMMAND "USE_OPENMP=1"
       BUILD_COMMAND make
       BUILD_IN_SOURCE 1
       INSTALL_COMMAND make PREFIX=${OpenBLAS_PATH} install

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -1072,15 +1072,17 @@ void build_batches(PDE<P> const &pde, element_table const &elem_table,
         }();
 
         // operator views, windows into operator matrix
-
-        std::vector<P *> operator_ptrs(pde.num_dims);
-        for (int d = pde.num_dims - 1; d >= 0; --d)
-        {
-          operator_ptrs[d] =
-              pde.get_coefficients(k, d).data() + operator_row(d) +
-              operator_col(d) * pde.get_coefficients(k, d).stride();
-        }
-
+        std::vector<P *> const operator_ptrs = [&pde, &operator_row,
+                                                &operator_col, k]() {
+          std::vector<P *> operator_ptrs(pde.num_dims);
+          for (int d = pde.num_dims - 1; d >= 0; --d)
+          {
+            operator_ptrs[d] =
+                pde.get_coefficients(k, d).data() + operator_row(d) +
+                operator_col(d) * pde.get_coefficients(k, d).stride();
+          }
+          return operator_ptrs;
+        }();
         // determine the index for the input vector
         int const x_index = subgrid.to_local_col(j) * elem_size;
 

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -3,6 +3,7 @@
 #ifdef ASGARD_USE_OPENMP
 #include <omp.h>
 #endif
+#include <chrono>
 #include "chunk.hpp"
 #include "connectivity.hpp"
 #include "lib_dispatch.hpp"
@@ -950,6 +951,8 @@ void build_batches(PDE<P> const &pde, element_table const &elem_table,
                    element_subgrid const &subgrid, element_chunk const &chunk,
                    std::vector<batch_operands_set<P>> &batches)
 {
+
+  auto const start = std::chrono::high_resolution_clock::now();
   // assume uniform degree for now
   int const degree    = pde.get_dimensions()[0].get_degree();
   int const elem_size = static_cast<int>(std::pow(degree, pde.num_dims));
@@ -1091,6 +1094,9 @@ void build_batches(PDE<P> const &pde, element_table const &elem_table,
       }
     }
   }
+        std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::high_resolution_clock::now() - start)
+            .count() << '\n';
 }
 
 // function to allocate and build implicit system.

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -7,7 +7,6 @@
 #include "connectivity.hpp"
 #include "lib_dispatch.hpp"
 #include "tensors.hpp"
-#include <chrono>
 #include <limits.h>
 /*
 
@@ -951,8 +950,6 @@ void build_batches(PDE<P> const &pde, element_table const &elem_table,
                    element_subgrid const &subgrid, element_chunk const &chunk,
                    std::vector<batch_operands_set<P>> &batches)
 {
-  auto const start = std::chrono::high_resolution_clock::now();
-
   // assume uniform degree for now
   int const degree    = pde.get_dimensions()[0].get_degree();
   int const elem_size = static_cast<int>(std::pow(degree, pde.num_dims));
@@ -1094,10 +1091,6 @@ void build_batches(PDE<P> const &pde, element_table const &elem_table,
       }
     }
   }
-  std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(
-                   std::chrono::high_resolution_clock::now() - start)
-                   .count()
-            << '\n';
 }
 
 // function to allocate and build implicit system.

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -7,7 +7,6 @@
 #include "connectivity.hpp"
 #include "lib_dispatch.hpp"
 #include "tensors.hpp"
-#include <chrono>
 #include <limits.h>
 
 /*
@@ -966,7 +965,6 @@ void build_batches(PDE<P> const &pde, element_table const &elem_table,
                    element_subgrid const &subgrid, element_chunk const &chunk,
                    std::vector<batch_operands_set<P>> &batches)
 {
-  auto const start = std::chrono::high_resolution_clock::now();
   // assume uniform degree for now
   int const degree    = pde.get_dimensions()[0].get_degree();
   int const elem_size = static_cast<int>(std::pow(degree, pde.num_dims));

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -7,7 +7,6 @@
 #include "connectivity.hpp"
 #include "lib_dispatch.hpp"
 #include "tensors.hpp"
-#include <chrono>
 #include <limits.h>
 /*
 
@@ -965,7 +964,6 @@ void build_batches(PDE<P> const &pde, element_table const &elem_table,
                    element_subgrid const &subgrid, element_chunk const &chunk,
                    std::vector<batch_operands_set<P>> &batches)
 {
-  auto const start = std::chrono::high_resolution_clock::now();
   // assume uniform degree for now
   int const degree    = pde.get_dimensions()[0].get_degree();
   int const elem_size = static_cast<int>(std::pow(degree, pde.num_dims));
@@ -1108,10 +1106,6 @@ void build_batches(PDE<P> const &pde, element_table const &elem_table,
       }
     }
   }
-  std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(
-                   std::chrono::high_resolution_clock::now() - start)
-                   .count()
-            << '\n';
 }
 
 // function to allocate and build implicit system.

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -1015,7 +1015,7 @@ void build_batches(PDE<P> const &pde, element_table const &elem_table,
     int operator_row[max_dims];
     int operator_col[max_dims];
     P *workspace_ptrs[max_workspaces];
-    P *operator_ptrs[max_workspaces];
+    P *operator_ptrs[max_dims];
 
     // i: row we are addressing in element grid
     int const i = index_to_key[chunk_num];

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -975,6 +975,9 @@ void build_batches(PDE<P> const &pde, element_table const &elem_table,
 
   ready_batches(pde, chunk, batches);
 
+  // here we map integers 0->chunk_size-1 to row_0->row_last in the chunk
+  // we could iterate over the chunk (which is a map rows->connected)
+  // but openmp requires traditional loop, not foreachs
   std::vector<int> const index_to_key = [&chunk]() {
     std::vector<int> builder;
     for (auto const &[i, connected] : chunk)

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -846,9 +846,6 @@ void unsafe_kronmult_to_batch_sets(P *const *const A, P *const x, P *const y,
   // this code will have to change...
   int const degree = pde.get_dimensions()[0].get_degree();
 
-  // check workspace sizes
-  // assert(static_cast<int>(work.size()) == std::min(pde.num_dims - 1, 2));
-
   // we need an operand set for each dimension on entry
   assert(static_cast<int>(batches.size()) == pde.num_dims);
 

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -3,11 +3,11 @@
 #ifdef ASGARD_USE_OPENMP
 #include <omp.h>
 #endif
-#include <chrono>
 #include "chunk.hpp"
 #include "connectivity.hpp"
 #include "lib_dispatch.hpp"
 #include "tensors.hpp"
+#include <chrono>
 #include <limits.h>
 /*
 
@@ -951,7 +951,6 @@ void build_batches(PDE<P> const &pde, element_table const &elem_table,
                    element_subgrid const &subgrid, element_chunk const &chunk,
                    std::vector<batch_operands_set<P>> &batches)
 {
-
   auto const start = std::chrono::high_resolution_clock::now();
   // assume uniform degree for now
   int const degree    = pde.get_dimensions()[0].get_degree();
@@ -1077,7 +1076,7 @@ void build_batches(PDE<P> const &pde, element_table const &elem_table,
           std::vector<P *> operator_ptrs(pde.num_dims);
           for (int d = pde.num_dims - 1; d >= 0; --d)
           {
-            operator_ptrs[d] =
+            operator_ptrs[(pde.num_dims - 1) - d] =
                 pde.get_coefficients(k, d).data() + operator_row(d) +
                 operator_col(d) * pde.get_coefficients(k, d).stride();
           }
@@ -1094,9 +1093,10 @@ void build_batches(PDE<P> const &pde, element_table const &elem_table,
       }
     }
   }
-        std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::high_resolution_clock::now() - start)
-            .count() << '\n';
+  std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(
+                   std::chrono::high_resolution_clock::now() - start)
+                   .count()
+            << '\n';
 }
 
 // function to allocate and build implicit system.

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -7,7 +7,9 @@
 #include "connectivity.hpp"
 #include "lib_dispatch.hpp"
 #include "tensors.hpp"
+#include <chrono>
 #include <limits.h>
+
 /*
 
 Problem relevant to batch_chain class:
@@ -964,6 +966,7 @@ void build_batches(PDE<P> const &pde, element_table const &elem_table,
                    element_subgrid const &subgrid, element_chunk const &chunk,
                    std::vector<batch_operands_set<P>> &batches)
 {
+  auto const start = std::chrono::high_resolution_clock::now();
   // assume uniform degree for now
   int const degree    = pde.get_dimensions()[0].get_degree();
   int const elem_size = static_cast<int>(std::pow(degree, pde.num_dims));
@@ -1004,7 +1007,8 @@ void build_batches(PDE<P> const &pde, element_table const &elem_table,
 
 // loop over elements
 #ifdef ASGARD_USE_OPENMP
-#pragma omp parallel for
+  int const threads = omp_get_num_procs();
+#pragma omp parallel for num_threads(threads)
 #endif
   for (int chunk_num = 0; chunk_num < static_cast<int>(chunk.size());
        ++chunk_num)

--- a/src/batch.hpp
+++ b/src/batch.hpp
@@ -186,10 +186,11 @@ void kronmult_to_batch_sets(
 // in the view class incurs a prohibitive runtime cost when used
 // to batch millions (or billions) of GEMMs, e.g. for a 6d problem
 template<typename P>
-void unsafe_kronmult_to_batch_sets(std::vector<P *> const &A, P *const x,
-                                   P *const y, std::vector<P *> const &work,
+void unsafe_kronmult_to_batch_sets(P *const *const A, P *const x, P *const y,
+                                   P *const *const work,
                                    std::vector<batch_operands_set<P>> &batches,
                                    int const batch_offset, PDE<P> const &pde);
+
 template<typename P>
 void build_batches(PDE<P> const &pde, element_table const &elem_table,
                    device_workspace<P> const &workspace,

--- a/src/batch_tests.cpp
+++ b/src/batch_tests.cpp
@@ -1044,9 +1044,9 @@ void unsafe_kronmult(
     std::vector<batch_operands_set<P>> &batches, int const batch_offset,
     PDE<P> const &pde)
 {
-  unsafe_kronmult_to_batch_sets(views_to_ptrs<P>(A), x.data(), y.data(),
-                                views_to_ptrs<P>(work), batches, batch_offset,
-                                pde);
+  unsafe_kronmult_to_batch_sets(views_to_ptrs<P>(A).data(), x.data(), y.data(),
+                                views_to_ptrs<P>(work).data(), batches,
+                                batch_offset, pde);
 }
 
 template<typename P>

--- a/src/element_table.cpp
+++ b/src/element_table.cpp
@@ -72,7 +72,7 @@ int element_table::get_index(fk::vector<int> const coords) const
 }
 
 // reverse lookup - returns coordinates at a certain index
-fk::vector<int> element_table::get_coords(int const index) const
+fk::vector<int> const &element_table::get_coords(int const index) const
 {
   assert(index >= 0);
   assert(static_cast<size_t>(index) < reverse_table.size());

--- a/src/element_table.hpp
+++ b/src/element_table.hpp
@@ -39,7 +39,7 @@ public:
   int get_index(fk::vector<int> const coords) const;
 
   // reverse lookup
-  fk::vector<int> get_coords(int const index) const;
+  fk::vector<int> const &get_coords(int const index) const;
 
   // returns the number of elements in table
   int size() const

--- a/src/lib_dispatch.cpp
+++ b/src/lib_dispatch.cpp
@@ -774,7 +774,7 @@ void batched_gemm(P **const &a, int *lda, char const *transa, P **const &b,
   }
 
   // default execution on the host for any resource
-  int end = *num_batch;
+  int const end = *num_batch;
 #ifdef ASGARD_USE_OPENMP
 #pragma omp parallel for
 #endif


### PR DESCRIPTION
noticed batch building scaled poorly with threads.

this is a nested loop process - outer loop over rows in a chunk, inner loop over connected items. we were parallelizing the inner loop, but significant work was also done in the outer loop.

so, two improvements: 1) hoisted the pragma into outer loop to parallelize more work. 
                                     2) ensured realloc wasn't called on operator ptrs.

update: playing with tcmalloc and trying to improve performance of heap allocation across threads failed.

so, allocate all variables inside batch building openmp loop on thread stacks.

this yields multiple x speedup and better scaling.