### PR TITLE
batch refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,6 +274,11 @@ if (ASGARD_BUILD_TESTS)
       target_link_libraries (io-tests PRIVATE highfive hdf5 tensors)
     endif ()
 
+    if ("${component}" STREQUAL "chunk")
+      target_link_libraries (chunk-tests PRIVATE batch)
+    endif ()
+
+
     if (ASGARD_USE_MPI)
       target_link_libraries (${component}-tests PRIVATE ${component} MPI::MPI_CXX)
       if ("${component}" STREQUAL "distribution" OR

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -226,7 +226,7 @@ batch<P, resrc> &batch<P, resrc>::clear_all()
 // execute a batched gemm given a, b, c batch lists
 // and other blas information
 // if we store info in the batch about where it is
-// resrcident, this could be an abstraction point
+// resident, this could be an abstraction point
 // for calling cpu/gpu blas etc.
 template<typename P, resource resrc>
 void batched_gemm(batch<P, resrc> const &a, batch<P, resrc> const &b,

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -352,20 +352,21 @@ linear_coords_to_indices(PDE<P> const &pde, int const degree,
   return indices;
 }
 
-// FIXME this needs trimming
 /*
 
-Problem relevant to batch_chain class:
+Problem solved by batch_chain class:
 
-given a vector "x" of length "x_size" and list of matrices of arbitrary
-dimension in "matrix": { m0, m1, ... , m_last }, calculate ( m0 kron m1 kron ...
-kron m_end ) * x
+perform one or many (A1 kron A2 ... kron An) * x via constructing pointer lists
+to small gemms and invoking BLAS
 
 */
 
 /*
-For a list of "n" matrices in "matrix" parameter, the Kron algorithm in this
-file will go through "n" rounds of batched matrix multiplications. The output of
+
+Realspace Transform
+
+For a list of "n" matrices in "matrix" parameter, this constructor
+will prepare "n" rounds of batched matrix multiplications. The output of
 each round becomes the input of the next round. Two workspaces are thus
 sufficient, if each of them is as large as the largest output from any round.
 This function calculates the largest output of any round.
@@ -385,21 +386,7 @@ Round 0 output size: b*d*f*g
 Round 1 output size: b*d*e*g
 Round 2 output size: b*c*e*g
 Round 3 ourput size: a*c*e*g
-
-Max space needed is maximum of the above sizes.
-
-Improvement idea: Each stage alternates between 2 workspaces,
-so the first workspace needs to be the maximum of round 0 and 2, while the other
-needs to be the max of round 1 and 3. As it stands now, each workspace is the
-size of the max of all rounds.
 */
-
-/* batch chain delineates the dataflow for the algorithm that implements the
-   particular problem described in the comment at the top of the file. The
-   algorithm proceeds in stages, with a stage for each matrix in the list. The
-   input for each stage is the output of the previous. The initial input is the
-   vector "x". The output of each stage is a vector. The output of the final
-   stage is the solution to the problem. */
 
 template<typename P, resource resrc, chain_method method>
 template<chain_method, typename>

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -9,257 +9,6 @@
 #include "tensors.hpp"
 #include <limits.h>
 
-/*
-
-Problem relevant to batch_chain class:
-
-given a vector "x" of length "x_size" and list of matrices of arbitrary
-dimension in "matrix": { m0, m1, ... , m_last }, calculate ( m0 kron m1 kron ...
-kron m_end ) * x
-
-*/
-
-/*
-For a list of "n" matrices in "matrix" parameter, the Kron algorithm in this
-file will go through "n" rounds of batched matrix multiplications. The output of
-each round becomes the input of the next round. Two workspaces are thus
-sufficient, if each of them is as large as the largest output from any round.
-This function calculates the largest output of any round.
-
-For a Kronecker product m0 * m1 * m2 * x = m3:
-matrix ~ ( rows, columns )
-m0 ~ (a, b)
-m1 ~ ( c, d )
-m2 ~ ( e, f )
-m3 ~ ( g, h )
-x ~ ( b*d*f*h, 1 )
-m3 ~ ( a*c*e*g, 1 )
-
-Algorithm completes in 3 rounds.
-Initial space needed: size of "x" vector: b*d*f*h
-Round 0 output size: b*d*f*g
-Round 1 output size: b*d*e*g
-Round 2 output size: b*c*e*g
-Round 3 ourput size: a*c*e*g
-
-Max space needed is maximum of the above sizes.
-
-Improvement idea: Each stage alternates between 2 workspaces,
-so the first workspace needs to be the maximum of round 0 and 2, while the other
-needs to be the max of round 1 and 3. As it stands now, each workspace is the
-size of the max of all rounds.
-*/
-template<typename P, resource resrc>
-int calculate_workspace_length(
-    std::vector<fk::matrix<P, mem_type::const_view, resrc>> const &matrices,
-    int const x_size)
-{
-  int greatest = x_size;
-  int r_prod   = 1;
-  int c_prod   = 1;
-
-  typename std::vector<
-      fk::matrix<P, mem_type::const_view, resrc>>::const_reverse_iterator iter;
-
-  for (iter = matrices.rbegin(); iter != matrices.rend(); ++iter)
-  {
-    c_prod *= iter->ncols();
-    assert(c_prod > 0);
-
-    r_prod *= iter->nrows();
-
-    int const size = x_size / c_prod * r_prod;
-    if (size > greatest)
-      greatest = size;
-  }
-
-  return greatest;
-}
-
-/* delineate the dataflow for the algorithm that implements the particular
-   problem described in the comment at the top of the file. The algorithm
-   proceeds in stages, with a stage for each matrix in the list. The input for
-   each stage is the output of the previous. The initial input is the vector
-   "x". The output of each stage is a vector. The output of the final stage is
-   the solution to the problem. */
-
-template<typename P, resource resrc, chain_method method>
-template<chain_method, typename>
-batch_chain<P, resrc, method>::batch_chain(
-    std::vector<fk::matrix<P, mem_type::const_view, resrc>> const &matrices,
-    fk::vector<P, mem_type::const_view, resrc> const &x,
-    std::array<fk::vector<P, mem_type::view, resrc>, 2> &workspace,
-    fk::vector<P, mem_type::view, resrc> &final_output)
-{
-  /* validation */
-  assert(matrices.size() > 0);
-  assert(workspace.size() == 2);
-
-  /* ensure "x" is correct size - should be the product of all the matrices
-     respective number of columns */
-  assert(x.size() == std::accumulate(matrices.begin(), matrices.end(), 1,
-                                     [](int const i, auto const &m) {
-                                       return i * m.ncols();
-                                     }));
-
-  /* these are used to index "workspace" - the input/output role alternates
-     between workspace[ 0 ] and workspace[ 1 ] in this algorithm */
-  int in  = 0;
-  int out = 1;
-
-  /* ensure the workspaces are big enough for the problem */
-  int const workspace_len = calculate_workspace_length(matrices, x.size());
-  assert(workspace[0].size() >= workspace_len);
-  assert(workspace[1].size() >= workspace_len);
-
-  /*
-    The algorithm iterates over each matrix in "matrix" in reverse order,
-    creates a batch_set object for each matrix, and assigns input and output for
-    each multiplication in that batch_set. The first and last iterations are
-    handled differently than the others, so the loop is unrolled accordingly.
-  */
-  {
-    /* only one large matrix multiply is needed for this first iteration. We
-       want to break up "x" into consecutive subvectors of length iter->ncols().
-       Each of these subvectors will be transformed into a vector of length
-       iter->nrows() by multiplying it by the last matrix in the list. These
-       results are concatenated to produce the output of the first stage. The
-       easiest way to implement the above process is with a large matrix
-       multiply: */
-
-    /* define the sizes of the operands */
-    int const rows = x.size() / matrices.back().ncols();
-
-    left_.emplace_back(1, matrices.back().nrows(), matrices.back().ncols(),
-                       matrices.back().stride(), false);
-    right_.emplace_back(1, matrices.back().ncols(), rows,
-                        matrices.back().ncols(), false);
-    product_.emplace_back(1, matrices.back().nrows(), rows,
-                          matrices.back().nrows(), false);
-
-    /* assign the data to the batches */
-    fk::matrix<P, mem_type::const_view, resrc> input(x, matrices.back().ncols(),
-                                                     rows, 0);
-
-    /* If there is only 1 iteration, write immediately to final_output */
-    fk::vector<P, mem_type::view, resrc> destination(workspace[out]);
-    fk::matrix<P, mem_type::view, resrc> output(
-        (matrices.size() > 1 ? destination : final_output),
-        matrices.back().nrows(), rows, 0);
-
-    right_.back().assign_entry(input, 0);
-    left_.back().assign_entry(matrices.back(), 0);
-    product_.back().assign_entry(output, 0);
-
-    /* output and input space will switch roles for the next iteration */
-    std::swap(in, out);
-  }
-
-  /* The remaining iterations are a general case of the first one */
-
-  /* distance in between first element of output subvectors above */
-  int stride = matrices.back().nrows();
-  /* initial value for the size of the input vector for the stage to follow:
-     each iter->ncols()
-     length consecutive subvector was previously replaced by one of length
-     iter->nrows() */
-  int v_size = x.size() / matrices.back().ncols() * matrices.back().nrows();
-
-  /* second to last iteration must be unrolled */
-  for (int i = matrices.size() - 2; i > 0; --i)
-  {
-    /* total number of input matrices encoded in linear input memory */
-    int const n_gemms = v_size / stride / matrices[i].ncols();
-
-    /*
-      left operand's data comes from a linear input array. The transposes ensure
-      that the input can be interpreted in column major format and that the
-      output will be implicitly stored that way.
-    */
-    left_.emplace_back(n_gemms, stride, matrices[i].ncols(), stride, false);
-    right_.emplace_back(n_gemms, matrices[i].nrows(), matrices[i].ncols(),
-                        matrices[i].stride(), true);
-    product_.emplace_back(n_gemms, stride, matrices[i].nrows(), stride, false);
-
-    /* assign actual data to the batches */
-    for (int j = 0; j < n_gemms; ++j)
-    {
-      fk::matrix<P, mem_type::view, resrc> input(
-          workspace[in], stride, matrices[i].ncols(),
-          j * stride * matrices[i].ncols());
-
-      fk::matrix<P, mem_type::view, resrc> output(
-          workspace[out], stride, matrices[i].nrows(),
-          j * stride * matrices[i].nrows());
-
-      left_.back().assign_entry(input, j);
-      right_.back().assign_entry(matrices[i], j);
-      product_.back().assign_entry(output, j);
-    }
-
-    /* output and input space will switch roles for the next iteration */
-    std::swap(in, out);
-
-    /* update variables for next iteration */
-    v_size = n_gemms * stride * matrices[i].nrows();
-    stride *= matrices[i].nrows();
-  }
-
-  /* final loop iteration - output goes into output space instead of workspace
-   */
-  if (matrices.size() > 1)
-  {
-    int const n_gemms = v_size / stride / matrices.front().ncols();
-
-    left_.emplace_back(n_gemms, stride, matrices.front().ncols(), stride,
-                       false);
-    right_.emplace_back(n_gemms, matrices.front().nrows(),
-                        matrices.front().ncols(), matrices.front().stride(),
-                        true);
-    product_.emplace_back(n_gemms, stride, matrices.front().nrows(), stride,
-                          false);
-
-    for (int j = 0; j < n_gemms; ++j)
-    {
-      fk::matrix<P, mem_type::view, resrc> input(
-          workspace[in], stride, matrices.front().ncols(),
-          j * stride * matrices.front().ncols());
-
-      fk::matrix<P, mem_type::view, resrc> output(
-          final_output, stride, matrices.front().nrows(),
-          j * stride * matrices.front().nrows());
-
-      left_.back().assign_entry(input, j);
-      right_.back().assign_entry(matrices.front(), j);
-      product_.back().assign_entry(output, j);
-    }
-  }
-
-  return;
-}
-template<typename P, resource resrc, chain_method method>
-template<chain_method, typename>
-batch_chain<P, resrc, method>::batch_chain(PDE<P> const &pde,
-                                           element_table const &elem_table,
-                                           device_workspace<P> const &workspace,
-                                           element_subgrid const &subgrid,
-                                           element_chunk const &chunk)
-{}
-
-template<typename P, resource resrc, chain_method method>
-void batch_chain<P, resrc, method>::execute() const
-{
-  assert(left.size() == right.size());
-  assert(right.size() == product.size());
-
-  for (int i = 0; i < static_cast<int>(left.size()); ++i)
-  {
-    batched_gemm(left[i], right[i], product[i], (P)1, (P)0);
-  }
-
-  return;
-}
-
 // utilized as the primary data structure for other functions
 // within this component.
 template<typename P, resource resrc>
@@ -272,10 +21,12 @@ batch<P, resrc>::batch(int const capacity, int const nrows, int const ncols,
   assert(nrows > 0);
   assert(ncols > 0);
   assert(stride > 0);
-  for (P *&ptr : (*this))
+
+  // FIXME
+  /*for (P *&ptr : (*this))
   {
     ptr = nullptr;
-  }
+  }*/
 }
 
 template<typename P, resource resrc>
@@ -407,8 +158,9 @@ void batch<P, resrc>::assign_entry(fk::matrix<P, mem, resrc> const &a,
   assert(position >= 0);
   assert(position < num_entries());
 
+  // FIXME
   // ensure nothing already assigned
-  assert(!batch_[position]);
+  // assert(!batch_[position]);
 
   batch_[position] = a.data();
 }
@@ -564,356 +316,7 @@ void batched_gemv(batch<P, resrc> const &a, batch<P, resrc> const &b,
                              resrc);
 }
 
-// --- batch allocation code --- /
-
-// static helper - compute how many gemms a single call to
-// kronmult_to_batch_sets adds for at a given PDE dimension
-//
-// num_dims is the total number of dimensions for the PDE
-static int
-compute_batch_size(int const degree, int const num_dims, int const dimension)
-{
-  assert(dimension >= 0);
-  assert(dimension < num_dims);
-  assert(num_dims > 0);
-  assert(degree > 0);
-
-  if (dimension == 0 || dimension == num_dims - 1)
-  {
-    return 1;
-  }
-
-  return std::pow(degree, (num_dims - dimension - 1));
-}
-
-// static helper - compute the dimensions (nrows/ncols) for gemm at a given
-// dimension
-static matrix_size_set
-compute_dimensions(int const degree, int const num_dims, int const dimension)
-{
-  assert(dimension >= 0);
-  assert(dimension < num_dims);
-  assert(num_dims > 0);
-  assert(degree > 0);
-
-  if (dimension == 0)
-  {
-    return matrix_size_set(degree, degree, degree,
-                           static_cast<int>(std::pow(degree, num_dims - 1)));
-  }
-  return matrix_size_set(static_cast<int>(std::pow(degree, dimension)), degree,
-                         degree, degree);
-}
-
-// create empty batches w/ correct dims/cardinality for a pde
-template<typename P>
-std::vector<batch_operands_set<P>>
-allocate_batches(PDE<P> const &pde, int const num_elems)
-{
-  std::vector<batch_operands_set<P>> batches(pde.num_dims);
-
-  // FIXME when we allow varying degree by dimension, all
-  // this code will have to change...
-  int const degree = pde.get_dimensions()[0].get_degree();
-
-  // add the first (lowest dimension) batch
-  bool const do_trans         = false;
-  int const num_gemms         = pde.num_terms * num_elems;
-  matrix_size_set const sizes = compute_dimensions(degree, pde.num_dims, 0);
-
-  // get stride of first coefficient matrix in 0th term set.
-  // note all the coefficient matrices for each term have the
-  // same dimensions
-  int const stride = pde.get_coefficients(0, 0).stride();
-  batches[0]       = std::vector<batch<P>>{
-      batch<P>(num_gemms, sizes.rows_a, sizes.cols_a, stride, do_trans),
-      batch<P>(num_gemms, sizes.rows_b, sizes.cols_b, sizes.rows_b, do_trans),
-      batch<P>(num_gemms, sizes.rows_a, sizes.cols_b, sizes.rows_a, false)};
-
-  // remaining batches
-  for (int i = 1; i < pde.num_dims; ++i)
-  {
-    int const num_gemms =
-        compute_batch_size(degree, pde.num_dims, i) * pde.num_terms * num_elems;
-    matrix_size_set const sizes = compute_dimensions(degree, pde.num_dims, i);
-    bool const trans_a          = false;
-    bool const trans_b          = true;
-
-    int const stride = pde.get_coefficients(0, i).stride();
-    batches[i]       = std::vector<batch<P>>{
-        batch<P>(num_gemms, sizes.rows_a, sizes.cols_a, sizes.rows_a, trans_a),
-        batch<P>(num_gemms, sizes.rows_b, sizes.cols_b, stride, trans_b),
-        batch<P>(num_gemms, sizes.rows_a, sizes.rows_b, sizes.rows_a, false)};
-  }
-  return batches;
-}
-
-// resize batches for chunk
-template<typename P>
-inline void ready_batches(PDE<P> const &pde, element_chunk const &chunk,
-                          std::vector<batch_operands_set<P>> &batches)
-{
-  // FIXME when we allow varying degree by dimension, all
-  // this code will have to change...
-  int const degree    = pde.get_dimensions()[0].get_degree();
-  int const num_elems = num_elements_in_chunk(chunk);
-
-  // add the first (lowest dimension) batch
-  int const num_gemms = pde.num_terms * num_elems;
-
-  // FIXME note clearing isn't required; just helps us
-  // check that entries aren't being overwritten by mistake.
-  // could be removed for performance
-  batches[0][0].set_num_entries(num_gemms).clear_all();
-  batches[0][1].set_num_entries(num_gemms).clear_all();
-  batches[0][2].set_num_entries(num_gemms).clear_all();
-
-  // remaining batches
-  for (int i = 1; i < pde.num_dims; ++i)
-  {
-    int const num_gemms =
-        compute_batch_size(degree, pde.num_dims, i) * pde.num_terms * num_elems;
-
-    batches[i][0].set_num_entries(num_gemms).clear_all();
-    batches[i][1].set_num_entries(num_gemms).clear_all();
-    batches[i][2].set_num_entries(num_gemms).clear_all();
-  }
-}
-
-// --- kronmult batching code --- //
-
-// helper for lowest level of kronmult
-// enqueue the gemms to perform A*x
-// for the 0th dimension of the PDE.
-//
-// A is a tensor view into the 0th dimension
-// operator matrix; x is the portion of the vector
-// for this element; y is the output vector.
-//
-// batch offset is the 0-indexed ordinal numbering
-// of the connected element these gemms address
-//
-// note that the view inputs are device tensors;
-// this indicates that they will be resident on the
-// accelerator when the appropriate build options
-// are set.
-template<typename P>
-static void
-kron_base(fk::matrix<P, mem_type::const_view, resource::device> const &A,
-          fk::vector<P, mem_type::const_view, resource::device> const &x,
-          fk::vector<P, mem_type::const_view, resource::device> const &y,
-          batch_operands_set<P> &batches, int const batch_offset,
-          int const degree, int const num_dims)
-{
-  batches[0].assign_entry(A, batch_offset);
-  matrix_size_set const sizes = compute_dimensions(degree, num_dims, 0);
-  fk::matrix<P, mem_type::const_view, resource::device> const x_view(
-      x, sizes.rows_b, sizes.cols_b);
-  batches[1].assign_entry(x_view, batch_offset);
-  fk::matrix<P, mem_type::const_view, resource::device> const y_view(
-      y, sizes.rows_a, sizes.cols_b);
-  batches[2].assign_entry(y_view, batch_offset);
-}
-
-// same function, unsafe version that uses raw pointers for performance
-// view reference counting was identified as a bottleneck in
-// parallel batch building code
-template<typename P>
-inline void kron_base(P *const A, P *const x, P *const y,
-                      batch_operands_set<P> &batches, int const batch_offset)
-{
-  batches[0].assign_raw(A, batch_offset);
-  batches[1].assign_raw(x, batch_offset);
-  batches[2].assign_raw(y, batch_offset);
-}
-
-// function to transform a single kronecker product * vector into a
-// series of batched gemm calls, where the kronecker product is
-// tensor encoded in the view vector A. x is the input vector; y is the output
-// vector. work is a vector of vectors (max size 2), each of which is the same
-// size as y. these store intermediate kron products - lower dimensional outputs
-// are higher dimensional inputs.
-//
-//
-// on entry the batches argument contains empty (pre-allocated) pointer lists
-// that this function will populate to perform the above operation
-//
-// batches is a vector of dimensions+1 batch sets:
-//
-//   dimension-many batch sets of 3 batch lists - a,b,c
-//   to perform the kronmult
-//
-//   1 batch set to perform the reduction of connected element
-//   contributions to each work item.
-//
-// like the other batch building functions, the tensor arguments
-// are resident on the accelerator when the appropriate build option
-// is set
-template<typename P>
-void kronmult_to_batch_sets(
-    std::vector<fk::matrix<P, mem_type::const_view, resource::device>> const &A,
-    fk::vector<P, mem_type::const_view, resource::device> const &x,
-    fk::vector<P, mem_type::const_view, resource::device> const &y,
-    std::vector<fk::vector<P, mem_type::const_view, resource::device>> const
-        &work,
-    std::vector<batch_operands_set<P>> &batches, int const batch_offset,
-    PDE<P> const &pde)
-{
-  // FIXME when we allow varying degree by dimension, all
-  // this code will have to change...
-  int const degree = pde.get_dimensions()[0].get_degree();
-
-  // check vector sizes
-  int const result_size = std::pow(degree, pde.num_dims);
-  assert(x.size() == result_size);
-  assert(y.size() == result_size);
-
-  // check workspace sizes
-  assert(static_cast<int>(work.size()) == std::min(pde.num_dims - 1, 2));
-  for (fk::vector<P, mem_type::const_view, resource::device> const &vector :
-       work)
-  {
-    assert(vector.size() == result_size);
-  }
-
-  // check matrix sizes
-  for (fk::matrix<P, mem_type::const_view, resource::device> const &matrix : A)
-  {
-    assert(matrix.nrows() == degree);
-    assert(matrix.ncols() == degree);
-  }
-
-  // we need an operand set for each dimension on entry
-  assert(static_cast<int>(batches.size()) == pde.num_dims);
-
-  // batch offset describes the ordinal position of the
-  // connected element we are on - should be non-negative
-  assert(batch_offset >= 0);
-
-  // first, enqueue gemms for the lowest dimension
-  if (pde.num_dims == 1)
-  {
-    // in a single dimensional PDE, we have to write lowest-dimension output
-    // directly into the output vector
-    kron_base(A[0], x, y, batches[0], batch_offset, degree, pde.num_dims);
-    return;
-  }
-
-  // otherwise, we write into a work vector to serve as input for next-highest
-  // dimension
-  kron_base(A[0], x, work[0], batches[0], batch_offset, degree, pde.num_dims);
-
-  // loop over intermediate dimensions, enqueueing gemms
-  for (int dimension = 1; dimension < pde.num_dims - 1; ++dimension)
-  {
-    // determine a and b matrix sizes at this dimension for all gemms
-    matrix_size_set const sizes =
-        compute_dimensions(degree, pde.num_dims, dimension);
-    // determine how many gemms we will enqueue for this dimension
-    int const num_gemms = compute_batch_size(degree, pde.num_dims, dimension);
-    int const offset    = sizes.rows_a * sizes.cols_a;
-    assert((offset * num_gemms) ==
-           static_cast<int>(std::pow(degree, pde.num_dims)));
-
-    // loop over gemms for this dimension and enqueue
-    for (int gemm = 0; gemm < num_gemms; ++gemm)
-    {
-      // the modulus here is to alternate input/output workspaces per dimension
-
-      fk::matrix<P, mem_type::const_view, resource::device> const x_view(
-          work[(dimension - 1) % 2], sizes.rows_a, sizes.cols_a, offset * gemm);
-      batches[dimension][0].assign_entry(x_view,
-                                         batch_offset * num_gemms + gemm);
-      batches[dimension][1].assign_entry(A[dimension],
-                                         batch_offset * num_gemms + gemm);
-      fk::matrix<P, mem_type::const_view, resource::device> const work_view(
-          work[dimension % 2], sizes.rows_a, sizes.cols_a, offset * gemm);
-      batches[dimension][2].assign_entry(work_view,
-                                         batch_offset * num_gemms + gemm);
-    }
-  }
-
-  // enqueue gemms for the highest dimension
-  matrix_size_set const sizes =
-      compute_dimensions(degree, pde.num_dims, pde.num_dims - 1);
-
-  fk::matrix<P, mem_type::const_view, resource::device> const x_view(
-      work[pde.num_dims % 2], sizes.rows_a, sizes.cols_a);
-  batches[pde.num_dims - 1][0].assign_entry(x_view, batch_offset);
-  batches[pde.num_dims - 1][1].assign_entry(A[pde.num_dims - 1], batch_offset);
-  fk::matrix<P, mem_type::const_view, resource::device> const y_view(
-      y, sizes.rows_a, sizes.cols_a);
-  batches[pde.num_dims - 1][2].assign_entry(y_view, batch_offset);
-}
-
-// unsafe version; uses raw pointers rather than views
-template<typename P>
-void unsafe_kronmult_to_batch_sets(P *const *const A, P *const x, P *const y,
-                                   P *const *const work,
-                                   std::vector<batch_operands_set<P>> &batches,
-                                   int const batch_offset, PDE<P> const &pde)
-{
-  // FIXME when we allow varying degree by dimension, all
-  // this code will have to change...
-  int const degree = pde.get_dimensions()[0].get_degree();
-
-  // we need an operand set for each dimension on entry
-  assert(static_cast<int>(batches.size()) == pde.num_dims);
-
-  // batch offset describes the ordinal position of the
-  // connected element we are on - should be non-negative
-  assert(batch_offset >= 0);
-
-  // first, enqueue gemms for the lowest dimension
-  if (pde.num_dims == 1)
-  {
-    // in a single dimensional PDE, we have to write lowest-dimension output
-    // directly into the output vector
-    kron_base(A[0], x, y, batches[0], batch_offset);
-    return;
-  }
-
-  // otherwise, we write into a work vector to serve as input for next-highest
-  // dimension
-  kron_base(A[0], x, work[0], batches[0], batch_offset);
-
-  // loop over intermediate dimensions, enqueueing gemms
-  for (int dimension = 1; dimension < pde.num_dims - 1; ++dimension)
-  {
-    // determine a and b matrix sizes at this dimension for all gemms
-    matrix_size_set const sizes =
-        compute_dimensions(degree, pde.num_dims, dimension);
-    // determine how many gemms we will enqueue for this dimension
-    int const num_gemms = compute_batch_size(degree, pde.num_dims, dimension);
-    int const offset    = sizes.rows_a * sizes.cols_a;
-    assert((offset * num_gemms) ==
-           static_cast<int>(std::pow(degree, pde.num_dims)));
-
-    // loop over gemms for this dimension and enqueue
-    for (int gemm = 0; gemm < num_gemms; ++gemm)
-    {
-      // the modulus here is to alternate input/output workspaces per dimension
-
-      P *const x_ptr = work[(dimension - 1) % 2] + offset * gemm;
-      batches[dimension][0].assign_raw(x_ptr, batch_offset * num_gemms + gemm);
-
-      batches[dimension][1].assign_raw(A[dimension],
-                                       batch_offset * num_gemms + gemm);
-
-      P *const work_ptr = work[dimension % 2] + offset * gemm;
-      batches[dimension][2].assign_raw(work_ptr,
-                                       batch_offset * num_gemms + gemm);
-    }
-  }
-
-  // enqueue gemms for the highest dimension
-  P *const x_ptr = work[pde.num_dims % 2];
-  batches[pde.num_dims - 1][0].assign_raw(x_ptr, batch_offset);
-  batches[pde.num_dims - 1][1].assign_raw(A[pde.num_dims - 1], batch_offset);
-  batches[pde.num_dims - 1][2].assign_raw(y, batch_offset);
-}
-
-// helper for calculating 1d indices for elements
+// helpers for calculating 1d indices for elements
 
 // performant (no-alloc) version
 inline void linearize(fk::vector<int> const &coords, int output[])
@@ -936,7 +339,7 @@ inline fk::vector<int> linearize(fk::vector<int> const &coords)
   return linear;
 }
 
