### PR TITLE
update timer to provide for tic/toc interface

### DIFF
--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -12,7 +12,7 @@ std::string recorder::report()
   std::ostringstream report;
   report << "\nperformance report, all times in ms...\n\n";
 
-  for (auto [id, times] : id_to_times)
+  for (auto [id, times] : id_to_times_)
   {
     auto const avg =
         std::accumulate(times.begin(), times.end(), 0.0) / times.size();

--- a/src/timer.hpp
+++ b/src/timer.hpp
@@ -22,6 +22,7 @@ public:
           !std::is_same_v<decltype(f(std::forward<Args>(args)...)), void>,
           decltype(f(std::forward<Args>(args)...))>::type
   {
+    assert(!identifier.empty());
     auto const beg = std::chrono::high_resolution_clock::now();
     auto const ret = std::forward<F>(f)(std::forward<Args>(args)...);
     auto const end = std::chrono::high_resolution_clock::now();
@@ -38,6 +39,7 @@ public:
           std::is_same_v<decltype(f(std::forward<Args>(args)...)), void>,
           void>::type
   {
+    assert(!identifier.empty());
     auto const beg = std::chrono::high_resolution_clock::now();
     std::forward<F>(f)(std::forward<Args>(args)...);
     auto const end = std::chrono::high_resolution_clock::now();
@@ -47,26 +49,51 @@ public:
     insert(identifier, dur);
   }
 
+  std::string start(std::string const identifier)
+  {
+    assert(!identifier.empty());
+    assert(id_to_start_.count(identifier) == 0);
+    id_to_start_[identifier] = std::chrono::high_resolution_clock::now();
+    return identifier;
+  }
+
+  void stop(std::string const identifier)
+  {
+    assert(!identifier.empty());
+    assert(id_to_start_.count(identifier) == 1);
+    auto const beg = id_to_start_[identifier];
+    auto const end = std::chrono::high_resolution_clock::now();
+    auto const dur =
+        std::chrono::duration_cast<std::chrono::milliseconds>(end - beg)
+            .count();
+    id_to_start_.erase(identifier);
+    insert(identifier, dur);
+  }
+
   // get performance report for recorded functions
   std::string report();
 
   // get times for some key, mostly for testing for now
   std::vector<double> const &get_times(std::string const id)
   {
-    assert(id_to_times.count(id) == 1);
-    return id_to_times[id];
+    assert(id_to_times_.count(id) == 1);
+    return id_to_times_[id];
   }
 
 private:
   // little helper for creating a new list if no values exist for key
   void insert(std::string const &key, double const time)
   {
-    id_to_times.try_emplace(key, std::vector<double>());
-    id_to_times[key].push_back(time);
+    id_to_times_.try_emplace(key, std::vector<double>());
+    id_to_times_[key].push_back(time);
   }
 
   // stores function identifier -> list of operator()times recorded
-  std::map<std::string, std::vector<double>> id_to_times;
+  std::map<std::string, std::vector<double>> id_to_times_;
+
+  std::map<std::string,
+           std::chrono::time_point<std::chrono::high_resolution_clock>>
+      id_to_start_;
 };
 extern recorder record;
 } // namespace timer

