### PR TITLE
Feature/views of views

### DIFF
--- a/src/tensors.hpp
+++ b/src/tensors.hpp
@@ -2607,7 +2607,7 @@ fk::matrix<P, mem, resrc>::matrix(fk::matrix<P, omem, resrc> const &owner,
     data_   = owner.data(start_row, start_col);
     nrows_  = view_rows;
     ncols_  = view_cols;
-    stride_ = owner.nrows();
+    stride_ = owner.stride();
   }
 }
 

--- a/src/tensors.hpp
+++ b/src/tensors.hpp
@@ -112,19 +112,23 @@ public:
            resource r_ = resrc, typename = enable_for_host<r_>>
   vector(fk::matrix<P> const &);
 
-  template<mem_type m_ = mem, typename = enable_for_view<m_>>
-  explicit vector(fk::vector<P, mem_type::owner, resrc> &vec,
-                  int const start_index, int const stop_index);
-  template<mem_type m_ = mem, typename = enable_for_const_view<m_>>
-  explicit vector(fk::vector<P, mem_type::owner, resrc> const &vec,
-                  int const start_index, int const stop_index);
+  template<mem_type m_ = mem, typename = enable_for_view<m_>, mem_type omem,
+           mem_type om_ = omem, typename = disable_for_const_view<om_>>
+  explicit vector(fk::vector<P, omem, resrc> &vec, int const start_index,
+                  int const stop_index);
+  template<mem_type m_ = mem, typename = enable_for_const_view<m_>,
+           mem_type omem>
+  explicit vector(fk::vector<P, omem, resrc> const &vec, int const start_index,
+                  int const stop_index);
 
   // overloads for default case - whole vector
-  template<mem_type m_ = mem, typename = enable_for_view<m_>>
-  explicit vector(fk::vector<P, mem_type::owner, resrc> &owner);
+  template<mem_type m_ = mem, typename = enable_for_view<m_>, mem_type omem,
+           mem_type om_ = omem, typename = disable_for_const_view<om_>>
+  explicit vector(fk::vector<P, omem, resrc> &owner);
 
-  template<mem_type m_ = mem, typename = enable_for_const_view<m_>>
-  explicit vector(fk::vector<P, mem_type::owner, resrc> const &owner);
+  template<mem_type m_ = mem, typename = enable_for_const_view<m_>,
+           mem_type omem>
+  explicit vector(fk::vector<P, omem, resrc> const &owner);
 
   // create vector view from matrix
   // const view version
@@ -133,7 +137,8 @@ public:
   explicit vector(fk::matrix<P, omem, resrc> const &source, int const col_index,
                   int const row_start, int const row_stop);
   // modifiable view version
-  template<mem_type m_ = mem, typename = enable_for_view<m_>, mem_type omem>
+  template<mem_type m_ = mem, typename = enable_for_view<m_>, mem_type omem,
+           mem_type om_ = omem, typename = disable_for_const_view<om_>>
   explicit vector(fk::matrix<P, omem, resrc> &source, int const col_index,
                   int const row_start, int const row_stop);
 
@@ -320,10 +325,10 @@ public:
 private:
   // const/nonconst view constructors delegate to this private constructor
   // delegated is a dummy variable to enable resolution
-  template<mem_type m_ = mem, typename = enable_for_all_views<m_>>
-  explicit vector(fk::vector<P, mem_type::owner, resrc> const &vec,
-                  int const start_index, int const stop_index,
-                  bool const delegated);
+  template<mem_type m_ = mem, typename = enable_for_all_views<m_>,
+           mem_type omem>
+  explicit vector(fk::vector<P, omem, resrc> const &vec, int const start_index,
+                  int const stop_index, bool const delegated);
 
   // matrix view from vector owner constructors (both const/nonconst) delegate
   // to this private constructor, also with a dummy variable
@@ -357,23 +362,25 @@ public:
   template<mem_type m_ = mem, typename = enable_for_owner<m_>>
   matrix(std::initializer_list<std::initializer_list<P>> list);
 