-// convert linear coordinates into operator matrix indices
+// helpers for converting linear coordinates into operator matrix indices
 
 // performant (no-alloc) version
 template<typename P>
@@ -963,18 +366,261 @@ linear_coords_to_indices(PDE<P> const &pde, int const degree,
   return indices;
 }
 
-// function to build batch lists.
-// given allocated batches and a  problem instance
-// (pde/elem table) and memory allocations (x, y, work),
-// enqueue the batch gemms/reduction gemv to perform A*x
-template<typename P>
-void build_batches(PDE<P> const &pde, element_table const &elem_table,
-                   device_workspace<P> const &workspace,
-                   element_subgrid const &subgrid, element_chunk const &chunk,
-                   std::vector<batch_operands_set<P>> &batches)
+// FIXME this needs trimming
+/*
+
+Problem relevant to batch_chain class:
+
+given a vector "x" of length "x_size" and list of matrices of arbitrary
+dimension in "matrix": { m0, m1, ... , m_last }, calculate ( m0 kron m1 kron ...
+kron m_end ) * x
+
+*/
+
+/*
+For a list of "n" matrices in "matrix" parameter, the Kron algorithm in this
+file will go through "n" rounds of batched matrix multiplications. The output of
+each round becomes the input of the next round. Two workspaces are thus
+sufficient, if each of them is as large as the largest output from any round.
+This function calculates the largest output of any round.
+
+For a Kronecker product m0 * m1 * m2 * x = m3:
+matrix ~ ( rows, columns )
+m0 ~ (a, b)
+m1 ~ ( c, d )
+m2 ~ ( e, f )
+m3 ~ ( g, h )
+x ~ ( b*d*f*h, 1 )
+m3 ~ ( a*c*e*g, 1 )
+
+Algorithm completes in 3 rounds.
+Initial space needed: size of "x" vector: b*d*f*h
+Round 0 output size: b*d*f*g
+Round 1 output size: b*d*e*g
+Round 2 output size: b*c*e*g
+Round 3 ourput size: a*c*e*g
+
+Max space needed is maximum of the above sizes.
+
+Improvement idea: Each stage alternates between 2 workspaces,
+so the first workspace needs to be the maximum of round 0 and 2, while the other
+needs to be the max of round 1 and 3. As it stands now, each workspace is the
+size of the max of all rounds.
+*/
+
+/* batch chain delineates the dataflow for the algorithm that implements the
+   particular problem described in the comment at the top of the file. The
+   algorithm proceeds in stages, with a stage for each matrix in the list. The
+   input for each stage is the output of the previous. The initial input is the
+   vector "x". The output of each stage is a vector. The output of the final
+   stage is the solution to the problem. */
+
+template<typename P, resource resrc, chain_method method>
+template<chain_method, typename>
+batch_chain<P, resrc, method>::batch_chain(
+    std::vector<fk::matrix<P, mem_type::const_view, resrc>> const &matrices,
+    fk::vector<P, mem_type::const_view, resrc> const &x,
+    std::array<fk::vector<P, mem_type::view, resrc>, 2> &workspace,
+    fk::vector<P, mem_type::view, resrc> &final_output)
 {
-  // assume uniform degree for now
-  int const degree    = pde.get_dimensions()[0].get_degree();
+  /* validation */
+  assert(matrices.size() > 0);
+  assert(workspace.size() == 2);
+
+  /* ensure "x" is correct size - should be the product of all the matrices
+     respective number of columns */
+  assert(x.size() == std::accumulate(matrices.begin(), matrices.end(), 1,
+                                     [](int const i, auto const &m) {
+                                       return i * m.ncols();
+                                     }));
+
+  /* these are used to index "workspace" - the input/output role alternates
+     between workspace[ 0 ] and workspace[ 1 ] in this algorithm */
+  int in  = 0;
+  int out = 1;
+
+  /* ensure the workspaces are big enough for the problem */
+  int const workspace_len = calculate_workspace_length(matrices, x.size());
+  assert(workspace[0].size() >= workspace_len);
+  assert(workspace[1].size() >= workspace_len);
+
+  /*
+    The algorithm iterates over each matrix in "matrix" in reverse order,
+    creates a batch_set object for each matrix, and assigns input and output for
+    each multiplication in that batch_set. The first and last iterations are
+    handled differently than the others, so the loop is unrolled accordingly.
+  */
+  {
+    /* only one large matrix multiply is needed for this first iteration. We
+       want to break up "x" into consecutive subvectors of length iter->ncols().
+       Each of these subvectors will be transformed into a vector of length
+       iter->nrows() by multiplying it by the last matrix in the list. These
+       results are concatenated to produce the output of the first stage. The
+       easiest way to implement the above process is with a large matrix
+       multiply: */
+
+    /* define the sizes of the operands */
+    int const rows = x.size() / matrices.back().ncols();
+
+    left_.emplace_back(1, matrices.back().nrows(), matrices.back().ncols(),
+                       matrices.back().stride(), false);
+    right_.emplace_back(1, matrices.back().ncols(), rows,
+                        matrices.back().ncols(), false);
+    product_.emplace_back(1, matrices.back().nrows(), rows,
+                          matrices.back().nrows(), false);
+
+    /* assign the data to the batches */
+    fk::matrix<P, mem_type::const_view, resrc> input(x, matrices.back().ncols(),
+                                                     rows, 0);
+
+    /* If there is only 1 iteration, write immediately to final_output */
+    fk::vector<P, mem_type::view, resrc> destination(workspace[out]);
+    fk::matrix<P, mem_type::view, resrc> output(
+        (matrices.size() > 1 ? destination : final_output),
+        matrices.back().nrows(), rows, 0);
+
+    right_.back().assign_entry(input, 0);
+    left_.back().assign_entry(matrices.back(), 0);
+    product_.back().assign_entry(output, 0);
+
+    /* output and input space will switch roles for the next iteration */
+    std::swap(in, out);
+  }
+
+  /* The remaining iterations are a general case of the first one */
+
+  /* distance in between first element of output subvectors above */
+  int stride = matrices.back().nrows();
+  /* initial value for the size of the input vector for the stage to follow:
+     each iter->ncols()
+     length consecutive subvector was previously replaced by one of length
+     iter->nrows() */
+  int v_size = x.size() / matrices.back().ncols() * matrices.back().nrows();
+
+  /* second to last iteration must be unrolled */
+  for (int i = matrices.size() - 2; i > 0; --i)
+  {
+    /* total number of input matrices encoded in linear input memory */
+    int const n_gemms = v_size / stride / matrices[i].ncols();
+
+    /*
+      left operand's data comes from a linear input array. The transposes ensure
+      that the input can be interpreted in column major format and that the
+      output will be implicitly stored that way.
+    */
+    left_.emplace_back(n_gemms, stride, matrices[i].ncols(), stride, false);
+    right_.emplace_back(n_gemms, matrices[i].nrows(), matrices[i].ncols(),
+                        matrices[i].stride(), true);
+    product_.emplace_back(n_gemms, stride, matrices[i].nrows(), stride, false);
+
+    /* assign actual data to the batches */
+    for (int j = 0; j < n_gemms; ++j)
+    {
+      fk::matrix<P, mem_type::view, resrc> input(
+          workspace[in], stride, matrices[i].ncols(),
+          j * stride * matrices[i].ncols());
+
+      fk::matrix<P, mem_type::view, resrc> output(
+          workspace[out], stride, matrices[i].nrows(),
+          j * stride * matrices[i].nrows());
+
+      left_.back().assign_entry(input, j);
+      right_.back().assign_entry(matrices[i], j);
+      product_.back().assign_entry(output, j);
+    }
+
+    /* output and input space will switch roles for the next iteration */
+    std::swap(in, out);
+
+    /* update variables for next iteration */
+    v_size = n_gemms * stride * matrices[i].nrows();
+    stride *= matrices[i].nrows();
+  }
+
+  /* final loop iteration - output goes into output space instead of workspace
+   */
+  if (matrices.size() > 1)
+  {
+    int const n_gemms = v_size / stride / matrices.front().ncols();
+
+    left_.emplace_back(n_gemms, stride, matrices.front().ncols(), stride,
+                       false);
+    right_.emplace_back(n_gemms, matrices.front().nrows(),
+                        matrices.front().ncols(), matrices.front().stride(),
+                        true);
+    product_.emplace_back(n_gemms, stride, matrices.front().nrows(), stride,
+                          false);
+
+    for (int j = 0; j < n_gemms; ++j)
+    {
+      fk::matrix<P, mem_type::view, resrc> input(
+          workspace[in], stride, matrices.front().ncols(),
+          j * stride * matrices.front().ncols());
+
+      fk::matrix<P, mem_type::view, resrc> output(
+          final_output, stride, matrices.front().nrows(),
+          j * stride * matrices.front().nrows());
+
+      left_.back().assign_entry(input, j);
+      right_.back().assign_entry(matrices.front(), j);
+      product_.back().assign_entry(output, j);
+    }
+  }
+}
+
+template<typename P, resource resrc, chain_method method>
+template<chain_method, typename>
+batch_chain<P, resrc, method>::batch_chain(PDE<P> const &pde,
+                                           element_table const &elem_table,
+                                           device_workspace<P> const &workspace,
+                                           element_subgrid const &subgrid,
+                                           element_chunk const &chunk)
+{
+  // 1 -- allocate batches
+
+  int const num_elems = num_elements_in_chunk(chunk);
+
+  // FIXME code relies on uniform degree across dimensions
+  int const degree = pde.get_dimensions()[0].get_degree();
+
+  // add the first (lowest dimension) batch
+  bool const do_trans         = false;
+  int const num_gemms         = pde.num_terms * num_elems;
+  matrix_size_set const sizes = compute_dimensions(degree, pde.num_dims, 0);
+
+  // get stride of first coefficient matrix in 0th term set.
+  // note all the coefficient matrices for each term have the
+  // same dimensions
+  int const stride = pde.get_coefficients(0, 0).stride();
+
+  left_.emplace_back(std::move(
+      batch<P>(num_gemms, sizes.rows_a, sizes.cols_a, stride, do_trans)));
+  right_.emplace_back(std::move(
+      batch<P>(num_gemms, sizes.rows_b, sizes.cols_b, sizes.rows_b, do_trans)));
+  product_.emplace_back(std::move(
+      batch<P>(num_gemms, sizes.rows_a, sizes.cols_b, sizes.rows_a, false)));
+
+  // remaining batches
+  for (int i = 1; i < pde.num_dims; ++i)
+  {
+    int const num_gemms =
+        compute_batch_size(degree, pde.num_dims, i) * pde.num_terms * num_elems;
+    matrix_size_set const sizes = compute_dimensions(degree, pde.num_dims, i);
+    bool const trans_a          = false;
+    bool const trans_b          = true;
+
+    int const stride = pde.get_coefficients(0, i).stride();
+
+    left_.emplace_back(std::move(batch<P>(num_gemms, sizes.rows_a, sizes.cols_a,
+                                          sizes.rows_a, trans_a)));
+    right_.emplace_back(std::move(
+        batch<P>(num_gemms, sizes.rows_b, sizes.cols_b, stride, trans_b)));
+    product_.emplace_back(std::move(
+        batch<P>(num_gemms, sizes.rows_a, sizes.rows_b, sizes.rows_a, false)));
+  }
+
+  // 2 -- populate
+
   int const elem_size = static_cast<int>(std::pow(degree, pde.num_dims));
 
   auto const x_size = (subgrid.col_stop - subgrid.col_start + 1) *
@@ -995,8 +641,6 @@ void build_batches(PDE<P> const &pde, element_table const &elem_table,
   int const max_connected       = max_connected_in_chunk(chunk);
   int const max_items_to_reduce = pde.num_terms * max_connected;
   assert(workspace.get_unit_vector().size() >= max_items_to_reduce);
-
-  ready_batches(pde, chunk, batches);
 
   // here we map integers 0->chunk_size-1 to row_0->row_last in the chunk
   // we could iterate over the chunk (which is a map rows->connected)
@@ -1111,15 +755,111 @@ void build_batches(PDE<P> const &pde, element_table const &elem_table,
         // x vector input to kronmult
         P *const x_ptr = workspace.batch_input.data() + x_index;
 
-        unsafe_kronmult_to_batch_sets(operator_ptrs, x_ptr, y_ptr,
-                                      workspace_ptrs, batches, kron_index, pde);
+        kronmult_to_batch_sets(operator_ptrs, x_ptr, y_ptr, workspace_ptrs,
+                               kron_index, pde);
       }
     }
   }
 }
 
