### PR TITLE
fix error causing system matrix to be built every time step (implicit)

### DIFF
--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -194,6 +194,8 @@ implicit_time_advance(PDE<P> const &pde, element_table const &table,
 
   if (first_time || update_system)
   {
+    first_time = false;
+
     A.clear_and_resize(A_size, A_size);
     for (auto const &chunk : chunks)
     {
@@ -222,8 +224,6 @@ implicit_time_advance(PDE<P> const &pde, element_table const &table,
       ignore(ipiv);
       break;
     }
-
-    first_time = false;
   } // end first time/update system
 
   switch (solver)


### PR DESCRIPTION
early return in switch statement caused bug where `first_time` variable not correctly toggled to false.