-  // create const view from owner
-  template<mem_type m_ = mem, typename = enable_for_const_view<m_>>
-  explicit matrix(fk::matrix<P, mem_type::owner, resrc> const &owner,
-                  int const start_row, int const stop_row, int const start_col,
-                  int const stop_col);
-  // create modifiable view from owner
-  template<mem_type m_ = mem, typename = enable_for_view<m_>>
-  explicit matrix(fk::matrix<P, mem_type::owner, resrc> &owner,
-                  int const start_row, int const stop_row, int const start_col,
-                  int const stop_col);
+  // create const view
+  template<mem_type m_ = mem, typename = enable_for_const_view<m_>,
+           mem_type omem>
+  explicit matrix(fk::matrix<P, omem, resrc> const &owner, int const start_row,
+                  int const stop_row, int const start_col, int const stop_col);
+  // create modifiable view
+  template<mem_type m_ = mem, typename = enable_for_view<m_>, mem_type omem,
+           mem_type om_ = omem, typename = disable_for_const_view<om_>>
+  explicit matrix(fk::matrix<P, omem, resrc> &owner, int const start_row,
+                  int const stop_row, int const start_col, int const stop_col);
 
   // overloads for default case - whole matrix
-  template<mem_type m_ = mem, typename = enable_for_const_view<m_>>
-  explicit matrix(fk::matrix<P, mem_type::owner, resrc> const &owner);
+  template<mem_type m_ = mem, typename = enable_for_const_view<m_>,
+           mem_type omem>
+  explicit matrix(fk::matrix<P, omem, resrc> const &owner);
 
-  template<mem_type m_ = mem, typename = enable_for_view<m_>>
-  explicit matrix(fk::matrix<P, mem_type::owner, resrc> &owner);
+  template<mem_type m_ = mem, typename = enable_for_view<m_>, mem_type omem,
+           mem_type om_ = omem, typename = disable_for_const_view<om_>>
+  explicit matrix(fk::matrix<P, omem, resrc> &owner);
 
   // create matrix view from vector
   // const view version
@@ -382,7 +389,8 @@ public:
   explicit matrix(fk::vector<P, omem, resrc> const &source, int const num_rows,
                   int const num_cols, int const start_index = 0);
   // modifiable view version
-  template<mem_type m_ = mem, typename = enable_for_view<m_>, mem_type omem>
+  template<mem_type m_ = mem, typename = enable_for_view<m_>, mem_type omem,
+           mem_type om_ = omem, typename = disable_for_const_view<om_>>
   explicit matrix(fk::vector<P, omem, resrc> &source, int const num_rows,
                   int const num_cols, int const start_index = 0);
 
@@ -596,10 +604,11 @@ public:
 private:
   // matrix view constructors (both const/nonconst) delegate to this private
   // constructor delegated is a dummy variable to assist in overload resolution
-  template<mem_type m_ = mem, typename = enable_for_all_views<m_>>
-  explicit matrix(fk::matrix<P, mem_type::owner, resrc> const &owner,
-                  int const start_row, int const stop_row, int const start_col,
-                  int const stop_col, bool const delegated);
+  template<mem_type m_ = mem, typename = enable_for_all_views<m_>,
+           mem_type omem>
+  explicit matrix(fk::matrix<P, omem, resrc> const &owner, int const start_row,
+                  int const stop_row, int const start_col, int const stop_col,
+                  bool const delegated);
 
   // matrix view from vector owner constructors (both const/nonconst) delegate
   // to this private constructor, also with a dummy variable
@@ -854,18 +863,17 @@ fk::vector<P, mem, resrc>::vector(fk::matrix<P> const &mat)
 // vector view constructor given a start and stop index
 // modifiable view version - delegates to private constructor
 template<typename P, mem_type mem, resource resrc>