+template<typename P, resource resrc, chain_method method>
+void batch_chain<P, resrc, method>::execute() const
+{
+  assert(left_.size() == right_.size());
+  assert(right_.size() == product_.size());
+
+  for (int i = 0; i < static_cast<int>(left_.size()); ++i)
+  {
+    batched_gemm(left_[i], right_[i], product_[i], (P)1, (P)0);
+  }
+
+  return;
+}
+
+// function to transform a single kronecker product * vector into a
+// series of batched gemm calls, where the kronecker product is
+// tensor encoded in the view vector A. x is the input vector; y is the output
+// vector. work is a vector of vectors (max size 2), each of which is the same
+// size as y. these store intermediate kron products - lower dimensional outputs
+// are higher dimensional inputs.
+//
+//
+// on entry the batches argument contains empty (pre-allocated) pointer lists
+// that this function will populate to perform the above operation
+
+// unsafe version; uses raw pointers rather than views as view construction
+// destruction incurred significant runtime expense (alloc sync in parallel
+// loop)
+
+template<typename P, resource resrc, chain_method method>
+template<chain_method, typename>
+void batch_chain<P, resrc, method>::kronmult_to_batch_sets(
+    P *const *const A, P *const x, P *const y, P *const *const work,
+    int const batch_offset, PDE<P> const &pde)
+{
+  // FIXME when we allow varying degree by dimension, all
+  // this code will have to change...
+  int const degree = pde.get_dimensions()[0].get_degree();
+
+  // batch offset describes the ordinal position of the
+  // connected element we are on - should be non-negative
+  assert(batch_offset >= 0);
+
+  // first, enqueue gemms for the lowest dimension
+  left_[0].assign_raw(A[0], batch_offset);
+  right_[0].assign_raw(x, batch_offset);
+
+  // in a single dimensional PDE, we have to write lowest-dimension output
+  // directly into the output vector
+  if (pde.num_dims == 1)
+  {
+    product_[0].assign_raw(y, batch_offset);
+    return;
+  }
+
+  // otherwise, we write into a work vector to serve as input for next-highest
+  // dimension
+  product_[0].assign_raw(work[0], batch_offset);
+
+  // loop over intermediate dimensions, enqueueing gemms
+  for (int dimension = 1; dimension < pde.num_dims - 1; ++dimension)
+  {
+    // determine a and b matrix sizes at this dimension for all gemms
+    matrix_size_set const sizes =
+        compute_dimensions(degree, pde.num_dims, dimension);
+    // determine how many gemms we will enqueue for this dimension
+    int const num_gemms = compute_batch_size(degree, pde.num_dims, dimension);
+    int const offset    = sizes.rows_a * sizes.cols_a;
+    assert((offset * num_gemms) ==
+           static_cast<int>(std::pow(degree, pde.num_dims)));
+
+    // loop over gemms for this dimension and enqueue
+    for (int gemm = 0; gemm < num_gemms; ++gemm)
+    {
+      // the modulus here is to alternate input/output workspaces per dimension
+
+      P *const x_ptr = work[(dimension - 1) % 2] + offset * gemm;
+      left_[dimension].assign_raw(x_ptr, batch_offset * num_gemms + gemm);
+
+      right_[dimension].assign_raw(A[dimension],
+                                   batch_offset * num_gemms + gemm);
+
+      P *const work_ptr = work[dimension % 2] + offset * gemm;
+      right_[dimension].assign_raw(work_ptr, batch_offset * num_gemms + gemm);
+    }
+  }
+
+  // enqueue gemms for the highest dimension
+  P *const x_ptr = work[pde.num_dims % 2];
+  left_[pde.num_dims - 1].assign_raw(x_ptr, batch_offset);
+  right_[pde.num_dims - 1].assign_raw(A[pde.num_dims - 1], batch_offset);
+  product_[pde.num_dims - 1].assign_raw(y, batch_offset);
+}
+
 // function to allocate and build implicit system.
 // given a problem instance (pde/elem table)
+// does not utilize batching, here because it shares underlying structure and
+// routines with explicit time advance
 template<typename P>
 void build_system_matrix(PDE<P> const &pde, element_table const &elem_table,
                          element_chunk const &chunk, fk::matrix<P> &A)
@@ -1249,54 +989,6 @@ template void batched_gemv(batch<double, resource::host> const &a,
                            batch<double, resource::host> const &c,
                            double const alpha, double const beta);
 