--- a/src/timer.hpp
+++ b/src/timer.hpp
@@ -23,7 +23,7 @@ public:
           decltype(f(std::forward<Args>(args)...))>::type
   {
     assert(!identifier.empty());
-    assert(id_to_start_.count(identifier == 0));
+    assert(id_to_start_.count(identifier) == 0);
     auto const beg = std::chrono::high_resolution_clock::now();
     auto const ret = std::forward<F>(f)(std::forward<Args>(args)...);
     auto const end = std::chrono::high_resolution_clock::now();
@@ -41,7 +41,7 @@ public:
           void>::type
   {
     assert(!identifier.empty());
-    assert(id_to_start_.count(identifier == 0));
+    assert(id_to_start_.count(identifier) == 0);
     auto const beg = std::chrono::high_resolution_clock::now();
     std::forward<F>(f)(std::forward<Args>(args)...);
     auto const end = std::chrono::high_resolution_clock::now();

--- a/src/timer.hpp
+++ b/src/timer.hpp
@@ -23,6 +23,7 @@ public:
           decltype(f(std::forward<Args>(args)...))>::type
   {
     assert(!identifier.empty());
+    assert(id_to_start_.count(identifier == 0));
     auto const beg = std::chrono::high_resolution_clock::now();
     auto const ret = std::forward<F>(f)(std::forward<Args>(args)...);
     auto const end = std::chrono::high_resolution_clock::now();
@@ -40,6 +41,7 @@ public:
           void>::type
   {
     assert(!identifier.empty());
+    assert(id_to_start_.count(identifier == 0));
     auto const beg = std::chrono::high_resolution_clock::now();
     std::forward<F>(f)(std::forward<Args>(args)...);
     auto const end = std::chrono::high_resolution_clock::now();
@@ -49,7 +51,7 @@ public:
     insert(identifier, dur);
   }
 
-  std::string start(std::string const identifier)
+  std::string const &start(std::string const &identifier)
   {
     assert(!identifier.empty());
     assert(id_to_start_.count(identifier) == 0);
@@ -57,7 +59,7 @@ public:
     return identifier;
   }
 
-  void stop(std::string const identifier)
+  void stop(std::string const &identifier)
   {
     assert(!identifier.empty());
     assert(id_to_start_.count(identifier) == 1);
@@ -74,7 +76,7 @@ public:
   std::string report();
 
   // get times for some key, mostly for testing for now
-  std::vector<double> const &get_times(std::string const id)
+  std::vector<double> const &get_times(std::string const &id)
   {
     assert(id_to_times_.count(id) == 1);
     return id_to_times_[id];

--- a/src/timer_tests.cpp
+++ b/src/timer_tests.cpp
@@ -100,7 +100,7 @@ TEST_CASE("test recorder")
     }
     double const gold_average = sum / times.size();
     REQUIRE(avg == gold_average);
-    relaxed_comparison(avg_wrap, gold_average, tolerance);
+    relaxed_fp_comparison(avg_wrap, gold_average, tolerance);
   }
 
   SECTION("min/max")
@@ -116,8 +116,8 @@ TEST_CASE("test recorder")
 
     REQUIRE(min == gold_min);
     REQUIRE(max == gold_max);
-    relaxed_comparison(min_wrap, gold_min, tolerance);
-    relaxed_comparison(max_wrap, gold_max, tolerance);
+    relaxed_fp_comparison(min_wrap, gold_min, tolerance);
+    relaxed_fp_comparison(max_wrap, gold_max, tolerance);
   }
 
   SECTION("med")
@@ -129,7 +129,7 @@ TEST_CASE("test recorder")
                                 ? (time_copy[mid] + time_copy[mid - 1]) / 2
                                 : time_copy[mid];
     REQUIRE(med == gold_med);
-    relaxed_comparison(med_wrap, gold_med, tolerance);
+    relaxed_fp_comparison(med_wrap, gold_med, tolerance);
   }
 
   SECTION("count")

--- a/src/timer_tests.cpp
+++ b/src/timer_tests.cpp
@@ -89,6 +89,8 @@ TEST_CASE("test recorder")
 
   auto const &times = record.get_times(identifier);
 
+  double const tolerance = 1e2;
+
   SECTION("avg")
   {
     double sum = 0.0;
@@ -98,7 +100,7 @@ TEST_CASE("test recorder")
     }
     double const gold_average = sum / times.size();
     REQUIRE(avg == gold_average);
-    REQUIRE(avg_wrap == gold_average);
+    relaxed_comparison(avg_wrap, gold_average, tolerance);
   }
 
   SECTION("min/max")
@@ -114,8 +116,8 @@ TEST_CASE("test recorder")
 
     REQUIRE(min == gold_min);
     REQUIRE(max == gold_max);
-    REQUIRE(min_wrap == gold_min);
-    REQUIRE(max_wrap == gold_max);
+    relaxed_comparison(min_wrap, gold_min, tolerance);
+    relaxed_comparison(max_wrap, gold_max, tolerance);
   }
 
   SECTION("med")
