### PR TITLE
Fix RPATH to libkron

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,17 +80,15 @@ if(ASGARD_USE_OPENMP)
   endif()
 endif()
 
-set(CMAKE_INSTALL_RPATH ${KRON_PATH})
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
 # build component to interface with Ed's kronmult lib
 add_library(kronmult_cuda SHARED src/device/kronmult_cuda.cpp)
 if(ASGARD_USE_CUDA)
   find_package(CUDA 9.0 REQUIRED)
   include_directories(${CUDA_INCLUDE_DIRS})
-  enable_language(CUDA)
-  set_target_properties( kronmult_cuda PROPERTIES COMPILE_FLAGS "-arch sm_70 -g -Xlinker -rpath,${KRON_PATH} --ptxas-options=-O3")
+  enable_language(CUDA) 
   set_source_files_properties( src/device/kronmult_cuda.cpp PROPERTIES LANGUAGE CUDA ) # no .cu extension
+  set_target_properties( kronmult_cuda PROPERTIES COMPILE_FLAGS "-arch sm_70 -g --ptxas-options=-O3")
+  set_target_properties( kronmult_cuda PROPERTIES LINK_FLAGS "-Wl,-rpath,${KRON_PATH}")
 endif()
 target_include_directories (kronmult_cuda PRIVATE ${KRON_PATH} ${CMAKE_BINARY_DIR})
 if(ASGARD_USE_MKL)
@@ -100,7 +98,6 @@ if(ASGARD_USE_MKL)
     target_compile_options (kronmult_cuda PRIVATE "-fopenmp") # CMAKE doesn't handle MKL openmp link properly
   endif()
 endif()
-
 
 if(ASGARD_USE_MPI)
   find_package(MPI REQUIRED)
@@ -202,9 +199,9 @@ if (ASGARD_USE_OPENMP AND NOT ASGARD_USE_MKL)
 endif ()
 
 if (ASGARD_USE_CUDA) 
-target_link_libraries(kronmult_cuda PUBLIC ${KRON_LIB})
+   target_link_libraries(kronmult_cuda PRIVATE ${KRON_LIB})
 else ()
-target_link_libraries(kronmult_cuda PUBLIC "-Wl,-rpath,${KRON_PATH} ${KRON_LIB}")
+   target_link_libraries(kronmult_cuda PRIVATE "-Wl,-rpath,${KRON_PATH} ${KRON_LIB}")
 endif ()
 
 if (ASGARD_USE_OPENMP AND NOT ASGARD_USE_MKL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ if(ASGARD_USE_CUDA)
   find_package(CUDA 9.0 REQUIRED)
   include_directories(${CUDA_INCLUDE_DIRS})
   enable_language(CUDA)
-  set_target_properties( kronmult_cuda PROPERTIES COMPILE_FLAGS "-arch sm_70 -g -Xlinker=Wl,-rpath,${KRON_PATH} --ptxas-options=-O3")
+  set_target_properties( kronmult_cuda PROPERTIES COMPILE_FLAGS "-arch sm_70 -g -Xlinker -rpath,${KRON_PATH} --ptxas-options=-O3")
   set_source_files_properties( src/device/kronmult_cuda.cpp PROPERTIES LANGUAGE CUDA ) # no .cu extension
 endif()
 target_include_directories (kronmult_cuda PRIVATE ${KRON_PATH} ${CMAKE_BINARY_DIR})

--- a/contrib/contrib.cmake
+++ b/contrib/contrib.cmake
@@ -185,7 +185,7 @@ endif ()
 #
 ###############################################################################
 
-set(KRON_PATH ${CMAKE_SOURCE_DIR}/contrib/kronmult/src/kronmult-ext)
+set(KRON_PATH "${CMAKE_SOURCE_DIR}/contrib/kronmult/src/kronmult-ext")
 find_library(KRON_LIB kron PATHS ${KRON_PATH})
 
 if(NOT KRON_LIB)


### PR DESCRIPTION
hackathon folks pointed out problems with rpath embedding.

shows "libkron.so not found" when trying to run.

pass appropriate flags to linker through nvcc.

addresses #303 .