-template std::vector<batch_operands_set<float>>
-allocate_batches(PDE<float> const &pde, int const num_elems);
-template std::vector<batch_operands_set<double>>
-allocate_batches(PDE<double> const &pde, int const num_elems);
-
-template void kronmult_to_batch_sets(
-    std::vector<fk::matrix<float, mem_type::const_view, resource::device>> const
-        &A,
-    fk::vector<float, mem_type::const_view, resource::device> const &x,
-    fk::vector<float, mem_type::const_view, resource::device> const &y,
-    std::vector<fk::vector<float, mem_type::const_view, resource::device>> const
-        &work,
-    std::vector<batch_operands_set<float>> &batches, int const batch_offset,
-    PDE<float> const &pde);
-
-template void kronmult_to_batch_sets(
-    std::vector<
-        fk::matrix<double, mem_type::const_view, resource::device>> const &A,
-    fk::vector<double, mem_type::const_view, resource::device> const &x,
-    fk::vector<double, mem_type::const_view, resource::device> const &y,
-    std::vector<
-        fk::vector<double, mem_type::const_view, resource::device>> const &work,
-    std::vector<batch_operands_set<double>> &batches, int const batch_offset,
-    PDE<double> const &pde);
-
-template void
-unsafe_kronmult_to_batch_sets(float *const *const A, float *const x,
-                              float *const y, float *const *const work,
-                              std::vector<batch_operands_set<float>> &batches,
-                              int const batch_offset, PDE<float> const &pde);
-
-template void
-unsafe_kronmult_to_batch_sets(double *const *const A, double *const x,
-                              double *const y, double *const *const work,
-                              std::vector<batch_operands_set<double>> &batches,
-                              int const batch_offset, PDE<double> const &pde);
-
-template void
-build_batches(PDE<float> const &pde, element_table const &elem_table,
-              device_workspace<float> const &workspace,
-              element_subgrid const &subgrid, element_chunk const &chunk,
-              std::vector<batch_operands_set<float>> &);
-template void
-build_batches(PDE<double> const &pde, element_table const &elem_table,
-              device_workspace<double> const &workspace,
-              element_subgrid const &subgrid, element_chunk const &chunk,
-              std::vector<batch_operands_set<double>> &);
-
 template void
 build_system_matrix(PDE<double> const &pde, element_table const &elem_table,
                     element_chunk const &chunk, fk::matrix<double> &A);
@@ -1304,35 +996,13 @@ template void
 build_system_matrix(PDE<float> const &pde, element_table const &elem_table,
                     element_chunk const &chunk, fk::matrix<float> &A);
 
-template int calculate_workspace_length<double, resource::device>(
-    std::vector<fk::matrix<double, mem_type::const_view,
-                           resource::device>> const &matrices,
-    int const x_size);
-
-template int calculate_workspace_length<double, resource::host>(
-    std::vector<fk::matrix<double, mem_type::const_view, resource::host>> const
-        &matrices,
-    int const x_size);
-
-template int calculate_workspace_length<float, resource::device>(
-    std::vector<fk::matrix<float, mem_type::const_view, resource::device>> const
-        &matrices,
-    int const x_size);
-
-template int calculate_workspace_length<float, resource::host>(
-    std::vector<fk::matrix<float, mem_type::const_view, resource::host>> const
-        &matrices,
-    int const x_size);
-
 template class batch_chain<double, resource::device, chain_method::realspace>;
 template class batch_chain<double, resource::host, chain_method::realspace>;
 template class batch_chain<float, resource::device, chain_method::realspace>;
 template class batch_chain<float, resource::host, chain_method::realspace>;
 
 template class batch_chain<double, resource::device, chain_method::advance>;
-template class batch_chain<double, resource::host, chain_method::advance>;
 template class batch_chain<float, resource::device, chain_method::advance>;
-template class batch_chain<float, resource::host, chain_method::advance>;
 
 template batch_chain<float, resource::host, chain_method::realspace>::
     batch_chain(
@@ -1380,12 +1050,12 @@ template batch_chain<double, resource::device, chain_method::advance>::
                 device_workspace<double> const &workspace,
                 element_subgrid const &subgrid, element_chunk const &chunk);
 
-template batch_chain<float, resource::host, chain_method::advance>::batch_chain(
-    PDE<float> const &pde, element_table const &elem_table,
-    host_workspace<float> const &workspace, element_subgrid const &subgrid,
-    element_chunk const &chunk);
+template void batch_chain<float, resource::device, chain_method::advance>::
+    kronmult_to_batch_sets(float *const *const A, float *const x,
+                           float *const y, float *const *const work,
+                           int const batch_offset, PDE<float> const &pde);
 
-template batch_chain<double, resource::host, chain_method::advance>::
-    batch_chain(PDE<double> const &pde, element_table const &elem_table,
-                host_workspace<double> const &workspace,
-                element_subgrid const &subgrid, element_chunk const &chunk);
+template void batch_chain<double, resource::device, chain_method::advance>::
+    kronmult_to_batch_sets(double *const *const A, double *const x,
+                           double *const y, double *const *const work,
+                           int const batch_offset, PDE<double> const &pde);

--- a/src/batch.hpp
+++ b/src/batch.hpp
@@ -99,6 +99,31 @@ struct matrix_size_set
       : rows_a(rows_a), cols_a(cols_a), rows_b(rows_b), cols_b(cols_b){};
 };
 
+
+// inline helper to calc workspace size for realspace batching, where dimensions of matrices
+// not uniform
+template<typename P, resource resrc>
+inline int calculate_workspace_length(
+      std::vector<fk::matrix<P, mem_type::const_view, resrc>> const &matrices,
+      int const x_size)
+  {
+    int greatest = x_size;
+    int r_prod   = 1;
+    int c_prod   = 1;
+    typename std::vector<fk::matrix<P, mem_type::const_view,
+                                    resrc>>::const_reverse_iterator iter;
+    for (iter = matrices.rbegin(); iter != matrices.rend(); ++iter)
+    {
+      c_prod *= iter->ncols();
+      assert(c_prod > 0);
+      r_prod *= iter->nrows();
+      int const size = x_size / c_prod * r_prod;
+      greatest = std::max(greatest, size);
+    }
+    return greatest;
+  }
+
+
 // which of the kronecker-product based algorithms the batch chain supports
 enum class chain_method
 {
@@ -172,35 +197,6 @@ private:
     }
 
     return std::pow(degree, (num_dims - dimension - 1));
-  }
-
-  // calc workspace size for realspace batching, where dimensions of matrices
-  // not uniform
-  template<chain_method m_ = method, typename = enable_for_realspace<m_>>
-  int calculate_workspace_length(
-      std::vector<fk::matrix<P, mem_type::const_view, resrc>> const &matrices,
-      int const x_size)
-  {
-    int greatest = x_size;
-    int r_prod   = 1;
-    int c_prod   = 1;
-
-    typename std::vector<fk::matrix<P, mem_type::const_view,
-                                    resrc>>::const_reverse_iterator iter;
-
-    for (iter = matrices.rbegin(); iter != matrices.rend(); ++iter)
-    {
-      c_prod *= iter->ncols();
-      assert(c_prod > 0);
-
-      r_prod *= iter->nrows();
-
-      int const size = x_size / c_prod * r_prod;
-      if (size > greatest)
-        greatest = size;
-    }
-
-    return greatest;
   }
 
   template<chain_method m_ = method, typename = enable_for_advance<m_>>

--- a/src/batch.hpp
+++ b/src/batch.hpp
@@ -99,30 +99,28 @@ struct matrix_size_set
       : rows_a(rows_a), cols_a(cols_a), rows_b(rows_b), cols_b(cols_b){};
 };
 
-
-// inline helper to calc workspace size for realspace batching, where dimensions of matrices
-// not uniform
+// inline helper to calc workspace size for realspace batching, where dimensions
+// of matrices not uniform
 template<typename P, resource resrc>
 inline int calculate_workspace_length(
-      std::vector<fk::matrix<P, mem_type::const_view, resrc>> const &matrices,
-      int const x_size)
+    std::vector<fk::matrix<P, mem_type::const_view, resrc>> const &matrices,
+    int const x_size)
+{
+  int greatest = x_size;
+  int r_prod   = 1;
+  int c_prod   = 1;
+  typename std::vector<
+      fk::matrix<P, mem_type::const_view, resrc>>::const_reverse_iterator iter;
+  for (iter = matrices.rbegin(); iter != matrices.rend(); ++iter)
   {
-    int greatest = x_size;
-    int r_prod   = 1;
-    int c_prod   = 1;
-    typename std::vector<fk::matrix<P, mem_type::const_view,
-                                    resrc>>::const_reverse_iterator iter;
-    for (iter = matrices.rbegin(); iter != matrices.rend(); ++iter)
-    {
-      c_prod *= iter->ncols();
-      assert(c_prod > 0);
-      r_prod *= iter->nrows();
-      int const size = x_size / c_prod * r_prod;
-      greatest = std::max(greatest, size);
-    }
-    return greatest;
+    c_prod *= iter->ncols();
+    assert(c_prod > 0);
+    r_prod *= iter->nrows();
+    int const size = x_size / c_prod * r_prod;
+    greatest       = std::max(greatest, size);
   }
-
+  return greatest;
+}
 
 // which of the kronecker-product based algorithms the batch chain supports
 enum class chain_method

--- a/src/batch_tests.cpp
+++ b/src/batch_tests.cpp
@@ -7,7 +7,6 @@
 #include <numeric>
 #include <random>
 
-
 // FIXME
 template<typename P, resource resrc>
 void test_kron(

--- a/src/batch_tests.cpp
+++ b/src/batch_tests.cpp
@@ -970,7 +970,6 @@ void batch_builder_test(int const degree, int const level, PDE<P> &pde,
   }
   x.transfer_from(batch_space.output);
 
-
   P const tol_factor = std::is_same<P, double>::value ? 1e-13 : 1e-5;
   rmse_comparison(gold, x, tol_factor);
 }

--- a/src/batch_tests.cpp
+++ b/src/batch_tests.cpp
@@ -7,7 +7,7 @@
 #include <numeric>
 #include <random>
 
-// FIXME
+// FIXME name etc.
 template<typename P, resource resrc>
 void test_kron(
     std::vector<fk::matrix<P, mem_type::const_view, resrc>> const &matrices,
@@ -27,8 +27,8 @@ void test_kron(
   fk::vector<P, mem_type::owner, resrc> real_space_owner(correct.size());
   fk::vector<P, mem_type::view, resrc> real_space(real_space_owner);
 
-  batch_chain<P, resrc> auto chain(matrices, x_view, workspace, real_space);
-  chain.execute_batch_chain();
+  batch_chain<P, resrc> chain(matrices, x_view, workspace, real_space);
+  chain.execute();
 
   if constexpr (resrc == resource::device)
   {
@@ -221,8 +221,8 @@ TEMPLATE_TEST_CASE("kron", "[kron]", double, float)
            fk::matrix<TestType, mem_type::const_view, resource::host> const
                &m) { return i * m.nrows(); });
 
-    /* because the kron matrices consist of all 2s except for the last one,
-       every value of the output matrix will be the equal: */
+    // because the kron matrices consist of all 2s except for the last one,
+    //   every value of the output matrix will be the equal:
     fk::vector<TestType> const correct(std::vector<TestType>(
         y_size, x_size * (1 << (matrices.size() - 1)) * 3));
 
@@ -919,206 +919,6 @@ TEMPLATE_TEST_CASE_SIG("batched gemv", "[batch]",
 }
 
 template<typename P>
-void test_kronmult_batching(PDE<P> const &pde, int const num_terms,
-                            int const num_elems)
-{
-  // FIXME assume uniform level and degree
-  auto const dim_0 = pde.get_dimensions()[0];
-  int const degree = dim_0.get_degree();
-  int const level  = dim_0.get_level();
-
-  // first, create example coefficient matrices in the pde
-  int const dof = degree * std::pow(2, level);
-  std::vector<fk::matrix<P>> A_mats_h(num_terms * pde.num_dims,
-                                      fk::matrix<P>(dof, dof));
-
-  // create different matrices for each term/dim pairing
-  int start = 1;
-
-  std::vector<fk::matrix<P, mem_type::owner, resource::device>> A_mats;
-  for (fk::matrix<P> &mat : A_mats_h)
-  {
-    std::iota(mat.begin(), mat.end(), start);
-    start += dof;
-    A_mats.push_back(fk::matrix<P, mem_type::owner, resource::device>(
-        mat.clone_onto_device()));
-  }
-
-  // create input vector
-  int const x_size = static_cast<int>(std::pow(degree, pde.num_dims));
-  fk::vector<P> x_h(x_size);
-  std::iota(x_h.begin(), x_h.end(), 1);
-  fk::vector<P, mem_type::owner, resource::device> const x(
-      x_h.clone_onto_device());
-
-  std::vector<batch_operands_set<P>> batches = allocate_batches(pde, num_elems);
-
-  // create intermediate workspaces
-  // and output vectors
-
-  int const num_workspaces = std::min(pde.num_dims - 1, 2);
-  fk::vector<P, mem_type::owner, resource::device> work_own(
-      x_size * num_elems * num_terms * num_workspaces);
-  fk::vector<P, mem_type::const_view, resource::device> const x_view(x);
-  fk::vector<P, mem_type::owner, resource::device> y_own(x_size * num_elems *
-                                                         num_terms);
-
-  fk::vector<P, mem_type::owner> gold(x_size * num_elems * num_terms);
-
-  for (int i = 0; i < num_elems; ++i)
-  {
-    for (int j = 0; j < pde.num_terms; ++j)
-    {
-      // linearize index
-      int const kron_index = i * num_terms + j;
-
-      // address y space
-      int const y_index = x_size * kron_index;
-      int const work_index =
-          x_size * kron_index * std::min(pde.num_dims - 1, 2);
-      fk::vector<P, mem_type::const_view, resource::device> const y_view(
-          y_own, y_index, y_index + x_size - 1);
-      fk::vector<P, mem_type::view> gold_view(gold, y_index,
-                                              y_index + x_size - 1);
-
-      // intermediate workspace
-      std::vector<fk::vector<P, mem_type::const_view, resource::device>> const
-          work_views = [&work_own, work_index, x_size, num_workspaces]() {
-            std::vector<fk::vector<P, mem_type::const_view, resource::device>>
-                builder;
-            builder.reserve(num_workspaces);
-            if (num_workspaces > 0)
-            {
-              builder.emplace_back(
-                  fk::vector<P, mem_type::const_view, resource::device>(
-                      work_own, work_index, work_index + x_size - 1));
-            }
-
-            if (num_workspaces == 2)
-            {
-              builder.emplace_back(
-                  fk::vector<P, mem_type::const_view, resource::device>(
-                      work_own, work_index + x_size,
-                      work_index + x_size * 2 - 1));
-            }
-            return builder;
-          }();
-
-      // create A_views
-      std::vector<fk::matrix<P, mem_type::const_view, resource::device>>
-          A_views;
-      std::vector<fk::matrix<P, mem_type::const_view>> A_views_h;
-      for (int k = 0; k < pde.num_dims; ++k)
-      {
-        int const start_row = degree * i;
-        int const stop_row  = degree * (i + 1) - 1;
-        int const start_col = 0;
-        int const stop_col  = degree - 1;
-        A_views.push_back(fk::matrix<P, mem_type::const_view, resource::device>(
-            A_mats[j * pde.num_dims + k], start_row, stop_row, start_col,
-            stop_col));
-        A_views_h.push_back(fk::matrix<P, mem_type::const_view>(
-            A_mats_h[j * pde.num_dims + k], start_row, stop_row, start_col,
-            stop_col));
-      }
-
-      int const batch_offset = kron_index;
-      if (safe_version)
-      {
-        kronmult_to_batch_sets(A_views, x_view, y_view, work_views, batches,
-                               batch_offset, pde);
-      }
-      else
-      {
-        unsafe_kronmult(A_views, x_view, y_view, work_views, batches,
-                        batch_offset, pde);
-      }
-
-      fk::matrix<P> gold_mat = {{1}};
-      for (int i = A_views_h.size() - 1; i >= 0; --i)
-      {
-        fk::matrix<P> const partial_result = gold_mat.kron(A_views_h[i]);
-        gold_mat.clear_and_resize(partial_result.nrows(),
-                                  partial_result.ncols()) = partial_result;
-      }
-      gold_view = gold_mat * x_h;
-    }
-  }
-
-  for (int k = 0; k < pde.num_dims; ++k)
-  {
-    batch<P> const a = batches[k][0];
-    batch<P> const b = batches[k][1];
-    batch<P> const c = batches[k][2];
-    P const alpha    = 1.0;
-    P const beta     = 0.0;
-    batched_gemm(a, b, c, alpha, beta);
-  }
-
-  fk::vector<P> const y_h(y_own.clone_onto_host());
-
-  P const tol_factor = std::is_same<P, double>::value ? 1e-15 : 1e-6;
-
-  rmse_comparison(y_h, gold, tol_factor);
-}
-
-TEMPLATE_TEST_CASE_SIG("kronmult batching", "[batch]",
-                       ((typename TestType, bool do_safe), TestType, do_safe),
-                       (double, true), (double, false), (float, true),
-                       (float, false))
-{
-  SECTION("1 element, 1d, 1 term")
-  {
-    int const degree = 4;
-    int const level  = 2;
-    auto const pde = make_PDE<TestType>(PDE_opts::continuity_1, level, degree);
-    int const num_terms = 1;
-    int const num_elems = 1;
-    test_kronmult_batching(*pde, num_terms, num_elems, do_safe);
-  }
-
-  SECTION("2 elements, 1d, 1 term")
-  {
-    int const degree = 4;
-    int const level  = 2;
-    auto const pde = make_PDE<TestType>(PDE_opts::continuity_1, level, degree);
-    int const num_terms = 1;
-    int const num_elems = 2;
-    test_kronmult_batching(*pde, num_terms, num_elems, do_safe);
-  }
-
-  SECTION("2 elements, 2d, 2 terms")
-  {
-    int const degree = 2;
-    int const level  = 2;
-    auto const pde = make_PDE<TestType>(PDE_opts::continuity_2, level, degree);
-    int const num_terms = 2;
-    int const num_elems = 2;
-    test_kronmult_batching(*pde, num_terms, num_elems, do_safe);
-  }
-
-  SECTION("1 element, 3d, 3 terms")
-  {
-    int const degree = 5;
-    int const level  = 2;
-    auto const pde = make_PDE<TestType>(PDE_opts::continuity_3, level, degree);
-    int const num_terms = 3;
-    int const num_elems = 1;
-    test_kronmult_batching(*pde, num_terms, num_elems, do_safe);
-  }
-
-  SECTION("3 elements, 6d, 6 terms")
-  {
-    int const degree = 2;
-    int const level  = 2;
-    auto const pde = make_PDE<TestType>(PDE_opts::continuity_6, level, degree);
-    int const num_terms = 6;
-    int const num_elems = 3;
-    test_kronmult_batching(*pde, num_terms, num_elems, do_safe);
-  }
-}
-
-template<typename P>
 void batch_builder_test(int const degree, int const level, PDE<P> &pde,
                         std::string const &gold_path = {},
                         bool const full_grid         = false)
@@ -1151,35 +951,24 @@ void batch_builder_test(int const degree, int const level, PDE<P> &pde,
   }();
 
   auto const chunks = assign_elements(subgrid, get_num_chunks(subgrid, pde));
-  device_workspace<P> dev_space(pde, subgrid, chunks);
-
-  auto const num_elems = elem_table.size() * elem_table.size();
-  auto batches         = allocate_batches(pde, num_elems);
+  batch_workspace<P, resource::device> batch_space(pde, subgrid, chunks);
 
   // copy in inputs
-
-  dev_space.batch_input.transfer_from(host_space.x);
+  batch_space.input.transfer_from(host_space.x);
   for (auto const &chunk : chunks)
   {
-    // build batches for this chunk
-    build_batches(pde, elem_table, dev_space, subgrid, chunk, batches);
+    // build batches
+    batch_chain<P, resource::device, chain_method::advance> const batches(
+        pde, elem_table, batch_space, subgrid, chunk);
 
-    // do the gemms
-    P const alpha = 1.0;
-    P const beta  = 0.0;
-    for (int i = 0; i < pde.num_dims; ++i)
-    {
-      batch<P> const &a = batches[i][0];
-      batch<P> const &b = batches[i][1];
-      batch<P> const &c = batches[i][2];
-
-      batched_gemm(a, b, c, alpha, beta);
-    }
+    // execute
+    batches.execute();
 
     // do the reduction
-    reduce_chunk(pde, dev_space, subgrid, chunk);
+    reduce_chunk(pde, batch_space.reduction_space, batch_space.output,
+                 batch_space.get_unit_vector(), subgrid, chunk);
   }
-  host_space.fx.transfer_from(dev_space.batch_output);
+  host_space.fx.transfer_from(batch_space.output);
 
   P const tol_factor = std::is_same<P, double>::value ? 1e-13 : 1e-5;
 

--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -47,32 +47,6 @@ grid_limits rows_in_chunk(element_chunk const &g)
   return grid_limits(g.begin()->first, g.rbegin()->first);
 }
 