@@ -127,7 +129,7 @@ TEST_CASE("test recorder")
                                 ? (time_copy[mid] + time_copy[mid - 1]) / 2
                                 : time_copy[mid];
     REQUIRE(med == gold_med);
-    REQUIRE(med_wrap == gold_med);
+    relaxed_comparison(med_wrap, gold_med, tolerance);
   }
 
   SECTION("count")

--- a/src/timer_tests.cpp
+++ b/src/timer_tests.cpp
@@ -89,7 +89,7 @@ TEST_CASE("test recorder")
 
   auto const &times = record.get_times(identifier);
 
-  double const tolerance = 1e2;
+  double const tolerance = 1e4;
 
   SECTION("avg")
   {

--- a/src/timer_tests.cpp
+++ b/src/timer_tests.cpp
@@ -23,17 +23,20 @@ double shuffle_random(int const num_items)
 TEST_CASE("test recorder")
 {
   timer::recorder record;
-  int const items_to_gen       = 1000000;
-  int const iterations         = 10;
-  std::string const identifier = "waste_time";
+  int const items_to_gen            = 1000000;
+  int const iterations              = 10;
+  std::string const identifier      = "waste_time";
+  std::string const identifier_wrap = "waste_more";
   for (int i = 0; i < iterations; ++i)
   {
+    record.start(identifier_wrap);
     double const val = record(shuffle_random, identifier, items_to_gen);
+    record.stop(identifier_wrap);
     assert(val > 0.0); // to avoid comp. warnings
   }
   std::string const report = record.report();
-  std::stringstream s1(report.substr(report.find("avg: ")));
 
+  std::stringstream s1(report.substr(report.find("avg: ")));
   std::string s;
   s1 >> s;
   double avg;
@@ -59,6 +62,31 @@ TEST_CASE("test recorder")
   int calls;
   s5 >> calls;
 
+  std::stringstream s1_w(report.substr(report.rfind("avg: ")));
+  s1_w >> s;
+  double avg_wrap;
+  s1_w >> avg_wrap;
+
+  std::stringstream s2_w(report.substr(report.rfind("min: ")));
+  s2_w >> s;
+  double min_wrap;
+  s2_w >> min_wrap;
+
+  std::stringstream s3_w(report.substr(report.rfind("max: ")));
+  s3_w >> s;
+  double max_wrap;
+  s3_w >> max_wrap;
+
+  std::stringstream s4_w(report.substr(report.rfind("med: ")));
+  s4_w >> s;
+  double med_wrap;
+  s4_w >> med_wrap;
+
+  std::stringstream s5_w(report.substr(report.rfind("calls: ")));
+  s5_w >> s;
+  int calls_wrap;
+  s5_w >> calls_wrap;
+
   auto const &times = record.get_times(identifier);
 
   SECTION("avg")
@@ -70,6 +98,7 @@ TEST_CASE("test recorder")
     }
     double const gold_average = sum / times.size();
     REQUIRE(avg == gold_average);
+    REQUIRE(avg_wrap == gold_average);
   }
 
   SECTION("min/max")
@@ -85,6 +114,8 @@ TEST_CASE("test recorder")
 
     REQUIRE(min == gold_min);
     REQUIRE(max == gold_max);
+    REQUIRE(min_wrap == gold_min);
+    REQUIRE(max_wrap == gold_max);
   }
 
   SECTION("med")
@@ -96,7 +127,12 @@ TEST_CASE("test recorder")
                                 ? (time_copy[mid] + time_copy[mid - 1]) / 2
                                 : time_copy[mid];
     REQUIRE(med == gold_med);
+    REQUIRE(med_wrap == gold_med);
   }
 
-  SECTION("count") { REQUIRE(calls == static_cast<int>(times.size())); }
+  SECTION("count")
+  {
+    REQUIRE(calls == static_cast<int>(times.size()));
+    REQUIRE(calls_wrap == static_cast<int>(times.size()));
+  }
 }


### PR DESCRIPTION
our timing method relies on passing a function into the timer w/ its arguments forwarded.

this does not work for constructors, see std: https://eel.is/c++draft/class.ctor#6.

so, extend timer with additional interface - classic tic/toc.