-template<mem_type, typename>
-fk::vector<P, mem, resrc>::vector(fk::vector<P, mem_type::owner, resrc> &vec,
+template<mem_type, typename, mem_type omem, mem_type, typename>
+fk::vector<P, mem, resrc>::vector(fk::vector<P, omem, resrc> &vec,
                                   int const start_index, int const stop_index)
     : vector(vec, start_index, stop_index, true)
 {}
 
 // const view version - delegates to private constructor
 template<typename P, mem_type mem, resource resrc>
-template<mem_type, typename>
-fk::vector<P, mem, resrc>::vector(
-    fk::vector<P, mem_type::owner, resrc> const &vec, int const start_index,
-    int const stop_index)
+template<mem_type, typename, mem_type omem>
+fk::vector<P, mem, resrc>::vector(fk::vector<P, omem, resrc> const &vec,
+                                  int const start_index, int const stop_index)
     : vector(vec, start_index, stop_index, true)
 {}
 
@@ -873,16 +881,15 @@ fk::vector<P, mem, resrc>::vector(
 // of viewing the entire owner
 // const view version
 template<typename P, mem_type mem, resource resrc>
-template<mem_type, typename>
-fk::vector<P, mem, resrc>::vector(
-    fk::vector<P, mem_type::owner, resrc> const &a)
+template<mem_type, typename, mem_type omem>
+fk::vector<P, mem, resrc>::vector(fk::vector<P, omem, resrc> const &a)
     : vector(a, 0, std::max(0, a.size() - 1), true)
 {}
 
 // modifiable view version
 template<typename P, mem_type mem, resource resrc>
-template<mem_type, typename>
-fk::vector<P, mem, resrc>::vector(fk::vector<P, mem_type::owner, resrc> &a)
+template<mem_type, typename, mem_type omem, mem_type, typename>
+fk::vector<P, mem, resrc>::vector(fk::vector<P, omem, resrc> &a)
     : vector(a, 0, std::max(0, a.size() - 1), true)
 {}
 
@@ -899,7 +906,7 @@ fk::vector<P, mem, resrc>::vector(fk::matrix<P, omem, resrc> const &source,
 
 // modifiable view version - delegates to private constructor
 template<typename P, mem_type mem, resource resrc>
-template<mem_type, typename, mem_type omem>
+template<mem_type, typename, mem_type omem, mem_type, typename>
 fk::vector<P, mem, resrc>::vector(fk::matrix<P, omem, resrc> &source,
                                   int const column_index, int const row_start,
                                   int const row_stop)
@@ -1520,10 +1527,10 @@ int fk::vector<P, mem, resrc>::get_num_views() const
 
 // const/nonconst view constructors delegate to this private constructor
 template<typename P, mem_type mem, resource resrc>
-template<mem_type, typename>
-fk::vector<P, mem, resrc>::vector(
-    fk::vector<P, mem_type::owner, resrc> const &vec, int const start_index,
-    int const stop_index, bool const delegated)
+template<mem_type, typename, mem_type omem>
+fk::vector<P, mem, resrc>::vector(fk::vector<P, omem, resrc> const &vec,
+                                  int const start_index, int const stop_index,
+                                  bool const delegated)
     : ref_count_{vec.ref_count_}
 {
   // ignore dummy argument to avoid compiler warnings
@@ -1638,18 +1645,18 @@ fk::matrix<P, mem, resrc>::matrix(
 // create view from owner - const view version
 // delegates to private constructor
 template<typename P, mem_type mem, resource resrc>
-template<mem_type, typename>
-fk::matrix<P, mem, resrc>::matrix(
-    fk::matrix<P, mem_type::owner, resrc> const &owner, int const start_row,
-    int const stop_row, int const start_col, int const stop_col)
+template<mem_type, typename, mem_type omem>
+fk::matrix<P, mem, resrc>::matrix(fk::matrix<P, omem, resrc> const &owner,
+                                  int const start_row, int const stop_row,
+                                  int const start_col, int const stop_col)
     : matrix(owner, start_row, stop_row, start_col, stop_col, true)
 {}
 
 // create view from owner - modifiable view version
 // delegates to private constructor
 template<typename P, mem_type mem, resource resrc>
-template<mem_type, typename>
-fk::matrix<P, mem, resrc>::matrix(fk::matrix<P, mem_type::owner, resrc> &owner,
+template<mem_type, typename, mem_type omem, mem_type, typename>
+fk::matrix<P, mem, resrc>::matrix(fk::matrix<P, omem, resrc> &owner,
                                   int const start_row, int const stop_row,
                                   int const start_col, int const stop_col)
     : matrix(owner, start_row, stop_row, start_col, stop_col, true)
@@ -1657,16 +1664,15 @@ fk::matrix<P, mem, resrc>::matrix(fk::matrix<P, mem_type::owner, resrc> &owner,
 
 // overload for default case - whole matrix
 template<typename P, mem_type mem, resource resrc>
-template<mem_type, typename>
-fk::matrix<P, mem, resrc>::matrix(
-    fk::matrix<P, mem_type::owner, resrc> const &owner)
+template<mem_type, typename, mem_type omem>
+fk::matrix<P, mem, resrc>::matrix(fk::matrix<P, omem, resrc> const &owner)
     : matrix(owner, 0, std::max(0, owner.nrows() - 1), 0,
              std::max(0, owner.ncols() - 1), true)
 {}
 
 template<typename P, mem_type mem, resource resrc>
-template<mem_type, typename>
-fk::matrix<P, mem, resrc>::matrix(fk::matrix<P, mem_type::owner, resrc> &owner)
+template<mem_type, typename, mem_type omem, mem_type, typename>
+fk::matrix<P, mem, resrc>::matrix(fk::matrix<P, omem, resrc> &owner)
     : matrix(owner, 0, std::max(0, owner.nrows() - 1), 0,
              std::max(0, owner.ncols() - 1), true)
 {}
@@ -1684,7 +1690,7 @@ fk::matrix<P, mem, resrc>::matrix(fk::vector<P, omem, resrc> const &source,
 // create matrix view of existing vector
 // modifiable view version - delegates to private constructor
 template<typename P, mem_type mem, resource resrc>
-template<mem_type, typename, mem_type omem>
+template<mem_type, typename, mem_type omem, mem_type, typename>
 fk::matrix<P, mem, resrc>::matrix(fk::vector<P, omem, resrc> &source,
                                   int const num_rows, int const num_cols,
                                   int const start_index)
@@ -2575,11 +2581,11 @@ int fk::matrix<P, mem, resrc>::get_num_views() const
 // public const/nonconst view constructors delegate to this private
 // constructor
 template<typename P, mem_type mem, resource resrc>
-template<mem_type, typename>
-fk::matrix<P, mem, resrc>::matrix(
-    fk::matrix<P, mem_type::owner, resrc> const &owner, int const start_row,
-    int const stop_row, int const start_col, int const stop_col,
-    bool const delegated)
+template<mem_type, typename, mem_type omem>
+fk::matrix<P, mem, resrc>::matrix(fk::matrix<P, omem, resrc> const &owner,
+                                  int const start_row, int const stop_row,
+                                  int const start_col, int const stop_col,
+                                  bool const delegated)
     : ref_count_(owner.ref_count_)
 {
   ignore(delegated);

--- a/src/tensors_tests.cpp
+++ b/src/tensors_tests.cpp
@@ -1481,8 +1481,11 @@ TEMPLATE_TEST_CASE("fk::vector device functions", "[tensors]", double, float,
       fk::vector<TestType, mem_type::const_view, resource::device> const
           vect_cview(vect);
       REQUIRE(vect.get_num_views() == 1);
-      fk::vector<TestType, mem_type::view, resource::device> vect_view(vect);
+      fk::vector<TestType, mem_type::const_view, resource::device> const
+          vect_cview2(vect_cview);
       REQUIRE(vect.get_num_views() == 2);
+      fk::vector<TestType, mem_type::view, resource::device> vect_view(vect);
+      REQUIRE(vect.get_num_views() == 3);
 
       {
         fk::vector<TestType, mem_type::view, resource::device> const

--- a/src/tensors_tests.cpp
+++ b/src/tensors_tests.cpp
@@ -89,22 +89,46 @@ TEMPLATE_TEST_CASE("fk::vector interface: constructors, copy/move", "[tensors]",
     // specify range (start/stop inclusive)
     fk::vector<TestType, mem_type::view> test_v2(gold_copy, 1, 3);
     fk::vector<TestType> const gold_portion = {3, 4, 5};
+    fk::vector<TestType, mem_type::view> test_vb(gold_copy);
+    fk::vector<TestType, mem_type::view> test_v3(test_vb, 1, 3);
     REQUIRE(test_v2 == gold_portion);
+    REQUIRE(test_v3 == gold_portion);
+
     gold_copy(2) = 1000;
     REQUIRE(test_v2 == gold_copy.extract(1, 3));
+    REQUIRE(test_v3 == gold_copy.extract(1, 3));
+
     REQUIRE(gold_copy != gold);
     REQUIRE(test_v2 != gold_portion);
+    REQUIRE(test_v3 != gold_portion);
+
     test_v2(2) = 10;
+
     REQUIRE(test_v2 == gold_copy.extract(1, 3));
+    REQUIRE(test_v3 == gold_copy.extract(1, 3));
     REQUIRE(gold_copy != gold);
     REQUIRE(test_v2 != gold_portion);
+    REQUIRE(test_v3 != gold_portion);
+
+    test_v3(0) = 4;
+    REQUIRE(test_v2 == gold_copy.extract(1, 3));
+    REQUIRE(test_v3 == gold_copy.extract(1, 3));
+    REQUIRE(gold_copy != gold);
+    REQUIRE(test_v2 != gold_portion);
+    REQUIRE(test_v3 != gold_portion);
 
     // empty case
     fk::vector<TestType> empty;
-    fk::vector<TestType, mem_type::view> const empty_v(empty);
+    fk::vector<TestType, mem_type::view> empty_v(empty);
+
+    fk::vector<TestType, mem_type::view> empty_v2(empty_v);
     REQUIRE(empty_v == empty);
+    REQUIRE(empty_v == empty_v2);
+    REQUIRE(empty_v2 == empty);
     REQUIRE(empty_v.data() == nullptr);
     REQUIRE(empty_v.size() == 0);
+    REQUIRE(empty_v2.data() == nullptr);
+    REQUIRE(empty_v2.size() == 0);
   }
 
   SECTION("construct const view from owner")
@@ -121,12 +145,25 @@ TEMPLATE_TEST_CASE("fk::vector interface: constructors, copy/move", "[tensors]",
     REQUIRE(test_v2 == gold_portion);
     REQUIRE(test_v2.data() == gold.data() + 1);
 
+    // from another const view
+    fk::vector<TestType, mem_type::const_view> const test_v3(test_v2, 1, 2);
+    REQUIRE(test_v3.size() == 2);
+    fk::vector<TestType> const gold_portion_2 = {4, 5};
+    REQUIRE(test_v3 == gold_portion_2);
+    REQUIRE(test_v3.data() == gold.data() + 2);
+
     // empty case
     fk::vector<TestType> const empty;
     fk::vector<TestType, mem_type::const_view> const empty_v(empty);
+    fk::vector<TestType, mem_type::const_view> const empty_v2(empty_v);
     REQUIRE(empty_v == empty);
+    REQUIRE(empty_v2 == empty);
+    REQUIRE(empty_v == empty_v);
+
     REQUIRE(empty_v.data() == nullptr);
     REQUIRE(empty_v.size() == 0);
+    REQUIRE(empty_v2.data() == nullptr);
+    REQUIRE(empty_v2.size() == 0);
   }
 
   SECTION("construct owner from view")
@@ -973,21 +1010,30 @@ TEMPLATE_TEST_CASE("fk::vector utilities", "[tensors]", double, float, int)
     fk::vector<TestType, mem_type::view> const test_view(test);
     REQUIRE(test.get_num_views() == 1);
 
-    // creating const views increments view count
-    fk::vector<TestType, mem_type::const_view> const test_view_2(test);
+    fk::vector<TestType, mem_type::view> const test_view_2(test_view);
     REQUIRE(test.get_num_views() == 2);
+
+    fk::vector<TestType, mem_type::const_view> const test_cview(test_view);
+    REQUIRE(test.get_num_views() == 3);
+
+    // creating const views increments view count
+    fk::vector<TestType, mem_type::const_view> const test_cview_2(test);
+    REQUIRE(test.get_num_views() == 4);
+
+    fk::vector<TestType, mem_type::const_view> const test_cview_3(test_cview_2);
+    REQUIRE(test.get_num_views() == 5);
 
     // copies have a fresh view count
     fk::vector<TestType> const test_cp(test);
     REQUIRE(test_cp.get_num_views() == 0);
-    REQUIRE(test.get_num_views() == 2);
+    REQUIRE(test.get_num_views() == 5);
 
     // test that view count gets decremented when views go out of scope
     {
       fk::vector<TestType, mem_type::const_view> const test_view_3(test);
-      REQUIRE(test.get_num_views() == 3);
+      REQUIRE(test.get_num_views() == 6);
     }
-    REQUIRE(test.get_num_views() == 2);
+    REQUIRE(test.get_num_views() == 5);
   }
 } // end fk::vector utilities
 
@@ -1490,16 +1536,19 @@ TEMPLATE_TEST_CASE("fk::vector device functions", "[tensors]", double, float,
       {
         fk::vector<TestType, mem_type::view, resource::device> const
             vect_view_2(vect_view);
-        REQUIRE(vect.get_num_views() == 3);
+        REQUIRE(vect.get_num_views() == 4);
         fk::vector<TestType, mem_type::const_view, resource::device> const
             vect_cview_2(vect_cview);
-        REQUIRE(vect.get_num_views() == 4);
+        REQUIRE(vect.get_num_views() == 5);
+        fk::vector<TestType, mem_type::view, resource::device> const vect_view3(
+            vect_view_2);
+        REQUIRE(vect.get_num_views() == 6);
       }
-      REQUIRE(vect.get_num_views() == 2);
+      REQUIRE(vect.get_num_views() == 3);
 
       fk::vector<TestType, mem_type::view, resource::device> const view_moved(
           std::move(vect_view));
-      REQUIRE(vect.get_num_views() == 2);
+      REQUIRE(vect.get_num_views() == 3);
     }
 
     // view semantics on device
@@ -1511,6 +1560,13 @@ TEMPLATE_TEST_CASE("fk::vector device functions", "[tensors]", double, float,
           vect_cview(vect);
       REQUIRE(vect_view.data() == vect.data());
       REQUIRE(vect_cview.data() == vect.data());
+      fk::vector<TestType, mem_type::view, resource::device> vect_view_2(
+          vect_view);
+      REQUIRE(vect_view_2.data() == vect.data());
+      fk::vector<TestType, mem_type::const_view, resource::device> const
+          vect_cview_2(vect_cview);
+      REQUIRE(vect_cview_2.data() == vect.data());
+
       {
         fk::vector<TestType, mem_type::owner, resource::host> const copy(
             vect_view.clone_onto_host());
@@ -1518,6 +1574,12 @@ TEMPLATE_TEST_CASE("fk::vector device functions", "[tensors]", double, float,
             vect_cview.clone_onto_host());
         REQUIRE(copy == gold);
         REQUIRE(ccopy == gold);
+        fk::vector<TestType, mem_type::owner, resource::host> const copy_2(
+            vect_view_2.clone_onto_host());
+        fk::vector<TestType, mem_type::owner, resource::host> const ccopy_2(
+            vect_cview_2.clone_onto_host());
+        REQUIRE(copy_2 == gold);
+        REQUIRE(ccopy_2 == gold);
       }
       fk::vector<TestType, mem_type::owner, resource::host> const gold_2(
           {1, 2, 3, 4, 5});
@@ -1525,7 +1587,43 @@ TEMPLATE_TEST_CASE("fk::vector device functions", "[tensors]", double, float,
       {
         fk::vector<TestType, mem_type::owner, resource::host> const copy(
             vect.clone_onto_host());
+
+        fk::vector<TestType, mem_type::owner, resource::host> const copy_2(
+            vect_view_2.clone_onto_host());
+
+        fk::vector<TestType, mem_type::owner, resource::host> const copy_3(
+            vect_cview.clone_onto_host());
+
+        fk::vector<TestType, mem_type::owner, resource::host> const copy_4(
+            vect_cview_2.clone_onto_host());
+
         REQUIRE(copy == gold_2);
+        REQUIRE(copy_2 == gold_2);
+        REQUIRE(copy_3 == gold_2);
+        REQUIRE(copy_4 == gold_2);
+      }
+
+      fk::vector<TestType, mem_type::owner, resource::host> const gold_3(
+          {3, 5, 7, 9, 11});
+      vect_view_2.transfer_from(gold_3);
+
+      {
+        fk::vector<TestType, mem_type::owner, resource::host> const copy(
+            vect.clone_onto_host());
+
+        fk::vector<TestType, mem_type::owner, resource::host> const copy_2(
+            vect_view.clone_onto_host());
+
+        fk::vector<TestType, mem_type::owner, resource::host> const copy_3(
+            vect_cview.clone_onto_host());
+
+        fk::vector<TestType, mem_type::owner, resource::host> const copy_4(
+            vect_cview_2.clone_onto_host());
+
+        REQUIRE(copy == gold_3);
+        REQUIRE(copy_2 == gold_3);
+        REQUIRE(copy_3 == gold_3);
+        REQUIRE(copy_4 == gold_3);
       }
     }
   }
@@ -1818,27 +1916,42 @@ TEMPLATE_TEST_CASE("fk::matrix interface: constructors, copy/move", "[tensors]",
   {
     // default one
     fk::matrix<TestType> base(gold);
-    fk::matrix<TestType, mem_type::view> const view(base);
+    fk::matrix<TestType, mem_type::view> view(base);
     REQUIRE(base == view);
 
-    // ranged
-    fk::matrix<TestType, mem_type::view> const view_2(base, 0, 2, 1, 2);
-    fk::matrix<TestType> const gold_partial_2 =
-        gold.extract_submatrix(0, 1, 3, 2);
-    REQUIRE(view_2 == gold_partial_2);
+    fk::matrix<TestType, mem_type::view> view_2(view);
+    REQUIRE(base == view_2);
+    REQUIRE(view == view_2);
 
-    fk::matrix<TestType, mem_type::view> const view_3(base, 1, 1, 0, 2);
+    // ranged
+    fk::matrix<TestType, mem_type::view> view_3(base, 0, 2, 1, 2);
     fk::matrix<TestType> const gold_partial_3 =
-        gold.extract_submatrix(1, 0, 1, 3);
+        gold.extract_submatrix(0, 1, 3, 2);
     REQUIRE(view_3 == gold_partial_3);
+
+    fk::matrix<TestType, mem_type::view> const view_4(view_3, 1, 1, 0, 1);
+
+    fk::matrix<TestType> const gold_partial_4 =
+        gold.extract_submatrix(1, 1, 1, 2);
+    REQUIRE(view_4 == gold_partial_4);
   }
 
   SECTION("const views constructor")
   {
     // default one
-    fk::matrix<TestType> const base(gold);
+    fk::matrix<TestType> base(gold);
     fk::matrix<TestType, mem_type::const_view> const view(base);
     REQUIRE(base == view);
+
+    fk::matrix<TestType, mem_type::const_view> const view_v(view);
+    REQUIRE(base == view_v);
+    REQUIRE(view == view_v);
+
+    fk::matrix<TestType, mem_type::view> const view_b(base);
+    fk::matrix<TestType, mem_type::const_view> const view_view(view_b);
+
+    REQUIRE(view_b == view_view);
+    REQUIRE(base == view_view);
 
     // ranged
     fk::matrix<TestType, mem_type::const_view> const view_2(gold, 0, 2, 1, 2);
@@ -1846,10 +1959,16 @@ TEMPLATE_TEST_CASE("fk::matrix interface: constructors, copy/move", "[tensors]",
         gold.extract_submatrix(0, 1, 3, 2);
     REQUIRE(view_2 == gold_partial_2);
 
-    fk::matrix<TestType, mem_type::const_view> const view_3(gold, 1, 1, 0, 2);
+    fk::matrix<TestType, mem_type::const_view> const view_3(view_2, 1, 1, 0, 1);
     fk::matrix<TestType> const gold_partial_3 =
-        gold.extract_submatrix(1, 0, 1, 3);
+        gold.extract_submatrix(1, 1, 1, 2);
     REQUIRE(view_3 == gold_partial_3);
+
+    fk::matrix<TestType, mem_type::view> const view_4(base);
+    fk::matrix<TestType, mem_type::const_view> const view_5(view_4, 0, 1, 0, 1);
+    fk::matrix<TestType> const gold_partial_4 =
+        gold.extract_submatrix(0, 0, 2, 2);
+    REQUIRE(view_5 == gold_partial_4);
   }
 
   SECTION("views from vector constructor")
@@ -3463,9 +3582,16 @@ TEMPLATE_TEST_CASE("fk::matrix device transfer functions", "[tensors]", double,
     REQUIRE(mat.get_num_views() == 2);
     fk::matrix<TestType, mem_type::view, resource::device> mat_view_5(mat);
     REQUIRE(mat.get_num_views() == 3);
-    fk::matrix<TestType, mem_type::view, resource::device> const mat_view_6(
+    fk::matrix<TestType, mem_type::view, resource::device> mat_view_6(
         std::move(mat_view_5));
     REQUIRE(mat.get_num_views() == 3);
+
+    fk::matrix<TestType, mem_type::view, resource::device> const mat_view_7(
+        mat_view_6);
+    REQUIRE(mat.get_num_views() == 4);
+    fk::matrix<TestType, mem_type::const_view, resource::device> const
+        mat_view_8(mat_view_6);
+    REQUIRE(mat.get_num_views() == 5);
   }
 
   SECTION("views - semantics on device")
@@ -3476,16 +3602,38 @@ TEMPLATE_TEST_CASE("fk::matrix device transfer functions", "[tensors]", double,
     fk::matrix<TestType, mem_type::const_view, resource::device> const
         mat_cview(mat);
     fk::matrix<TestType, mem_type::view, resource::device> mat_view(mat);
+
+    fk::matrix<TestType, mem_type::view, resource::device> mat_view_v(mat_view);
+    fk::matrix<TestType, mem_type::const_view, resource::device> const
+        mat_view_cv(mat_view);
+    fk::matrix<TestType, mem_type::const_view, resource::device> const
+        mat_view_cv_2(mat_cview);
+
     REQUIRE(mat_view.data() == mat.data());
     REQUIRE(mat_cview.data() == mat.data());
+    REQUIRE(mat_view_v.data() == mat.data());
+    REQUIRE(mat_view_cv.data() == mat.data());
+    REQUIRE(mat_view_cv_2.data() == mat.data());
 
     {
       fk::matrix<TestType, mem_type::owner, resource::host> const copy(
           mat_view.clone_onto_host());
       fk::matrix<TestType, mem_type::owner, resource::host> const ccopy(
           mat_cview.clone_onto_host());
+
+      fk::matrix<TestType, mem_type::owner, resource::host> const copy_2(
+          mat_view_v.clone_onto_host());
+      fk::matrix<TestType, mem_type::owner, resource::host> const ccopy_2(
+          mat_view_cv.clone_onto_host());
+      fk::matrix<TestType, mem_type::owner, resource::host> const ccopy_3(
+          mat_view_cv_2.clone_onto_host());
+
       REQUIRE(copy == gold);
       REQUIRE(ccopy == gold);
+
+      REQUIRE(copy_2 == gold);
+      REQUIRE(ccopy_2 == gold);
+      REQUIRE(ccopy_3 == gold);
     }
     fk::matrix<TestType, mem_type::owner, resource::host> const gold_2(
         {{1, 2, 3, 4, 5}, {11, 12, 13, 14, 15}});
@@ -3493,7 +3641,42 @@ TEMPLATE_TEST_CASE("fk::matrix device transfer functions", "[tensors]", double,
     {
       fk::matrix<TestType, mem_type::owner, resource::host> const copy(
           mat.clone_onto_host());
+
+      fk::matrix<TestType, mem_type::owner, resource::host> const copy_2(
+          mat_view_cv.clone_onto_host());
+
+      fk::matrix<TestType, mem_type::owner, resource::host> const copy_3(
+          mat_view_v.clone_onto_host());
+
+      fk::matrix<TestType, mem_type::owner, resource::host> const copy_4(
+          mat_view_cv_2.clone_onto_host());
+
       REQUIRE(copy == gold_2);
+      REQUIRE(copy_2 == gold_2);
+      REQUIRE(copy_3 == gold_2);
+      REQUIRE(copy_4 == gold_2);
+    }
+
+    fk::matrix<TestType, mem_type::owner, resource::host> const gold_3(
+        {{1, 2, 3, 4, 5}, {15, 16, 17, 18, 19}});
+    mat_view_v.transfer_from(gold_2);
+    {
+      fk::matrix<TestType, mem_type::owner, resource::host> const copy(
+          mat.clone_onto_host());
+
+      fk::matrix<TestType, mem_type::owner, resource::host> const copy_2(
+          mat_view_cv.clone_onto_host());
+
+      fk::matrix<TestType, mem_type::owner, resource::host> const copy_3(
+          mat_view_v.clone_onto_host());
+
+      fk::matrix<TestType, mem_type::owner, resource::host> const copy_4(
+          mat_view_cv_2.clone_onto_host());
+
+      REQUIRE(copy == gold_2);
+      REQUIRE(copy_2 == gold_2);
+      REQUIRE(copy_3 == gold_2);
+      REQUIRE(copy_4 == gold_2);
     }
   }
 


### PR DESCRIPTION
Some view constructors (e.g. matrix view from vector view) allowed building a view of an existing view. Others were restricted to owners only. Standardize by allowing views from existing views in all cases, and add appropriate tests. Needed for the new basis transform method #292.