-template<typename P>
-host_workspace<P>::host_workspace(PDE<P> const &pde,
-                                  element_subgrid const &grid,
-                                  int const memory_limit_MB)
-{
-  assert(memory_limit_MB > 0);
-  int const elem_size    = element_segment_size(pde);
-  int64_t const col_size = elem_size * static_cast<int64_t>(grid.ncols());
-  int64_t const row_size = elem_size * static_cast<int64_t>(grid.nrows());
-  assert(col_size < INT_MAX);
-  assert(row_size < INT_MAX);
-  x_orig.resize(col_size);
-  x.resize(col_size);
-  fx.resize(row_size);
-  reduced_fx.resize(row_size);
-  scaled_source.resize(row_size);
-  result_1.resize(col_size);
-  result_2.resize(col_size);
-  result_3.resize(col_size);
-
-  /* we eventually need to make these checks consistent across realspace
-     transform and time advance */
-  /* size_MB() calculation relies on above members already being initialized */
-  assert(size_MB() <= static_cast<double>(memory_limit_MB));
-}
-
 // calculate how much workspace we need on device to compute a single connected
 // element
 //
@@ -271,9 +245,6 @@ reduce_chunk(PDE<P> const &pde,
   }
   return output;
 }
-
-template class host_workspace<float>;
-template class host_workspace<double>;
 
 template int get_num_chunks(element_subgrid const &grid, PDE<float> const &pde,
                             int const rank_size_MB);

--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -47,63 +47,6 @@ grid_limits rows_in_chunk(element_chunk const &g)
   return grid_limits(g.begin()->first, g.rbegin()->first);
 }
 
-// FIXME eventually, chunk will be removed as param and replaced with grid
-// for now, unit vector (reduction) and y (batch output) still chunk dependent
-template<typename P>
-device_workspace<P>::device_workspace(PDE<P> const &pde,
-                                      element_subgrid const &subgrid,
-                                      std::vector<element_chunk> const &chunks)
-{
-  int const elem_size = element_segment_size(pde);
-
-  // the size of the x vector needed for assigned subgrid
-  auto const x_size = static_cast<int64_t>(subgrid.ncols()) * elem_size;
-  assert(x_size < INT_MAX);
-  batch_input.resize(x_size);
-
-  // the size of the y vector for assigned subgrid
-  auto const y_size = static_cast<int64_t>(subgrid.nrows()) * elem_size;
-  assert(y_size < INT_MAX);
-  batch_output.resize(y_size);
-
-  // reduction space for kron outputs
-  int const max_total = num_elements_in_chunk(*std::max_element(
-      chunks.begin(), chunks.end(),
-      [](element_chunk const &a, element_chunk const &b) {
-        return num_elements_in_chunk(a) < num_elements_in_chunk(b);
-      }));
-
-  reduction_space.resize(elem_size * max_total * pde.num_terms);
-
-  // intermediate workspaces for kron product.
-  int const num_workspaces = std::min(pde.num_dims - 1, 2);
-  batch_intermediate.resize(reduction_space.size() * num_workspaces);
-
-  // unit vector for reduction
-  auto const max_col_limits = columns_in_chunk(*std::max_element(
-      chunks.begin(), chunks.end(),
-      [](element_chunk const &a, element_chunk const &b) {
-        auto const cols_in_a = columns_in_chunk(a);
-        auto const cols_in_b = columns_in_chunk(b);
-        auto const num_a     = cols_in_a.stop - cols_in_a.start + 1;
-        auto const num_b     = cols_in_b.stop - cols_in_b.start + 1;
-        return num_a < num_b;
-      }));
-  auto const max_cols       = max_col_limits.size();
-
-  unit_vector_.resize(pde.num_terms * max_cols);
-  fk::vector<P, mem_type::owner, resource::host> unit_vect(unit_vector_.size());
-  std::fill(unit_vect.begin(), unit_vect.end(), 1.0);
-  unit_vector_.transfer_from(unit_vect);
-}
-
-template<typename P>
-fk::vector<P, mem_type::owner, resource::device> const &
-device_workspace<P>::get_unit_vector() const
-{
-  return unit_vector_;
-}
-
 template<typename P>
 host_workspace<P>::host_workspace(PDE<P> const &pde,
                                   element_subgrid const &grid,
@@ -278,9 +221,13 @@ assign_elements(element_subgrid const &grid, int const num_chunks)
   return chunks;
 }
 
-template<typename P>
-void reduce_chunk(PDE<P> const &pde, device_workspace<P> &dev_space,
-                  element_subgrid const &subgrid, element_chunk const &chunk)
+template<typename P, resource resrc>
+fk::vector<P, mem_type::owner, resrc> const &
+reduce_chunk(PDE<P> const &pde,
+             fk::vector<P, mem_type::owner, resrc> const &reduction_space,
+             fk::vector<P, mem_type::owner, resrc> &output,
+             fk::vector<P, mem_type::owner, resrc> const &unit_vector,
+             element_subgrid const &subgrid, element_chunk const &chunk)
 {
   int const elem_size = element_segment_size(pde);
 
@@ -305,28 +252,25 @@ void reduce_chunk(PDE<P> const &pde, device_workspace<P> &dev_space,
       return prev_elems;
     }();
 
-    fk::matrix<P, mem_type::const_view, resource::device> const
-        reduction_matrix(dev_space.reduction_space, elem_size,
-                         cols.size() * pde.num_terms,
-                         prev_row_elems * elem_size * pde.num_terms);
+    fk::matrix<P, mem_type::const_view, resrc> const reduction_matrix(
+        reduction_space, elem_size, cols.size() * pde.num_terms,
+        prev_row_elems * elem_size * pde.num_terms);
 
     int const reduction_row = subgrid.to_local_row(row);
-    fk::vector<P, mem_type::view, resource::device> output_view(
-        dev_space.batch_output, reduction_row * elem_size,
+    fk::vector<P, mem_type::view, resrc> output_view(
+        output, reduction_row * elem_size,
         ((reduction_row + 1) * elem_size) - 1);
 
-    fk::vector<P, mem_type::const_view, resource::device> const unit_view(
-        dev_space.get_unit_vector(), 0, cols.size() * pde.num_terms - 1);
+    fk::vector<P, mem_type::const_view, resrc> const unit_view(
+        unit_vector, 0, cols.size() * pde.num_terms - 1);
 
     P const alpha     = 1.0;
     P const beta      = 1.0;
     bool const transA = false;
     fm::gemv(reduction_matrix, unit_view, output_view, transA, alpha, beta);
   }
+  return output;
 }
-
-template class device_workspace<float>;
-template class device_workspace<double>;
 
 template class host_workspace<float>;
 template class host_workspace<double>;
@@ -336,10 +280,34 @@ template int get_num_chunks(element_subgrid const &grid, PDE<float> const &pde,
 template int get_num_chunks(element_subgrid const &grid, PDE<double> const &pde,
                             int const rank_size_MB);
 
-template void
-reduce_chunk(PDE<float> const &pde, device_workspace<float> &dev_space,
-             element_subgrid const &subgrid, element_chunk const &chunk);
+template fk::vector<float, mem_type::owner, resource::host> const &reduce_chunk(
+    PDE<float> const &pde,
+    fk::vector<float, mem_type::owner, resource::host> const &reduction_space,
+    fk::vector<float, mem_type::owner, resource::host> &output,
+    fk::vector<float, mem_type::owner, resource::host> const &unit_vector,
+    element_subgrid const &subgrid, element_chunk const &chunk);
 
-template void
-reduce_chunk(PDE<double> const &pde, device_workspace<double> &dev_space,
-             element_subgrid const &subgrid, element_chunk const &chunk);
+template fk::vector<double, mem_type::owner, resource::host> const &
+reduce_chunk(
+    PDE<double> const &pde,
+    fk::vector<double, mem_type::owner, resource::host> const &reduction_space,
+    fk::vector<double, mem_type::owner, resource::host> &output,
+    fk::vector<double, mem_type::owner, resource::host> const &unit_vector,
+    element_subgrid const &subgrid, element_chunk const &chunk);
+
+template fk::vector<float, mem_type::owner, resource::device> const &
+reduce_chunk(
+    PDE<float> const &pde,
+    fk::vector<float, mem_type::owner, resource::device> const &reduction_space,
+    fk::vector<float, mem_type::owner, resource::device> &output,
+    fk::vector<float, mem_type::owner, resource::device> const &unit_vector,
+    element_subgrid const &subgrid, element_chunk const &chunk);
+
+template fk::vector<double, mem_type::owner, resource::device> const &
+reduce_chunk(
+    PDE<double> const &pde,
+    fk::vector<double, mem_type::owner, resource::device> const
+        &reduction_space,
+    fk::vector<double, mem_type::owner, resource::device> &output,
+    fk::vector<double, mem_type::owner, resource::device> const &unit_vector,
+    element_subgrid const &subgrid, element_chunk const &chunk);

--- a/src/chunk.hpp
+++ b/src/chunk.hpp
@@ -7,19 +7,6 @@
 
 using element_chunk = std::map<int, grid_limits>;
 
-// convenience functions when working with element chunks
-int num_elements_in_chunk(element_chunk const &g);
-int max_connected_in_chunk(element_chunk const &g);
-
-grid_limits columns_in_chunk(element_chunk const &g);
-grid_limits rows_in_chunk(element_chunk const &g);
-
-// FIXME we should eventually put this in the pde class?
-auto const element_segment_size = [](auto const &pde) {
-  int const degree = pde.get_dimensions()[0].get_degree();
-  return static_cast<int>(std::pow(degree, pde.num_dims));
-};
-
 template<typename P>
 double get_MB(uint64_t const num_elems)
 {
@@ -29,36 +16,12 @@ double get_MB(uint64_t const num_elems)
   return MB;
 }
 
-// FIXME going away
-// host-side memory space holding the assigned portion of input/output
-// vectors.
-template<typename P>
-class host_workspace
-{
-public:
-  host_workspace(PDE<P> const &pde, element_subgrid const &grid,
-                 int const memory_limit_MB);
-  // working vectors for time advance (e.g. intermediate RK result vects,
-  // source vector space)
-  fk::vector<P> scaled_source;
-  fk::vector<P> x_orig;
-  fk::vector<P> x;
-  fk::vector<P> fx;
-  fk::vector<P> reduced_fx;
-  fk::vector<P> result_1;
-  fk::vector<P> result_2;
-  fk::vector<P> result_3;
+// convenience functions when working with element chunks
+int num_elements_in_chunk(element_chunk const &g);
+int max_connected_in_chunk(element_chunk const &g);
 
-  double size_MB() const
-  {
-    int64_t num_elems = scaled_source.size() + x_orig.size() + fx.size() +
-                        reduced_fx.size() + x.size() + result_1.size() +
-                        result_2.size() + result_3.size();
-    double const bytes     = static_cast<double>(num_elems) * sizeof(P);
-    double const megabytes = bytes * 1e-6;
-    return megabytes;
-  };
-};
+grid_limits columns_in_chunk(element_chunk const &g);
+grid_limits rows_in_chunk(element_chunk const &g);
 
 // functions to assign chunks
 template<typename P>

--- a/src/chunk_tests.cpp
+++ b/src/chunk_tests.cpp
@@ -311,8 +311,6 @@ void reduction_test(int const degree, int const level, PDE<P> const &pde)
   for (auto const &[rank, grid] : plan)
   {
     ignore(rank);
-    int const workspace_MB_limit = 4000;
-    host_workspace<P> host_space(pde, grid, workspace_MB_limit);
 
     int const limit_MB = 1000;
     auto const chunks =

--- a/src/chunk_tests.cpp
+++ b/src/chunk_tests.cpp
@@ -1,3 +1,4 @@
+#include "batch.hpp"
 #include "chunk.hpp"
 #include "distribution.hpp"
 #include "tests_general.hpp"
@@ -113,7 +114,7 @@ void size_check_subgrid(std::vector<element_chunk> const &chunks,
                         element_subgrid const &subgrid, PDE<P> const &pde,
                         int const limit_MB)
 {
-  device_workspace const work(pde, subgrid, chunks);
+  batch_workspace<P, resource::device> const work(pde, subgrid, chunks);
   P lower_bound                   = static_cast<P>(limit_MB * 0.49);
   P const upper_bound             = static_cast<P>(limit_MB * 1.01);
   P const workspace_size          = work.size_MB();
@@ -241,12 +242,12 @@ TEMPLATE_TEST_CASE("element chunk, continuity 6", "[chunk]", float, double)
 
 template<typename P>
 void verify_reduction(PDE<P> const &pde, element_chunk const &chunk,
-                      device_workspace<P> const &dev_space)
+                      batch_workspace<P, resource::device> const &batch_space)
 {
   int const elem_size = element_segment_size(pde);
   auto const x_range  = columns_in_chunk(chunk);
 
-  fk::vector<P> total_sum(dev_space.batch_output.size());
+  fk::vector<P> total_sum(batch_space.output.size());
   for (auto const &[row, cols] : chunk)
   {
     int const prev_row_elems = [i = row, &chunk] {
@@ -263,7 +264,7 @@ void verify_reduction(PDE<P> const &pde, element_chunk const &chunk,
     }();
     int const reduction_offset = prev_row_elems * pde.num_terms * elem_size;
     fk::matrix<P, mem_type::const_view, resource::device> const
-        reduction_matrix(dev_space.reduction_space, elem_size,
+        reduction_matrix(batch_space.reduction_space, elem_size,
                          (cols.stop - cols.start + 1) * pde.num_terms,
                          reduction_offset);
 
@@ -283,7 +284,7 @@ void verify_reduction(PDE<P> const &pde, element_chunk const &chunk,
     partial_sum = partial_sum + sum;
   }
 
-  fk::vector<P> const output_copy(dev_space.batch_output.clone_onto_host());
+  fk::vector<P> const output_copy(batch_space.output.clone_onto_host());
   fk::vector<P> const diff = output_copy - total_sum;
   auto const abs_compare   = [](auto const a, auto const b) {
     return (std::abs(a) < std::abs(b));
@@ -316,23 +317,24 @@ void reduction_test(int const degree, int const level, PDE<P> const &pde)
     int const limit_MB = 1000;
     auto const chunks =
         assign_elements(grid, get_num_chunks(grid, pde, limit_MB));
-    device_workspace<P> dev_space(pde, grid, chunks);
+    batch_workspace<P, resource::device> batch_space(pde, grid, chunks);
 
     std::random_device rd;
     std::mt19937 mersenne_engine(rd());
     std::uniform_real_distribution<P> dist(-3.0, 3.0);
-    fk::vector<P> reduction_h(dev_space.reduction_space.clone_onto_host());
+    fk::vector<P> reduction_h(batch_space.reduction_space.clone_onto_host());
     auto const gen = [&dist, &mersenne_engine]() {
       return dist(mersenne_engine);
     };
     std::generate(reduction_h.begin(), reduction_h.end(), gen);
-    dev_space.reduction_space.transfer_from(reduction_h);
+    batch_space.reduction_space.transfer_from(reduction_h);
 
     for (auto const &chunk : chunks)
     {
       // reduce and test
-      reduce_chunk(pde, dev_space, grid, chunk);
-      verify_reduction(pde, chunk, dev_space);
+      reduce_chunk(pde, batch_space.reduction_space, batch_space.output,
+                   batch_space.get_unit_vector(), grid, chunk);
+      verify_reduction(pde, chunk, batch_space);
     }
   }
 }

--- a/src/lib_dispatch.cpp
+++ b/src/lib_dispatch.cpp
@@ -772,7 +772,7 @@ void batched_gemm(P **const &a, int *lda, char const *transa, P **const &b,
   // default execution on the host for any resource
   int const end = *num_batch;
 #ifdef ASGARD_USE_OPENMP
-#pragma omp parallel for
+//#pragma omp parallel for
 #endif
   for (int i = 0; i < end; ++i)
   {

--- a/src/lib_dispatch.cpp
+++ b/src/lib_dispatch.cpp
@@ -772,7 +772,7 @@ void batched_gemm(P **const &a, int *lda, char const *transa, P **const &b,
   // default execution on the host for any resource
   int const end = *num_batch;
 #ifdef ASGARD_USE_OPENMP
-//#pragma omp parallel for
+#pragma omp parallel for
 #endif
   for (int i = 0; i < end; ++i)
   {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -179,28 +179,29 @@ int main(int argc, char **argv)
   host_workspace<prec> host_space(*pde, subgrid, default_workspace_cpu_MB);
   std::vector<element_chunk> const chunks = assign_elements(
       subgrid, get_num_chunks(plan.at(my_rank), *pde, default_workspace_MB));
-  device_workspace<prec> dev_space(*pde, plan.at(my_rank), chunks);
 
-  auto const get_MB = [&](int num_elems) {
+  // FIXME print in static block when first chunk is performed
+  /*auto const get_MB = [&](int num_elems) {
     int64_t const bytes    = num_elems * sizeof(prec);
     double const megabytes = bytes * 1e-6;
     return megabytes;
   };
+*/
+  /*
+   node_out() << "allocating workspace..." << '\n';
 
-  node_out() << "allocating workspace..." << '\n';
-
-  node_out() << "input vector size (MB): "
-             << get_MB(dev_space.batch_input.size()) << '\n';
-  node_out() << "kronmult output space size (MB): "
-             << get_MB(dev_space.reduction_space.size()) << '\n';
-  node_out() << "kronmult working space size (MB): "
-             << get_MB(dev_space.batch_intermediate.size()) << '\n';
-  node_out() << "output vector size (MB): "
-             << get_MB(dev_space.batch_output.size()) << '\n';
-  auto const &unit_vect = dev_space.get_unit_vector();
-  node_out() << "reduction vector size (MB): " << get_MB(unit_vect.size())
-             << '\n';
-
+   node_out() << "input vector size (MB): "
+              << get_MB(dev_space.batch_input.size()) << '\n';
+   node_out() << "kronmult output space size (MB): "
+              << get_MB(dev_space.reduction_space.size()) << '\n';
+   node_out() << "kronmult working space size (MB): "
+              << get_MB(dev_space.batch_intermediate.size()) << '\n';
+   node_out() << "output vector size (MB): "
+              << get_MB(dev_space.batch_output.size()) << '\n';
+   auto const &unit_vect = dev_space.get_unit_vector();
+   node_out() << "reduction vector size (MB): " << get_MB(unit_vect.size())
+              << '\n';
+ */
   node_out() << "explicit time loop workspace size (host) (MB): "
              << host_space.size_MB() << '\n';
 
@@ -258,9 +259,11 @@ int main(int argc, char **argv)
     else
     {
       // FIXME fold initial sources into host space
+
       auto const &time_id = timer::record.start("explicit_time_advance");
       explicit_time_advance(*pde, table, initial_sources, unscaled_parts,
-                            host_space, dev_space, chunks, plan, time, dt);
+                            host_space, chunks, plan, time, dt);
+
       timer::record.stop(time_id);
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -179,31 +179,6 @@ int main(int argc, char **argv)
   std::vector<element_chunk> const chunks = assign_elements(
       subgrid, get_num_chunks(plan.at(my_rank), *pde, default_workspace_MB));
 
-  // FIXME print in static block when first chunk is performed
-  /*auto const get_MB = [&](int num_elems) {
-    int64_t const bytes    = num_elems * sizeof(prec);
-    double const megabytes = bytes * 1e-6;
-    return megabytes;
-  };
-*/
-  /*
-   node_out() << "allocating workspace..." << '\n';
-
-   node_out() << "input vector size (MB): "
-              << get_MB(dev_space.batch_input.size()) << '\n';
-   node_out() << "kronmult output space size (MB): "
-              << get_MB(dev_space.reduction_space.size()) << '\n';
-   node_out() << "kronmult working space size (MB): "
-              << get_MB(dev_space.batch_intermediate.size()) << '\n';
-   node_out() << "output vector size (MB): "
-              << get_MB(dev_space.batch_output.size()) << '\n';
-   auto const &unit_vect = dev_space.get_unit_vector();
-   node_out() << "reduction vector size (MB): " << get_MB(unit_vect.size())
-              << '\n';
- */
-  // node_out() << "explicit time loop workspace size (host) (MB): "
-  //         << host_space.size_MB() << '\n';
-
   // -- setup output file and write initial condition
 #ifdef ASGARD_IO_HIGHFIVE
 

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -51,6 +51,12 @@ enum class homogeneity
   inhomogeneous
 };
 
+// helper - single element size
+auto const element_segment_size = [](auto const &pde) {
+  int const degree = pde.get_dimensions()[0].get_degree();
+  return static_cast<int>(std::pow(degree, pde.num_dims));
+};
+
 // ---------------------------------------------------------------------------
 //
 // Dimension: holds all information for a single dimension in the pde

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -37,19 +37,9 @@ void explicit_time_advance(
   element_subgrid const &grid = plan.at(my_rank);
   int const elem_size         = element_segment_size(pde);
 
-  // allocate batches
-  // max number of elements in any chunk
-  int const max_elems = num_elements_in_chunk(*std::max_element(
-      chunks.begin(), chunks.end(),
-      [](element_chunk const &a, element_chunk const &b) {
-        return num_elements_in_chunk(a) < num_elements_in_chunk(b);
-      }));
-  // allocate batches for that size
-  std::vector<batch_operands_set<P>> batches =
-      allocate_batches<P>(pde, max_elems);
 
   auto const apply_id = timer::record.start("apply_A");
-  apply_A(pde, table, grid, chunks, host_space, dev_space, batches);
+  apply_A(pde, table, grid, chunks, host_space, dev_space);
   timer::record.stop(apply_id);
 
   reduce_results(host_space.fx, host_space.reduced_fx, plan, my_rank);
@@ -68,9 +58,11 @@ void explicit_time_advance(
   P const fx_scale_1 = a21 * dt;
   fm::axpy(host_space.result_1, host_space.x, fx_scale_1);
 
+
   timer::record.start(apply_id);
-  apply_A(pde, table, grid, chunks, host_space, dev_space, batches);
+  apply_A(pde, table, grid, chunks, host_space, dev_space);
   timer::record.stop(apply_id);
+
 
   reduce_results(host_space.fx, host_space.reduced_fx, plan, my_rank);
   scale_sources(pde, unscaled_sources, host_space.scaled_source,
@@ -94,7 +86,7 @@ void explicit_time_advance(
   fm::axpy(host_space.result_2, host_space.x, fx_scale_2b);
 
   timer::record.start(apply_id);
-  apply_A(pde, table, grid, chunks, host_space, dev_space, batches);
+  apply_A(pde, table, grid, chunks, host_space, dev_space);
   timer::record.stop(apply_id);
 
   reduce_results(host_space.fx, host_space.reduced_fx, plan, my_rank);

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -36,13 +36,9 @@ void explicit_time_advance(
   element_subgrid const &grid = plan.at(my_rank);
   int const elem_size         = element_segment_size(pde);
 
-<<<<<<< HEAD
-  auto const apply_id         = timer::record.start("apply_A");
-  apply_A(pde, table, grid, chunks, host_space, dev_space);
+  auto const apply_id = timer::record.start("apply_A");
+  apply_A(pde, table, grid, chunks, host_space);
   timer::record.stop(apply_id);
-=======
-  timer::record(apply_A<P>, "apply_A", pde, table, grid, chunks, host_space);
->>>>>>> remove device workspace -> batch_workspace
 
   reduce_results(host_space.fx, host_space.reduced_fx, plan, my_rank);
   scale_sources(pde, unscaled_sources, host_space.scaled_source, time);
@@ -60,13 +56,9 @@ void explicit_time_advance(
   P const fx_scale_1 = a21 * dt;
   fm::axpy(host_space.result_1, host_space.x, fx_scale_1);
 
-<<<<<<< HEAD
   timer::record.start(apply_id);
-  apply_A(pde, table, grid, chunks, host_space, dev_space);
+  apply_A(pde, table, grid, chunks, host_space);
   timer::record.stop(apply_id);
-=======
-  timer::record(apply_A<P>, "apply_A", pde, table, grid, chunks, host_space);
->>>>>>> remove device workspace -> batch_workspace
 
   reduce_results(host_space.fx, host_space.reduced_fx, plan, my_rank);
   scale_sources(pde, unscaled_sources, host_space.scaled_source,
@@ -89,13 +81,9 @@ void explicit_time_advance(
   fm::axpy(host_space.result_1, host_space.x, fx_scale_2a);
   fm::axpy(host_space.result_2, host_space.x, fx_scale_2b);
 
-<<<<<<< HEAD
   timer::record.start(apply_id);
-  apply_A(pde, table, grid, chunks, host_space, dev_space);
+  apply_A(pde, table, grid, chunks, host_space);
   timer::record.stop(apply_id);
-=======
-  timer::record(apply_A<P>, "apply_A", pde, table, grid, chunks, host_space);
->>>>>>> remove device workspace -> batch_workspace
 
   reduce_results(host_space.fx, host_space.reduced_fx, plan, my_rank);
   scale_sources(pde, unscaled_sources, host_space.scaled_source,

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -175,9 +175,12 @@ implicit_time_advance(PDE<P> const &pde, element_table const &table,
   int const elem_size = static_cast<int>(std::pow(degree, pde.num_dims));
   int const A_size    = elem_size * table.size();
 
-  auto const scaled_source = scale_sources(pde, unscaled_sources, time + dt);
-
-  auto x = x_orig + (scaled_source * dt);
+  fk::vector<P> x(x_orig);
+  if (!unscaled_sources.empty())
+  {
+    auto const scaled_source = scale_sources(pde, unscaled_sources, time + dt);
+    fm::axpy(scaled_source, x, dt);
+  }
 
   /* add the boundary condition */
   int const my_rank = get_rank();

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -13,9 +13,8 @@ void explicit_time_advance(
     PDE<P> const &pde, element_table const &table,
     std::vector<fk::vector<P>> const &unscaled_sources,
     std::array<unscaled_bc_parts<P>, 2> const &unscaled_parts,
-    host_workspace<P> &host_space, device_workspace<P> &dev_space,
-    std::vector<element_chunk> const &chunks, distribution_plan const &plan,
-    P const time, P const dt)
+    host_workspace<P> &host_space, std::vector<element_chunk> const &chunks,
+    distribution_plan const &plan, P const time, P const dt)
 {
   assert(time >= 0);
   assert(dt > 0);
@@ -37,9 +36,13 @@ void explicit_time_advance(
   element_subgrid const &grid = plan.at(my_rank);
   int const elem_size         = element_segment_size(pde);
 
-  auto const apply_id = timer::record.start("apply_A");
+<<<<<<< HEAD
+  auto const apply_id         = timer::record.start("apply_A");
   apply_A(pde, table, grid, chunks, host_space, dev_space);
   timer::record.stop(apply_id);
+=======
+  timer::record(apply_A<P>, "apply_A", pde, table, grid, chunks, host_space);
+>>>>>>> remove device workspace -> batch_workspace
 
   reduce_results(host_space.fx, host_space.reduced_fx, plan, my_rank);
   scale_sources(pde, unscaled_sources, host_space.scaled_source, time);
@@ -57,9 +60,13 @@ void explicit_time_advance(
   P const fx_scale_1 = a21 * dt;
   fm::axpy(host_space.result_1, host_space.x, fx_scale_1);
 
+<<<<<<< HEAD
   timer::record.start(apply_id);
   apply_A(pde, table, grid, chunks, host_space, dev_space);
   timer::record.stop(apply_id);
+=======
+  timer::record(apply_A<P>, "apply_A", pde, table, grid, chunks, host_space);
+>>>>>>> remove device workspace -> batch_workspace
 
   reduce_results(host_space.fx, host_space.reduced_fx, plan, my_rank);
   scale_sources(pde, unscaled_sources, host_space.scaled_source,
@@ -82,9 +89,13 @@ void explicit_time_advance(
   fm::axpy(host_space.result_1, host_space.x, fx_scale_2a);
   fm::axpy(host_space.result_2, host_space.x, fx_scale_2b);
 
+<<<<<<< HEAD
   timer::record.start(apply_id);
   apply_A(pde, table, grid, chunks, host_space, dev_space);
   timer::record.stop(apply_id);
+=======
+  timer::record(apply_A<P>, "apply_A", pde, table, grid, chunks, host_space);
+>>>>>>> remove device workspace -> batch_workspace
 
   reduce_results(host_space.fx, host_space.reduced_fx, plan, my_rank);
   scale_sources(pde, unscaled_sources, host_space.scaled_source,
@@ -216,7 +227,7 @@ template void explicit_time_advance(
     PDE<double> const &pde, element_table const &table,
     std::vector<fk::vector<double>> const &unscaled_sources,
     std::array<unscaled_bc_parts<double>, 2> const &unscaled_parts,
-    host_workspace<double> &host_space, device_workspace<double> &dev_space,
+    host_workspace<double> &host_space,
     std::vector<element_chunk> const &chunks, distribution_plan const &plan,
     double const time, double const dt);
 
@@ -224,9 +235,8 @@ template void explicit_time_advance(
     PDE<float> const &pde, element_table const &table,
     std::vector<fk::vector<float>> const &unscaled_sources,
     std::array<unscaled_bc_parts<float>, 2> const &unscaled_parts,
-    host_workspace<float> &host_space, device_workspace<float> &dev_space,
-    std::vector<element_chunk> const &chunks, distribution_plan const &plan,
-    float const time, float const dt);
+    host_workspace<float> &host_space, std::vector<element_chunk> const &chunks,
+    distribution_plan const &plan, float const time, float const dt);
 
 template void implicit_time_advance(
     PDE<double> const &pde, element_table const &table,

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -5,22 +5,41 @@
 #include "fast_math.hpp"
 #include "solver.hpp"
 #include "timer.hpp"
+#include <limits.h>
 
 // this function executes an explicit time step using the current solution
 // vector x. on exit, the next solution vector is stored in x.
 template<typename P>
-void explicit_time_advance(
-    PDE<P> const &pde, element_table const &table,
-    std::vector<fk::vector<P>> const &unscaled_sources,
-    std::array<unscaled_bc_parts<P>, 2> const &unscaled_parts,
-    host_workspace<P> &host_space, std::vector<element_chunk> const &chunks,
-    distribution_plan const &plan, P const time, P const dt)
+fk::vector<P>
+explicit_time_advance(PDE<P> const &pde, element_table const &table,
+                      std::vector<fk::vector<P>> const &unscaled_sources,
+                      std::array<unscaled_bc_parts<P>, 2> const &unscaled_parts,
+                      fk::vector<P> const &x,
+                      std::vector<element_chunk> const &chunks,
+                      distribution_plan const &plan, P const time, P const dt)
 {
+  int const my_rank           = get_rank();
+  element_subgrid const &grid = plan.at(get_rank());
+  int const elem_size         = element_segment_size(pde);
+
+  // allocate workspace
+  int64_t const col_size = elem_size * static_cast<int64_t>(grid.ncols());
+  assert(x.size() == col_size);
+  int64_t const row_size = elem_size * static_cast<int64_t>(grid.nrows());
+  assert(col_size < INT_MAX);
+  assert(row_size < INT_MAX);
+
+  // input vector for apply_A
+  fk::vector<P> fx(col_size);
+  fm::copy(x, fx);
+
+  // a buffer for reducing across subgrid row
+  fk::vector<P> reduced_fx(row_size);
+
   assert(time >= 0);
   assert(dt > 0);
   assert(static_cast<int>(unscaled_sources.size()) == pde.num_sources);
 
-  fm::copy(host_space.x, host_space.x_orig);
   // see
   // https://en.wikipedia.org/wiki/Runge%E2%80%93Kutta_methods#Explicit_Runge%E2%80%93Kutta_methods
   P const a21 = 0.5;
@@ -32,91 +51,85 @@ void explicit_time_advance(
   P const c2  = 1.0 / 2.0;
   P const c3  = 1.0;
 
-  int const my_rank           = get_rank();
-  element_subgrid const &grid = plan.at(my_rank);
-  int const elem_size         = element_segment_size(pde);
-
   auto const apply_id = timer::record.start("apply_A");
-  apply_A(pde, table, grid, chunks, host_space);
+  fk::vector<P> fx1   = apply_A(pde, table, grid, chunks, fx);
   timer::record.stop(apply_id);
 
-  reduce_results(host_space.fx, host_space.reduced_fx, plan, my_rank);
-  scale_sources(pde, unscaled_sources, host_space.scaled_source, time);
-  fm::axpy(host_space.scaled_source, host_space.reduced_fx);
+  reduce_results(fx1, reduced_fx, plan, my_rank);
+  fk::vector<P> scaled_source = scale_sources(pde, unscaled_sources, time);
+  fm::axpy(scaled_source, reduced_fx);
 
   fk::vector<P> const bc0 = boundary_conditions::generate_scaled_bc(
       unscaled_parts[0], unscaled_parts[1], pde, grid.row_start, grid.row_stop,
       time);
 
-  fm::axpy(bc0, host_space.reduced_fx);
+  fm::axpy(bc0, reduced_fx);
 
-  exchange_results(host_space.reduced_fx, host_space.result_1, elem_size, plan,
-                   my_rank);
+  exchange_results(reduced_fx, fx1, elem_size, plan, my_rank);
 
   P const fx_scale_1 = a21 * dt;
-  fm::axpy(host_space.result_1, host_space.x, fx_scale_1);
+  fm::axpy(fx1, fx, fx_scale_1);
 
   timer::record.start(apply_id);
-  apply_A(pde, table, grid, chunks, host_space);
+  fk::vector<P> fx2 = apply_A(pde, table, grid, chunks, fx);
   timer::record.stop(apply_id);
 
-  reduce_results(host_space.fx, host_space.reduced_fx, plan, my_rank);
-  scale_sources(pde, unscaled_sources, host_space.scaled_source,
-                time + c2 * dt);
-  fm::axpy(host_space.scaled_source, host_space.reduced_fx);
+  reduce_results(fx2, reduced_fx, plan, my_rank);
+  scaled_source = scale_sources(pde, unscaled_sources, time + c2 * dt);
+  fm::axpy(scaled_source, reduced_fx);
 
   fk::vector<P> const bc1 = boundary_conditions::generate_scaled_bc(
       unscaled_parts[0], unscaled_parts[1], pde, grid.row_start, grid.row_stop,
       time + c2 * dt);
 
-  fm::axpy(bc1, host_space.reduced_fx);
+  fm::axpy(bc1, reduced_fx);
 
-  exchange_results(host_space.reduced_fx, host_space.result_2, elem_size, plan,
-                   my_rank);
+  exchange_results(reduced_fx, fx2, elem_size, plan, my_rank);
 
-  fm::copy(host_space.x_orig, host_space.x);
+  fm::copy(x, fx);
   P const fx_scale_2a = a31 * dt;
   P const fx_scale_2b = a32 * dt;
 
-  fm::axpy(host_space.result_1, host_space.x, fx_scale_2a);
-  fm::axpy(host_space.result_2, host_space.x, fx_scale_2b);
+  fm::axpy(fx1, fx, fx_scale_2a);
+  fm::axpy(fx2, fx, fx_scale_2b);
 
   timer::record.start(apply_id);
-  apply_A(pde, table, grid, chunks, host_space);
+  fk::vector<P> fx3 = apply_A(pde, table, grid, chunks, fx);
   timer::record.stop(apply_id);
 
-  reduce_results(host_space.fx, host_space.reduced_fx, plan, my_rank);
-  scale_sources(pde, unscaled_sources, host_space.scaled_source,
-                time + c3 * dt);
-  fm::axpy(host_space.scaled_source, host_space.reduced_fx);
+  reduce_results(fx3, reduced_fx, plan, my_rank);
+  scaled_source = scale_sources(pde, unscaled_sources, time + c3 * dt);
+  fm::axpy(scaled_source, reduced_fx);
 
   fk::vector<P> const bc2 = boundary_conditions::generate_scaled_bc(
       unscaled_parts[0], unscaled_parts[1], pde, grid.row_start, grid.row_stop,
       time + c3 * dt);
 
-  fm::axpy(bc2, host_space.reduced_fx);
-  exchange_results(host_space.reduced_fx, host_space.result_3, elem_size, plan,
-                   my_rank);
+  fm::axpy(bc2, reduced_fx);
+  exchange_results(reduced_fx, fx3, elem_size, plan, my_rank);
 
-  fm::copy(host_space.x_orig, host_space.x);
+  fm::copy(x, fx);
   P const scale_1 = dt * b1;
   P const scale_2 = dt * b2;
   P const scale_3 = dt * b3;
 
-  fm::axpy(host_space.result_1, host_space.x, scale_1);
-  fm::axpy(host_space.result_2, host_space.x, scale_2);
-  fm::axpy(host_space.result_3, host_space.x, scale_3);
+  fm::axpy(fx1, fx, scale_1);
+  fm::axpy(fx2, fx, scale_2);
+  fm::axpy(fx3, fx, scale_3);
+
+  return fx;
 }
 
 // scale source vectors for time
 template<typename P>
-static fk::vector<P> &
+fk::vector<P>
 scale_sources(PDE<P> const &pde,
-              std::vector<fk::vector<P>> const &unscaled_sources,
-              fk::vector<P> &scaled_source, P const time)
+              std::vector<fk::vector<P>> const &unscaled_sources, P const time)
 {
   // zero out final vect
-  fm::scal(static_cast<P>(0.0), scaled_source);
+  assert(unscaled_sources.size() > 0);
+  fk::vector<P> scaled_source(unscaled_sources[0].size());
+
   // scale and accumulate all sources
   for (int i = 0; i < pde.num_sources; ++i)
   {
@@ -129,13 +142,14 @@ scale_sources(PDE<P> const &pde,
 // this function executes an implicit time step using the current solution
 // vector x. on exit, the next solution vector is stored in fx.
 template<typename P>
-void implicit_time_advance(
-    PDE<P> const &pde, element_table const &table,
-    std::vector<fk::vector<P>> const &unscaled_sources,
-    std::array<unscaled_bc_parts<P>, 2> const &unscaled_parts,
-    host_workspace<P> &host_space, std::vector<element_chunk> const &chunks,
-    distribution_plan const &plan, P const time, P const dt,
-    solve_opts const solver, bool update_system)
+fk::vector<P>
+implicit_time_advance(PDE<P> const &pde, element_table const &table,
+                      std::vector<fk::vector<P>> const &unscaled_sources,
+                      std::array<unscaled_bc_parts<P>, 2> const &unscaled_parts,
+                      fk::vector<P> const &x_orig,
+                      std::vector<element_chunk> const &chunks,
+                      distribution_plan const &plan, P const time, P const dt,
+                      solve_opts const solver, bool update_system)
 {
   assert(time >= 0);
   assert(dt > 0);
@@ -148,8 +162,9 @@ void implicit_time_advance(
   int const elem_size = static_cast<int>(std::pow(degree, pde.num_dims));
   int const A_size    = elem_size * table.size();
 
-  scale_sources(pde, unscaled_sources, host_space.scaled_source, time + dt);
-  host_space.x = host_space.x + host_space.scaled_source * dt;
+  fk::vector<P> scaled_source = scale_sources(pde, unscaled_sources, time + dt);
+
+  fk::vector<P> x = x_orig + scaled_source * dt;
 
   /* add the boundary condition */
   int const my_rank           = get_rank();
@@ -158,7 +173,7 @@ void implicit_time_advance(
   fk::vector<P> const bc = boundary_conditions::generate_scaled_bc(
       unscaled_parts[0], unscaled_parts[1], pde, grid.row_start, grid.row_stop,
       time + dt);
-  fm::axpy(bc, host_space.x, dt);
+  fm::axpy(bc, x, dt);
 
   if (first_time || update_system)
   {
@@ -183,8 +198,8 @@ void implicit_time_advance(
     case solve_opts::direct:
       if (ipiv.size() != static_cast<unsigned long>(A.nrows()))
         ipiv.resize(A.nrows());
-      fm::gesv(A, host_space.x, ipiv);
-      return;
+      fm::gesv(A, x, ipiv);
+      return x;
       break;
     case solve_opts::gmres:
       ignore(ipiv);
@@ -197,48 +212,47 @@ void implicit_time_advance(
   switch (solver)
   {
   case solve_opts::direct:
-    fm::getrs(A, host_space.x, ipiv);
+    fm::getrs(A, x, ipiv);
     break;
   case solve_opts::gmres:
     P const tolerance  = std::is_same_v<float, P> ? 1e-6 : 1e-12;
     int const restart  = A.ncols();
     int const max_iter = A.ncols();
-    fm::scal(static_cast<P>(0.0), host_space.result_1);
-    solver::simple_gmres(A, host_space.result_1, host_space.x, fk::matrix<P>(),
-                         restart, max_iter, tolerance);
-    fm::copy(host_space.result_1, host_space.x);
-    break;
+    fk::vector<P> fx(x.size());
+    solver::simple_gmres(A, fx, x, fk::matrix<P>(), restart, max_iter,
+                         tolerance);
+    return fx;
   }
+  return x;
 }
 
-template void explicit_time_advance(
+template fk::vector<double> explicit_time_advance(
     PDE<double> const &pde, element_table const &table,
     std::vector<fk::vector<double>> const &unscaled_sources,
     std::array<unscaled_bc_parts<double>, 2> const &unscaled_parts,
-    host_workspace<double> &host_space,
-    std::vector<element_chunk> const &chunks, distribution_plan const &plan,
-    double const time, double const dt);
+    fk::vector<double> const &x, std::vector<element_chunk> const &chunks,
+    distribution_plan const &plan, double const time, double const dt);
 
-template void explicit_time_advance(
+template fk::vector<float> explicit_time_advance(
     PDE<float> const &pde, element_table const &table,
     std::vector<fk::vector<float>> const &unscaled_sources,
     std::array<unscaled_bc_parts<float>, 2> const &unscaled_parts,
-    host_workspace<float> &host_space, std::vector<element_chunk> const &chunks,
+    fk::vector<float> const &x, std::vector<element_chunk> const &chunks,
     distribution_plan const &plan, float const time, float const dt);
 
-template void implicit_time_advance(
+template fk::vector<double> implicit_time_advance(
     PDE<double> const &pde, element_table const &table,
     std::vector<fk::vector<double>> const &unscaled_sources,
     std::array<unscaled_bc_parts<double>, 2> const &unscaled_parts,
-    host_workspace<double> &host_space,
+    fk::vector<double> const &host_space,
     std::vector<element_chunk> const &chunks, distribution_plan const &plan,
     double const time, double const dt, solve_opts const solver,
     bool update_system = true);
 
-template void implicit_time_advance(
+template fk::vector<float> implicit_time_advance(
     PDE<float> const &pde, element_table const &table,
     std::vector<fk::vector<float>> const &unscaled_sources,
     std::array<unscaled_bc_parts<float>, 2> const &unscaled_parts,
-    host_workspace<float> &host_space, std::vector<element_chunk> const &chunks,
+    fk::vector<float> const &x, std::vector<element_chunk> const &chunks,
     distribution_plan const &plan, float const time, float const dt,
     solve_opts const solver, bool update_system = true);

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -37,7 +37,6 @@ void explicit_time_advance(
   element_subgrid const &grid = plan.at(my_rank);
   int const elem_size         = element_segment_size(pde);
 
-
   auto const apply_id = timer::record.start("apply_A");
   apply_A(pde, table, grid, chunks, host_space, dev_space);
   timer::record.stop(apply_id);
@@ -58,11 +57,9 @@ void explicit_time_advance(
   P const fx_scale_1 = a21 * dt;
   fm::axpy(host_space.result_1, host_space.x, fx_scale_1);
 
-
   timer::record.start(apply_id);
   apply_A(pde, table, grid, chunks, host_space, dev_space);
   timer::record.stop(apply_id);
-
 
   reduce_results(host_space.fx, host_space.reduced_fx, plan, my_rank);
   scale_sources(pde, unscaled_sources, host_space.scaled_source,

--- a/src/time_advance.hpp
+++ b/src/time_advance.hpp
@@ -15,9 +15,8 @@ void explicit_time_advance(
     PDE<P> const &pde, element_table const &table,
     std::vector<fk::vector<P>> const &unscaled_sources,
     std::array<unscaled_bc_parts<P>, 2> const &unscaled_parts,
-    host_workspace<P> &host_space, device_workspace<P> &dev_space,
-    std::vector<element_chunk> const &chunks, distribution_plan const &plan,
-    P const time, P const dt);
+    host_workspace<P> &host_space, std::vector<element_chunk> const &chunks,
+    distribution_plan const &plan, P const time, P const dt);
 
 template<typename P>
 void implicit_time_advance(
@@ -34,20 +33,26 @@ template<typename P>
 static void
 apply_A(PDE<P> const &pde, element_table const &elem_table,
         element_subgrid const &grid, std::vector<element_chunk> const &chunks,
-        host_workspace<P> &host_space, device_workspace<P> &dev_space)
+        host_workspace<P> &host_space)
 {
+  batch_workspace<P, resource::device> batch_space(pde, grid, chunks);
   fm::scal(static_cast<P>(0.0), host_space.fx);
-  fm::scal(static_cast<P>(0.0), dev_space.batch_output);
-
-  // copy inputs onto GPU
-  dev_space.batch_input.transfer_from(host_space.x);
+  fm::scal(static_cast<P>(0.0), batch_space.output);
 
   for (auto const &chunk : chunks)
   {
+<<<<<<< HEAD
     // build batches for this chunk
     auto const batch_id = timer::record.start("build_batches");
+=======
+    // copy inputs onto GPU
+    batch_space.input.transfer_from(host_space.x);
+
+    // build batches for this chunk
+    auto const &batch_id = timer::record.start("build_batches");
+>>>>>>> remove device workspace -> batch_workspace
     batch_chain<P, resource::device, chain_method::advance> const batches(
-        pde, elem_table, dev_space, grid, chunk);
+        pde, elem_table, batch_space, grid, chunk);
     timer::record.stop(batch_id);
 
     // execute
@@ -56,11 +61,17 @@ apply_A(PDE<P> const &pde, element_table const &elem_table,
     timer::record.stop(gemm_id);
 
     // do the reduction
+<<<<<<< HEAD
     auto const reduce_id = timer::record.start("reduce_chunk");
     reduce_chunk(pde, dev_space, grid, chunk);
     timer::record.stop(reduce_id);
+=======
+    timer::record(reduce_chunk<P, resource::device>, "reduce_chunk", pde,
+                  batch_space.reduction_space, batch_space.output,
+                  batch_space.get_unit_vector(), grid, chunk);
+>>>>>>> remove device workspace -> batch_workspace
   }
 
   // copy outputs back from GPU
-  host_space.fx.transfer_from(dev_space.batch_output);
+  host_space.fx.transfer_from(batch_space.output);
 }

--- a/src/time_advance.hpp
+++ b/src/time_advance.hpp
@@ -41,16 +41,11 @@ apply_A(PDE<P> const &pde, element_table const &elem_table,
 
   for (auto const &chunk : chunks)
   {
-<<<<<<< HEAD
-    // build batches for this chunk
-    auto const batch_id = timer::record.start("build_batches");
-=======
     // copy inputs onto GPU
     batch_space.input.transfer_from(host_space.x);
 
     // build batches for this chunk
-    auto const &batch_id = timer::record.start("build_batches");
->>>>>>> remove device workspace -> batch_workspace
+    auto const batch_id = timer::record.start("build_batches");
     batch_chain<P, resource::device, chain_method::advance> const batches(
         pde, elem_table, batch_space, grid, chunk);
     timer::record.stop(batch_id);
@@ -61,15 +56,10 @@ apply_A(PDE<P> const &pde, element_table const &elem_table,
     timer::record.stop(gemm_id);
 
     // do the reduction
-<<<<<<< HEAD
     auto const reduce_id = timer::record.start("reduce_chunk");
-    reduce_chunk(pde, dev_space, grid, chunk);
+    reduce_chunk(pde, batch_space.reduction_space, batch_space.output,
+                 batch_space.get_unit_vector(), grid, chunk);
     timer::record.stop(reduce_id);
-=======
-    timer::record(reduce_chunk<P, resource::device>, "reduce_chunk", pde,
-                  batch_space.reduction_space, batch_space.output,
-                  batch_space.get_unit_vector(), grid, chunk);
->>>>>>> remove device workspace -> batch_workspace
   }
 
   // copy outputs back from GPU

--- a/src/time_advance.hpp
+++ b/src/time_advance.hpp
@@ -40,7 +40,6 @@ apply_A(PDE<P> const &pde, element_table const &elem_table,
         element_subgrid const &grid, std::vector<element_chunk> const &chunks,
         fk::vector<P> const &x)
 {
-  fk::vector<P> fx(x.size());
   batch_workspace<P, resource::device> batch_space(pde, grid, chunks);
 
   // print information about workspace size on first invocation
@@ -90,6 +89,5 @@ apply_A(PDE<P> const &pde, element_table const &elem_table,
   }
 
   // copy outputs back from GPU
-  fx.transfer_from(batch_space.output);
-  return fx;
+  return batch_space.output.clone_onto_host();
 }

--- a/src/time_advance.hpp
+++ b/src/time_advance.hpp
@@ -64,7 +64,6 @@ apply_A(PDE<P> const &pde, element_table const &elem_table,
     auto const &unit_vect = batch_space.get_unit_vector();
     node_out() << "reduction vector size (MB): " << get_MB(unit_vect.size())
                << '\n';
-    return true;
   });
 
   for (auto const &chunk : chunks)

--- a/src/time_advance.hpp
+++ b/src/time_advance.hpp
@@ -45,21 +45,15 @@ apply_A(PDE<P> const &pde, element_table const &elem_table,
   for (auto const &chunk : chunks)
   {
     // build batches for this chunk
-
-
     auto const batch_id = timer::record.start("build_batches");
     batch_chain<P, resource::device, chain_method::advance> const batches(
         pde, elem_table, dev_space, grid, chunk);
     timer::record.stop(batch_id);
 
-
-
-
     // execute
     auto const gemm_id = timer::record.start("batched_gemm");
     batches.execute();
     timer::record.stop(gemm_id);
-
 
     // do the reduction
     auto const reduce_id = timer::record.start("reduce_chunk");

--- a/src/time_advance.hpp
+++ b/src/time_advance.hpp
@@ -27,8 +27,8 @@ implicit_time_advance(PDE<P> const &pde, element_table const &table,
                       fk::vector<P> const &x,
                       std::vector<element_chunk> const &chunks,
                       distribution_plan const &plan, P const time, P const dt,
-                      solve_opts const solver = solve_opts::direct,
-                      bool update_system      = true);
+                      solve_opts const solver  = solve_opts::direct,
+                      bool const update_system = true);
 
 // apply the system matrix to the current solution vector using batched
 // gemm.

--- a/src/time_advance_tests.cpp
+++ b/src/time_advance_tests.cpp
@@ -21,8 +21,7 @@ static distribution_test_init const distrib_test_info;
 #endif
 
 // settings for time advance testing
-static auto constexpr num_steps          = 5;
-static auto constexpr workspace_limit_MB = 1000;
+static auto constexpr num_steps = 5;
 
 template<typename P>
 void time_advance_test(int const level, int const degree, PDE<P> &pde,

--- a/src/time_advance_tests.cpp
+++ b/src/time_advance_tests.cpp
@@ -45,7 +45,6 @@ void time_advance_test(int const level, int const degree, PDE<P> &pde,
 
     return args;
   }();
-
   options const o = make_options(args);
 
   element_table const table(o, pde.num_dims);
@@ -104,22 +103,22 @@ void time_advance_test(int const level, int const degree, PDE<P> &pde,
                                                   subgrid.row_stop);
 
   // -- prep workspace/chunks
-  int const workspace_MB_limit = 4000;
-  host_workspace<P> host_space(pde, subgrid, workspace_MB_limit);
+  int const workspace_limit_MB            = 4000;
   std::vector<element_chunk> const chunks = assign_elements(
       subgrid, get_num_chunks(subgrid, pde, workspace_limit_MB));
-  host_space.x = initial_condition;
 
   // -- time loop
   P const dt = pde.get_dt() * o.get_cfl();
 
+  fk::vector<P> f_val(initial_condition);
   for (int i = 0; i < num_steps; ++i)
   {
     P const time = i * dt;
 
-    explicit_time_advance(pde, table, initial_sources, unscaled_parts,
-                          host_space, chunks, plan, time, dt);
-
+    std::cout.setstate(std::ios_base::failbit);
+    f_val = explicit_time_advance(pde, table, initial_sources, unscaled_parts,
+                                  f_val, chunks, plan, time, dt);
+    std::cout.clear();
     std::string const file_path = filepath + std::to_string(i) + ".dat";
 
     int const degree       = pde.get_dimensions()[0].get_degree();
@@ -128,8 +127,7 @@ void time_advance_test(int const level, int const degree, PDE<P> &pde,
         fk::vector<P>(read_vector_from_txt_file(file_path))
             .extract(subgrid.col_start * segment_size,
                      (subgrid.col_stop + 1) * segment_size - 1);
-
-    rmse_comparison(gold, host_space.x, tol_factor);
+    rmse_comparison(gold, f_val, tol_factor);
   }
 }
 
@@ -204,12 +202,11 @@ void implicit_time_advance_test(int const level, int const degree, PDE<P> &pde,
                                                   subgrid.row_stop);
 
   // -- prep workspace/chunks
-  int const workspace_MB_limit = 4000;
-  host_workspace<P> host_space(pde, subgrid, workspace_MB_limit);
+  int const workspace_limit_MB            = 4000;
   std::vector<element_chunk> const chunks = assign_elements(
       subgrid, get_num_chunks(subgrid, pde, workspace_limit_MB));
 
-  host_space.x = initial_condition;
+  fk::vector<P> f_val(initial_condition);
 
   // -- time loop
   P const dt = pde.get_dt() * o.get_cfl();
@@ -219,15 +216,15 @@ void implicit_time_advance_test(int const level, int const degree, PDE<P> &pde,
     P const time = i * dt;
 
     std::cout.setstate(std::ios_base::failbit);
-    implicit_time_advance(pde, table, initial_sources, unscaled_parts,
-                          host_space, chunks, plan, time, dt, solver);
+    f_val = implicit_time_advance(pde, table, initial_sources, unscaled_parts,
+                                  f_val, chunks, plan, time, dt, solver);
     std::cout.clear();
     std::string const file_path = filepath + std::to_string(i) + ".dat";
 
     fk::vector<P> const gold =
         fk::vector<P>(read_vector_from_txt_file(file_path));
 
-    rmse_comparison(gold, host_space.x, tolerance_factor);
+    rmse_comparison(gold, f_val, tolerance_factor);
   }
 }
 

--- a/src/time_advance_tests.cpp
+++ b/src/time_advance_tests.cpp
@@ -108,7 +108,6 @@ void time_advance_test(int const level, int const degree, PDE<P> &pde,
   host_workspace<P> host_space(pde, subgrid, workspace_MB_limit);
   std::vector<element_chunk> const chunks = assign_elements(
       subgrid, get_num_chunks(subgrid, pde, workspace_limit_MB));
-  device_workspace<P> dev_space(pde, subgrid, chunks);
   host_space.x = initial_condition;
 
   // -- time loop
@@ -119,7 +118,7 @@ void time_advance_test(int const level, int const degree, PDE<P> &pde,
     P const time = i * dt;
 
     explicit_time_advance(pde, table, initial_sources, unscaled_parts,
-                          host_space, dev_space, chunks, plan, time, dt);
+                          host_space, chunks, plan, time, dt);
 
     std::string const file_path = filepath + std::to_string(i) + ".dat";
 

--- a/src/transformations.cpp
+++ b/src/transformations.cpp
@@ -179,9 +179,9 @@ void wavelet_to_realspace(
   /* clear out the vector */
   real_space.scale(0);
 
-  for (auto &link : chain)
+  for (auto const &link : chain)
   {
-    link.execute_batch_chain();
+    link.execute();
     real_space = real_space + real_space_accumulator;
   }
 


### PR DESCRIPTION
use the same machinery for batch building/execution in time advance and realspace conversion where possible.

clean up batch set interface and enforce RAII if no performance penalty.

closes #85 .
