### PR TITLE
constify options, eliminate redundant state between pde and opts

### DIFF
--- a/src/batch_tests.cpp
+++ b/src/batch_tests.cpp
@@ -928,7 +928,7 @@ void batch_builder_test(int const degree, int const level, PDE<P> &pde,
                                          std::to_string(degree), grid_str};
   options const o                     = make_options(args);
 
-  element_table const elem_table(o, pde.num_dims);
+  element_table const elem_table(o, level, pde.num_dims);
   int const num_ranks = 1;
   int const my_rank   = 0;
   auto const plan     = get_plan(num_ranks, elem_table);

--- a/src/boundary_conditions_tests.cpp
+++ b/src/boundary_conditions_tests.cpp
@@ -13,7 +13,7 @@ void test_boundary_condition_vector(PDE<P> &pde,
   int const level       = d.get_level();
   int const degree      = d.get_degree();
 
-  element_table table(make_options({"-l", std::to_string(level)}),
+  element_table table(make_options({"-l", std::to_string(level)}), level,
                       pde.num_dims);
 
   basis::wavelet_transform<P, resource::host> const transformer(level, degree);
@@ -51,8 +51,10 @@ void test_compute_boundary_condition(PDE<P> &pde,
                                      P const tol_factor)
 {
   dimension<P> const &d = pde.get_dimensions()[0];
-  int const level       = d.get_level();
-  int const degree      = d.get_degree();
+
+  // FIXME assume uniform degree
+  int const level  = d.get_level();
+  int const degree = d.get_degree();
 
   basis::wavelet_transform<P, resource::host> const transformer(level, degree);
   generate_all_coefficients<P>(pde, transformer);
@@ -61,9 +63,8 @@ void test_compute_boundary_condition(PDE<P> &pde,
 
   std::vector<dimension<P>> const &dimensions = pde.get_dimensions();
 
-  element_table table(
-      make_options({"-l", std::to_string(dimensions[0].get_level())}),
-      pde.num_dims);
+  element_table table(make_options({"-l", std::to_string(level)}), level,
+                      pde.num_dims);
 
   /* this timestep value must be consistent with the value used in the gold data
      generation scripts in matlab */
@@ -151,7 +152,7 @@ TEMPLATE_TEST_CASE("problem separability", "[boundary_condition]", double,
     int const degree = 5;
     auto const pde   = make_PDE<TestType>(PDE_opts::diffusion_1, level, degree);
 
-    element_table table(make_options({"-l", std::to_string(level)}),
+    element_table table(make_options({"-l", std::to_string(level)}), level,
                         pde->num_dims);
 
     basis::wavelet_transform<TestType, resource::host> const transformer(
@@ -195,7 +196,7 @@ TEMPLATE_TEST_CASE("problem separability", "[boundary_condition]", double,
     int const degree = 5;
     auto const pde   = make_PDE<TestType>(PDE_opts::diffusion_1, level, degree);
 
-    element_table table(make_options({"-l", std::to_string(level)}),
+    element_table table(make_options({"-l", std::to_string(level)}), level,
                         pde->num_dims);
 
     basis::wavelet_transform<TestType, resource::host> const transformer(

--- a/src/chunk_tests.cpp
+++ b/src/chunk_tests.cpp
@@ -143,7 +143,7 @@ void test_chunking(PDE<P> const &pde, int const ranks)
 
   options const o =
       make_options({"-l", std::to_string(level), "-d", std::to_string(degree)});
-  element_table const table(o, pde.num_dims);
+  element_table const table(o, level, pde.num_dims);
   auto const plan = get_plan(ranks, table);
 
   for (int limit_MB = workspace_min_MB; limit_MB <= workspace_max_MB;
@@ -303,7 +303,7 @@ void reduction_test(int const degree, int const level, PDE<P> const &pde)
   options const o =
       make_options({"-l", std::to_string(level), "-d", std::to_string(degree)});
 
-  element_table const elem_table(o, pde.num_dims);
+  element_table const elem_table(o, level, pde.num_dims);
 
   int const num_ranks = 1;
   auto const plan     = get_plan(num_ranks, elem_table);

--- a/src/connectivity_tests.cpp
+++ b/src/connectivity_tests.cpp
@@ -48,7 +48,7 @@ void test_connectivity(int const dims, int const levels,
 {
   std::string const grid_str = full_grid ? "-f" : "";
   options const o = make_options({"-l", std::to_string(levels), grid_str});
-  element_table const t(o, dims);
+  element_table const t(o, levels, dims);
   int const max_levels        = full_grid ? dims * levels : levels;
   list_set const connectivity = make_connectivity(t, dims, max_levels, levels);
 

--- a/src/device/kronmult_cuda_tests.cpp
+++ b/src/device/kronmult_cuda_tests.cpp
@@ -78,7 +78,7 @@ void test_kronmult_build(PDE<P> const &pde)
   std::vector<std::string> const args = {"-l", std::to_string(level), "-d",
                                          std::to_string(degree)};
   options const o                     = make_options(args);
-  element_table const table(o, pde.num_dims);
+  element_table const table(o, level, pde.num_dims);
   element_subgrid const my_subgrid(0, table.size() - 1, 0, table.size() - 1);
 
   P *element_x;

--- a/src/distribution_tests.cpp
+++ b/src/distribution_tests.cpp
@@ -150,7 +150,7 @@ TEST_CASE("rank subgrid function", "[distribution]")
     options const o = make_options(
         {"-l", std::to_string(level), "-d", std::to_string(degree)});
 
-    element_table const table(o, num_dims);
+    element_table const table(o, level, num_dims);
 
     int const num_ranks = 1;
     int const my_rank   = 0;
@@ -172,7 +172,7 @@ TEST_CASE("rank subgrid function", "[distribution]")
     options const o = make_options(
         {"-l", std::to_string(level), "-d", std::to_string(degree)});
 
-    element_table const table(o, num_dims);
+    element_table const table(o, level, num_dims);
 
     int const num_ranks  = 2;
     int const first_rank = 0;
@@ -203,7 +203,7 @@ TEST_CASE("rank subgrid function", "[distribution]")
     options const o = make_options(
         {"-l", std::to_string(level), "-d", std::to_string(degree)});
 
-    element_table const table(o, num_dims);
+    element_table const table(o, level, num_dims);
 
     int const num_ranks  = 4;
     int const first_rank = 0;
@@ -250,7 +250,7 @@ TEST_CASE("rank subgrid function", "[distribution]")
     options const o = make_options(
         {"-l", std::to_string(level), "-d", std::to_string(degree)});
 
-    element_table const table(o, num_dims);
+    element_table const table(o, level, num_dims);
 
     int const num_ranks = 9;
 
@@ -284,7 +284,7 @@ TEST_CASE("distribution plan function", "[distribution]")
     options const o = make_options(
         {"-l", std::to_string(level), "-d", std::to_string(degree)});
 
-    element_table const table(o, num_dims);
+    element_table const table(o, level, num_dims);
 
     int const num_ranks = 1;
 
@@ -301,7 +301,7 @@ TEST_CASE("distribution plan function", "[distribution]")
     options const o = make_options(
         {"-l", std::to_string(level), "-d", std::to_string(degree)});
 
-    element_table const table(o, num_dims);
+    element_table const table(o, level, num_dims);
 
     int const num_ranks = 2;
     auto const plan     = get_plan(num_ranks, table);
@@ -330,7 +330,7 @@ TEST_CASE("distribution plan function", "[distribution]")
     options const o = make_options(
         {"-l", std::to_string(level), "-d", std::to_string(degree)});
 
-    element_table const table(o, num_dims);
+    element_table const table(o, level, num_dims);
 
     int const num_ranks = 20;
     auto const plan     = get_plan(num_ranks, table);
@@ -355,7 +355,7 @@ TEMPLATE_TEST_CASE("allreduce across row of subgrids", "[distribution]", float,
     options const o = make_options(
         {"-l", std::to_string(level), "-d", std::to_string(degree)});
 
-    element_table const table(o, num_dims);
+    element_table const table(o, level, num_dims);
     auto const plan = get_plan(num_ranks, table);
 
     fk::vector<TestType> const gold{0, 1, 2, 3, 4, 5};
@@ -381,7 +381,7 @@ TEMPLATE_TEST_CASE("allreduce across row of subgrids", "[distribution]", float,
       options const o = make_options(
           {"-l", std::to_string(level), "-d", std::to_string(degree)});
 
-      element_table const table(o, num_dims);
+      element_table const table(o, level, num_dims);
       auto const plan       = get_plan(num_ranks, table);
       int const vector_size = 10;
 
@@ -535,7 +535,7 @@ TEST_CASE("generate messages tests", "[distribution]")
         {"-l", std::to_string(level), "-d", std::to_string(degree)});
 
     auto const pde = make_PDE<double>(PDE_opts::continuity_1, level, degree);
-    element_table const table(o, pde->num_dims);
+    element_table const table(o, level, pde->num_dims);
 
     int const num_ranks = 1;
     generate_messages_test(num_ranks, table);
@@ -549,7 +549,7 @@ TEST_CASE("generate messages tests", "[distribution]")
         {"-l", std::to_string(level), "-d", std::to_string(degree)});
 
     auto const pde = make_PDE<double>(PDE_opts::continuity_3, level, degree);
-    element_table const table(o, pde->num_dims);
+    element_table const table(o, level, pde->num_dims);
 
     int const num_ranks = 1;
     generate_messages_test(num_ranks, table);
@@ -563,7 +563,7 @@ TEST_CASE("generate messages tests", "[distribution]")
         {"-l", std::to_string(level), "-d", std::to_string(degree)});
 
     auto const pde = make_PDE<double>(PDE_opts::continuity_2, level, degree);
-    element_table const table(o, pde->num_dims);
+    element_table const table(o, level, pde->num_dims);
 
     int const num_ranks = 9;
     generate_messages_test(num_ranks, table);
@@ -577,7 +577,7 @@ TEST_CASE("generate messages tests", "[distribution]")
         {"-l", std::to_string(level), "-d", std::to_string(degree)});
 
     auto const pde = make_PDE<double>(PDE_opts::continuity_3, level, degree);
-    element_table const table(o, pde->num_dims);
+    element_table const table(o, level, pde->num_dims);
 
     int const num_ranks = 36;
     generate_messages_test(num_ranks, table);
@@ -591,7 +591,7 @@ TEST_CASE("generate messages tests", "[distribution]")
         {"-l", std::to_string(level), "-d", std::to_string(degree)});
 
     auto const pde = make_PDE<double>(PDE_opts::continuity_1, level, degree);
-    element_table const table(o, pde->num_dims);
+    element_table const table(o, level, pde->num_dims);
 
     int const num_ranks = 20;
     generate_messages_test(num_ranks, table);
@@ -605,7 +605,7 @@ TEST_CASE("generate messages tests", "[distribution]")
         {"-l", std::to_string(level), "-d", std::to_string(degree)});
 
     auto const pde = make_PDE<double>(PDE_opts::continuity_6, level, degree);
-    element_table const table(o, pde->num_dims);
+    element_table const table(o, level, pde->num_dims);
 
     int const num_ranks = 32;
     generate_messages_test(num_ranks, table);
@@ -642,7 +642,7 @@ TEMPLATE_TEST_CASE("prepare inputs tests", "[distribution]", float, double)
       options const o = make_options(
           {"-l", std::to_string(level), "-d", std::to_string(degree)});
 
-      element_table const table(o, num_dims);
+      element_table const table(o, level, num_dims);
 
       // create the system vector
       fk::vector<TestType> const fx = [&table, segment_size]() {
@@ -703,7 +703,7 @@ TEMPLATE_TEST_CASE("gather results tests", "[distribution]", float, double)
       options const o = make_options(
           {"-l", std::to_string(level), "-d", std::to_string(degree)});
 
-      element_table const table(o, num_dims);
+      element_table const table(o, level, num_dims);
       auto const plan         = get_plan(num_ranks, table);
       auto const segment_size = static_cast<int>(std::pow(degree, num_dims));
 

--- a/src/element_table.cpp
+++ b/src/element_table.cpp
@@ -11,10 +11,10 @@
 #include <vector>
 
 // Construct forward and reverse element tables
-element_table::element_table(options const program_opts, int const num_dims)
+element_table::element_table(options const program_opts, int const num_levels,
+                             int const num_dims)
 {
-  int const num_levels     = program_opts.get_level();
-  bool const use_full_grid = program_opts.using_full_grid();
+  bool const use_full_grid = program_opts.use_full_grid;
 
   assert(num_dims > 0);
   assert(num_levels > 1);

--- a/src/element_table.hpp
+++ b/src/element_table.hpp
@@ -33,7 +33,8 @@
 class element_table
 {
 public:
-  element_table(options const program_opts, int const num_dims);
+  element_table(options const program_opts, int const num_levels,
+                int const num_dims);
 
   // forward lookup
   int get_index(fk::vector<int> const coords) const;

--- a/src/element_table_tests.cpp
+++ b/src/element_table_tests.cpp
@@ -11,7 +11,7 @@ void test_element_table(int const levels, int const dims,
   std::string const grid_str = full_grid ? "-f" : "";
   options const o = make_options({"-l", std::to_string(levels), grid_str});
 
-  element_table const t(o, dims);
+  element_table const t(o, levels, dims);
   fk::vector<int> const dev_table(t.get_device_table().clone_onto_host());
   auto const gold = fk::matrix<int>(read_matrix_from_txt_file(gold_filename));
   for (int i = 0; i < static_cast<int>(t.size()); ++i)
@@ -58,8 +58,11 @@ TEST_CASE("element table constructor/accessors/size", "[element_table]")
 
 TEST_CASE("Static helper - cell builder", "[element_table]")
 {
-  element_table const t(
-      make_options({"-l", std::to_string(3), "-d", std::to_string(2)}), 1);
+  int const levels = 3;
+  int const degree = 2;
+  element_table const t(make_options({"-l", std::to_string(levels), "-d",
+                                      std::to_string(degree)}),
+                        levels, 1);
 
   SECTION("cell index set builder")
   {

--- a/src/kronmult_tests.cpp
+++ b/src/kronmult_tests.cpp
@@ -26,7 +26,7 @@ void test_kronmult(PDE<P> &pde, int const workspace_size_MB, P const tol_factor)
                                          std::to_string(degree)};
 
   options const o = make_options(args);
-  element_table const table(o, pde.num_dims);
+  element_table const table(o, level, pde.num_dims);
   element_subgrid const my_subgrid(0, table.size() - 1, 0, table.size() - 1);
   basis::wavelet_transform<P, resource::host> const transformer(level, degree);
   generate_all_coefficients(pde, transformer);

--- a/src/pde.hpp
+++ b/src/pde.hpp
@@ -41,58 +41,46 @@
 // ---------------------------------------------------------------------------
 
 template<typename P>
-std::unique_ptr<PDE<P>> make_PDE(options const &opts)
+std::unique_ptr<PDE<P>> make_PDE(parser const &cli_input)
 {
-  switch (opts.get_selected_pde())
+  switch (cli_input.get_selected_pde())
   {
   case PDE_opts::continuity_1:
-    return std::make_unique<PDE_continuity_1d<P>>(opts);
+    return std::make_unique<PDE_continuity_1d<P>>(cli_input);
   case PDE_opts::continuity_2:
-    return std::make_unique<PDE_continuity_2d<P>>(opts);
+    return std::make_unique<PDE_continuity_2d<P>>(cli_input);
   case PDE_opts::continuity_3:
-    return std::make_unique<PDE_continuity_3d<P>>(opts);
+    return std::make_unique<PDE_continuity_3d<P>>(cli_input);
   case PDE_opts::continuity_6:
-    return std::make_unique<PDE_continuity_6d<P>>(opts);
+    return std::make_unique<PDE_continuity_6d<P>>(cli_input);
   case PDE_opts::fokkerplanck_1d_4p1a:
-    return std::make_unique<PDE_fokkerplanck_1d_4p1a<P>>(opts);
+    return std::make_unique<PDE_fokkerplanck_1d_4p1a<P>>(cli_input);
   case PDE_opts::fokkerplanck_1d_4p2:
-    return std::make_unique<PDE_fokkerplanck_1d_4p2<P>>(opts);
+    return std::make_unique<PDE_fokkerplanck_1d_4p2<P>>(cli_input);
   case PDE_opts::fokkerplanck_1d_4p3:
-    return std::make_unique<PDE_fokkerplanck_1d_4p3<P>>(opts);
+    return std::make_unique<PDE_fokkerplanck_1d_4p3<P>>(cli_input);
   case PDE_opts::fokkerplanck_1d_4p4:
-    return std::make_unique<PDE_fokkerplanck_1d_4p4<P>>(opts);
+    return std::make_unique<PDE_fokkerplanck_1d_4p4<P>>(cli_input);
   case PDE_opts::fokkerplanck_1d_4p5:
-    return std::make_unique<PDE_fokkerplanck_1d_4p5<P>>(opts);
+    return std::make_unique<PDE_fokkerplanck_1d_4p5<P>>(cli_input);
   case PDE_opts::fokkerplanck_2d_complete:
-    return std::make_unique<PDE_fokkerplanck_2d_complete<P>>(opts);
+    return std::make_unique<PDE_fokkerplanck_2d_complete<P>>(cli_input);
   case PDE_opts::diffusion_1:
-    return std::make_unique<PDE_diffusion_1d<P>>(opts);
+    return std::make_unique<PDE_diffusion_1d<P>>(cli_input);
   case PDE_opts::diffusion_2:
-    return std::make_unique<PDE_diffusion_2d<P>>(opts);
-  // TODO not yet implemented, replace return with appropriate types
-  case PDE_opts::vlasov4:
-    return std::make_unique<PDE_continuity_1d<P>>(opts);
-  case PDE_opts::vlasov43:
-    return std::make_unique<PDE_continuity_1d<P>>(opts);
-  case PDE_opts::vlasov5:
-    return std::make_unique<PDE_continuity_1d<P>>(opts);
-  case PDE_opts::vlasov7:
-    return std::make_unique<PDE_continuity_1d<P>>(opts);
-  case PDE_opts::vlasov8:
-    return std::make_unique<PDE_continuity_1d<P>>(opts);
-  case PDE_opts::pde_user:
-    return std::make_unique<PDE_continuity_1d<P>>(opts);
+    return std::make_unique<PDE_diffusion_2d<P>>(cli_input);
   default:
     std::cout << "Invalid pde choice" << std::endl;
     exit(-1);
   }
 }
+
 // shim for easy PDE creation in tests
 template<typename P>
 std::unique_ptr<PDE<P>>
-make_PDE(PDE_opts const pde_choice, int const level = options::NO_USER_VALUE,
-         int const degree = options::NO_USER_VALUE,
-         double const cfl = options::DEFAULT_CFL)
+make_PDE(PDE_opts const pde_choice, int const level = parser::NO_USER_VALUE,
+         int const degree = parser::NO_USER_VALUE,
+         double const cfl = parser::DEFAULT_CFL)
 {
-  return make_PDE<P>(options(pde_choice, level, degree, cfl));
+  return make_PDE<P>(parser(pde_choice, level, degree, cfl));
 }

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -335,7 +335,7 @@ template<typename P>
 class PDE
 {
 public:
-  PDE(options const &opts, int const num_dims, int const num_sources,
+  PDE(parser const &cli_input, int const num_dims, int const num_sources,
       int const num_terms, std::vector<dimension<P>> const dimensions,
       term_set<P> const terms, std::vector<source<P>> const sources,
       std::vector<vector_func<P>> const exact_vector_funcs,
@@ -355,8 +355,8 @@ public:
     assert(terms.size() == static_cast<unsigned>(num_terms));
     assert(sources.size() == static_cast<unsigned>(num_sources));
 
-    auto const degree     = opts.get_degree();
-    auto const num_levels = opts.get_level();
+    auto const degree     = cli_input.get_degree();
+    auto const num_levels = cli_input.get_level();
 
     for (auto tt : terms)
     {
@@ -397,19 +397,18 @@ public:
 
     // modify for appropriate level/degree
     // if default lev/degree not used
-    if (num_levels != options::NO_USER_VALUE ||
-        degree != options::NO_USER_VALUE)
+    if (num_levels != parser::NO_USER_VALUE || degree != parser::NO_USER_VALUE)
     {
       // FIXME eventually independent levels for each dim will be
       // supported
       for (dimension<P> &d : dimensions_)
       {
-        if (num_levels != options::NO_USER_VALUE)
+        if (num_levels != parser::NO_USER_VALUE)
         {
           assert(num_levels > 1);
           d.set_level(num_levels);
         }
-        if (degree != options::NO_USER_VALUE)
+        if (degree != parser::NO_USER_VALUE)
         {
           assert(degree > 0);
           d.set_degree(degree);
@@ -443,13 +442,13 @@ public:
     }
 
     // set the dt
-    if (opts.get_dt() == options::NO_USER_VALUE_FP)
+    if (cli_input.get_dt() == parser::NO_USER_VALUE_FP)
     {
-      dt_ = get_dt(dimensions_[0]) * opts.get_cfl();
+      dt_ = get_dt(dimensions_[0]) * cli_input.get_cfl();
     }
     else
     {
-      dt_ = opts.get_dt();
+      dt_ = cli_input.get_dt();
     }
   }
 

--- a/src/pde/pde_continuity1.hpp
+++ b/src/pde/pde_continuity1.hpp
@@ -25,10 +25,10 @@ template<typename P>
 class PDE_continuity_1d : public PDE<P>
 {
 public:
-  PDE_continuity_1d(options const &opts)
-      : PDE<P>(opts, num_dims_, num_sources_, num_terms_, dimensions_, terms_,
-               sources_, exact_vector_funcs_, exact_scalar_func_, get_dt_,
-               do_poisson_solve_, has_analytic_soln_)
+  PDE_continuity_1d(parser const &cli_input)
+      : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
+               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               get_dt_, do_poisson_solve_, has_analytic_soln_)
   {}
 
 private:

--- a/src/pde/pde_continuity2.hpp
+++ b/src/pde/pde_continuity2.hpp
@@ -25,10 +25,10 @@ template<typename P>
 class PDE_continuity_2d : public PDE<P>
 {
 public:
-  PDE_continuity_2d(options const &opts)
-      : PDE<P>(opts, num_dims_, num_sources_, num_terms_, dimensions_, terms_,
-               sources_, exact_vector_funcs_, exact_scalar_func_, get_dt_,
-               do_poisson_solve_, has_analytic_soln_)
+  PDE_continuity_2d(parser const &cli_input)
+      : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
+               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               get_dt_, do_poisson_solve_, has_analytic_soln_)
   {}
 
 private:

--- a/src/pde/pde_continuity3.hpp
+++ b/src/pde/pde_continuity3.hpp
@@ -25,10 +25,10 @@ template<typename P>
 class PDE_continuity_3d : public PDE<P>
 {
 public:
-  PDE_continuity_3d(options const &opts)
-      : PDE<P>(opts, num_dims_, num_sources_, num_terms_, dimensions_, terms_,
-               sources_, exact_vector_funcs_, exact_scalar_func_, get_dt_,
-               do_poisson_solve_, has_analytic_soln_)
+  PDE_continuity_3d(parser const &cli_input)
+      : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
+               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               get_dt_, do_poisson_solve_, has_analytic_soln_)
   {}
 
 private:

--- a/src/pde/pde_continuity6.hpp
+++ b/src/pde/pde_continuity6.hpp
@@ -25,10 +25,10 @@ template<typename P>
 class PDE_continuity_6d : public PDE<P>
 {
 public:
-  PDE_continuity_6d(options const &opts)
-      : PDE<P>(opts, num_dims_, num_sources_, num_terms_, dimensions_, terms_,
-               sources_, exact_vector_funcs_, exact_scalar_func_, get_dt_,
-               do_poisson_solve_, has_analytic_soln_)
+  PDE_continuity_6d(parser const &cli_input)
+      : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
+               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               get_dt_, do_poisson_solve_, has_analytic_soln_)
   {}
 
 private:

--- a/src/pde/pde_diffusion1.hpp
+++ b/src/pde/pde_diffusion1.hpp
@@ -5,10 +5,10 @@ template<typename P>
 class PDE_diffusion_1d : public PDE<P>
 {
 public:
-  PDE_diffusion_1d(options const &opts)
-      : PDE<P>(opts, num_dims_, num_sources_, num_terms_, dimensions_, terms_,
-               sources_, exact_vector_funcs_, exact_scalar_func_, get_dt_,
-               do_poisson_solve_, has_analytic_soln_)
+  PDE_diffusion_1d(parser const &cli_input)
+      : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
+               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               get_dt_, do_poisson_solve_, has_analytic_soln_)
   {}
 
 private:

--- a/src/pde/pde_diffusion2.hpp
+++ b/src/pde/pde_diffusion2.hpp
@@ -5,10 +5,10 @@ template<typename P>
 class PDE_diffusion_2d : public PDE<P>
 {
 public:
-  PDE_diffusion_2d(options const &opts)
-      : PDE<P>(opts, num_dims_, num_sources_, num_terms_, dimensions_, terms_,
-               sources_, exact_vector_funcs_, exact_scalar_func_, get_dt_,
-               do_poisson_solve_, has_analytic_soln_)
+  PDE_diffusion_2d(parser const &cli_input)
+      : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
+               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               get_dt_, do_poisson_solve_, has_analytic_soln_)
   {}
 
 private:

--- a/src/pde/pde_fokkerplanck1_4p1a.hpp
+++ b/src/pde/pde_fokkerplanck1_4p1a.hpp
@@ -36,10 +36,10 @@ template<typename P>
 class PDE_fokkerplanck_1d_4p1a : public PDE<P>
 {
 public:
-  PDE_fokkerplanck_1d_4p1a(options const &opts)
-      : PDE<P>(opts, num_dims_, num_sources_, num_terms_, dimensions_, terms_,
-               sources_, exact_vector_funcs_, exact_scalar_func_, get_dt_,
-               do_poisson_solve_, has_analytic_soln_)
+  PDE_fokkerplanck_1d_4p1a(parser const &cli_input)
+      : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
+               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               get_dt_, do_poisson_solve_, has_analytic_soln_)
   {}
 
 private:

--- a/src/pde/pde_fokkerplanck1_4p2.hpp
+++ b/src/pde/pde_fokkerplanck1_4p2.hpp
@@ -36,10 +36,10 @@ template<typename P>
 class PDE_fokkerplanck_1d_4p2 : public PDE<P>
 {
 public:
-  PDE_fokkerplanck_1d_4p2(options const &opts)
-      : PDE<P>(opts, num_dims_, num_sources_, num_terms_, dimensions_, terms_,
-               sources_, exact_vector_funcs_, exact_scalar_func_, get_dt_,
-               do_poisson_solve_, has_analytic_soln_)
+  PDE_fokkerplanck_1d_4p2(parser const &cli_input)
+      : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
+               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               get_dt_, do_poisson_solve_, has_analytic_soln_)
   {}
 
 private:

--- a/src/pde/pde_fokkerplanck1_4p3.hpp
+++ b/src/pde/pde_fokkerplanck1_4p3.hpp
@@ -25,10 +25,10 @@ template<typename P>
 class PDE_fokkerplanck_1d_4p3 : public PDE<P>
 {
 public:
-  PDE_fokkerplanck_1d_4p3(options const &opts)
-      : PDE<P>(opts, num_dims_, num_sources_, num_terms_, dimensions_, terms_,
-               sources_, exact_vector_funcs_, exact_scalar_func_, get_dt_,
-               do_poisson_solve_, has_analytic_soln_)
+  PDE_fokkerplanck_1d_4p3(parser const &cli_input)
+      : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
+               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               get_dt_, do_poisson_solve_, has_analytic_soln_)
   {}
 
 private:

--- a/src/pde/pde_fokkerplanck1_4p4.hpp
+++ b/src/pde/pde_fokkerplanck1_4p4.hpp
@@ -27,10 +27,10 @@ template<typename P>
 class PDE_fokkerplanck_1d_4p4 : public PDE<P>
 {
 public:
-  PDE_fokkerplanck_1d_4p4(options const &opts)
-      : PDE<P>(opts, num_dims_, num_sources_, num_terms_, dimensions_, terms_,
-               sources_, exact_vector_funcs_, exact_scalar_func_, get_dt_,
-               do_poisson_solve_, has_analytic_soln_)
+  PDE_fokkerplanck_1d_4p4(parser const &cli_input)
+      : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
+               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               get_dt_, do_poisson_solve_, has_analytic_soln_)
   {}
 
 private:

--- a/src/pde/pde_fokkerplanck1_4p5.hpp
+++ b/src/pde/pde_fokkerplanck1_4p5.hpp
@@ -28,10 +28,10 @@ template<typename P>
 class PDE_fokkerplanck_1d_4p5 : public PDE<P>
 {
 public:
-  PDE_fokkerplanck_1d_4p5(options const &opts)
-      : PDE<P>(opts, num_dims_, num_sources_, num_terms_, dimensions_, terms_,
-               sources_, exact_vector_funcs_, exact_scalar_func_, get_dt_,
-               do_poisson_solve_, has_analytic_soln_)
+  PDE_fokkerplanck_1d_4p5(parser const &cli_input)
+      : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
+               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               get_dt_, do_poisson_solve_, has_analytic_soln_)
   {}
 
 private:

--- a/src/pde/pde_fokkerplanck2_complete.hpp
+++ b/src/pde/pde_fokkerplanck2_complete.hpp
@@ -46,10 +46,10 @@ template<typename P>
 class PDE_fokkerplanck_2d_complete : public PDE<P>
 {
 public:
-  PDE_fokkerplanck_2d_complete(options const &opts)
-      : PDE<P>(opts, num_dims_, num_sources_, num_terms_, dimensions_, terms_,
-               sources_, exact_vector_funcs_, exact_scalar_func_, get_dt_,
-               do_poisson_solve_, has_analytic_soln_)
+  PDE_fokkerplanck_2d_complete(parser const &cli_input)
+      : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
+               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               get_dt_, do_poisson_solve_, has_analytic_soln_)
   {}
 
 private:

--- a/src/pde_tests.cpp
+++ b/src/pde_tests.cpp
@@ -61,7 +61,7 @@ TEMPLATE_TEST_CASE("testing diffusion 2 implementations", "[pde]", double,
   SECTION("diffusion 2 dt")
   {
     TestType const gold = read_scalar_from_txt_file(base_dir + "dt.dat");
-    TestType const dt   = pde->get_dt() / options::DEFAULT_CFL;
+    TestType const dt   = pde->get_dt() / parser::DEFAULT_CFL;
     REQUIRE(dt == gold);
   }
 }
@@ -107,7 +107,7 @@ TEMPLATE_TEST_CASE("testing diffusion 1 implementations", "[pde]", double,
   SECTION("diffusion 1 dt")
   {
     TestType const gold = read_scalar_from_txt_file(base_dir + "dt.dat");
-    TestType const dt   = pde->get_dt() / options::DEFAULT_CFL;
+    TestType const dt   = pde->get_dt() / parser::DEFAULT_CFL;
     REQUIRE(dt == gold);
   }
 }
@@ -168,7 +168,7 @@ TEMPLATE_TEST_CASE("testing contuinity 1 implementations", "[pde]", double,
   SECTION("continuity 1 dt")
   {
     TestType const gold = read_scalar_from_txt_file(base_dir + "dt.dat");
-    TestType const dt   = pde->get_dt() / options::DEFAULT_CFL;
+    TestType const dt   = pde->get_dt() / parser::DEFAULT_CFL;
     REQUIRE(dt == gold);
   }
 }
@@ -228,7 +228,7 @@ TEMPLATE_TEST_CASE("testing contuinity 2 implementations", "[pde]", double,
   SECTION("continuity 2 dt")
   {
     TestType const gold = read_scalar_from_txt_file(base_dir + "dt.dat");
-    TestType const dt   = pde->get_dt() / options::DEFAULT_CFL;
+    TestType const dt   = pde->get_dt() / parser::DEFAULT_CFL;
     REQUIRE(dt == gold);
   }
 }
@@ -291,7 +291,7 @@ TEMPLATE_TEST_CASE("testing contuinity 3 implementations", "[pde]", double,
   SECTION("continuity 3 dt")
   {
     TestType const gold = read_scalar_from_txt_file(base_dir + "dt.dat");
-    TestType const dt   = pde->get_dt() / options::DEFAULT_CFL;
+    TestType const dt   = pde->get_dt() / parser::DEFAULT_CFL;
     REQUIRE(dt == gold);
   }
 }
@@ -354,7 +354,7 @@ TEMPLATE_TEST_CASE("testing contuinity 6 implementations", "[pde]", double,
   SECTION("continuity 6 dt")
   {
     TestType const gold = read_scalar_from_txt_file(base_dir + "dt.dat");
-    TestType const dt   = pde->get_dt() / options::DEFAULT_CFL;
+    TestType const dt   = pde->get_dt() / parser::DEFAULT_CFL;
     REQUIRE(dt == gold);
   }
 }
@@ -381,7 +381,7 @@ TEMPLATE_TEST_CASE("testing fokkerplanck2_complete implementations", "[pde]",
   SECTION("fokkerplanck2_complete dt")
   {
     TestType const gold = read_scalar_from_txt_file(base_dir + "dt.dat");
-    TestType const dt   = pde->get_dt() / options::DEFAULT_CFL;
+    TestType const dt   = pde->get_dt() / parser::DEFAULT_CFL;
     REQUIRE(dt == gold);
   }
 }

--- a/src/program_options.cpp
+++ b/src/program_options.cpp
@@ -20,15 +20,15 @@ parser::parser(int argc, char **argv)
           "Use full grid (vs. sparse grid)") |
       clara::detail::Opt(use_implicit_stepping)["-i"]["--implicit"](
           "Use implicit time advance (vs. explicit)") |
-      clara::detail::Opt(selected_solver, "selected_solver")["-s"]["--solver"](
+      clara::detail::Opt(solver_str, "solver_str")["-s"]["--solver"](
           "Solver to use (direct or gmres) for implicit advance") |
       clara::detail::Opt(level, "level")["-l"]["--level"](
-          "Hierarchical levels (resolution)") |
+          "Stating hierarchical levels (resolution)") |
       clara::detail::Opt(max_level, "max level")["-m"]["--max_level"](
           "Maximum hierarchical levels (resolution) for adaptivity") |
       clara::detail::Opt(num_time_steps, "time steps")["-n"]["--num_steps"](
           "Number of iterations") |
-      clara::detail::Opt(selected_pde, "selected_pde")["-p"]["--pde"](
+      clara::detail::Opt(pde_str, "pde_str")["-p"]["--pde"](
           "PDE to solve; see options.hpp for list") |
       clara::detail::Opt(do_poisson)["-e"]["--electric_solve"](
           "Do poisson solve for electric field") |
@@ -98,7 +98,7 @@ parser::parser(int argc, char **argv)
     valid = false;
   }
 
-  auto const choice = pde_mapping.find(selected_pde);
+  auto const choice = pde_mapping.find(pde_str);
   if (choice == pde_mapping.end())
   {
     std::cerr << "Invalid pde choice; see options.hpp for valid choices"
@@ -107,7 +107,7 @@ parser::parser(int argc, char **argv)
   }
   else
   {
-    pde_choice = pde_mapping.at(selected_pde);
+    pde_choice = pde_mapping.at(pde_str);
   }
 
   if (realspace_output_freq < 0 || wavelet_output_freq < 0)
@@ -135,11 +135,11 @@ parser::parser(int argc, char **argv)
 
   if (use_implicit_stepping)
   {
-    if (selected_solver == "none")
+    if (solver_str == "none")
     {
-      selected_solver = "direct";
+      solver_str = "direct";
     }
-    auto const choice = solver_mapping.find(selected_solver);
+    auto const choice = solver_mapping.find(solver_str);
     if (choice == solver_mapping.end())
     {
       std::cerr << "Invalid solver choice; see options.hpp for valid choices\n";
@@ -147,12 +147,12 @@ parser::parser(int argc, char **argv)
     }
     else
     {
-      solver = solver_mapping.at(selected_solver);
+      solver = solver_mapping.at(solver_str);
     }
   }
   else // explicit time advance
   {
-    if (selected_solver != "none")
+    if (solver_str != "none")
     {
       std::cerr << "Must set implicit (-i) flag to select a solver\n";
       valid = false;
@@ -195,7 +195,8 @@ int parser::get_realspace_output_freq() const { return realspace_output_freq; }
 double parser::get_cfl() const { return cfl; }
 double parser::get_dt() const { return dt; }
 
-std::string parser::get_pde_string() const { return selected_pde; }
+std::string parser::get_pde_string() const { return pde_str; }
+std::string parser::get_solver_string() const { return solver_str; }
 
 PDE_opts parser::get_selected_pde() const { return pde_choice; }
 solve_opts parser::get_selected_solver() const { return solver; }

--- a/src/program_options.hpp
+++ b/src/program_options.hpp
@@ -98,6 +98,7 @@ public:
   double get_cfl() const;
 
   std::string get_pde_string() const;
+  std::string get_solver_string() const;
 
   PDE_opts get_selected_pde() const;
   solve_opts get_selected_solver() const;
@@ -105,6 +106,11 @@ public:
   bool is_valid() const;
 
 private:
+  bool use_implicit_stepping =
+      DEFAULT_USE_IMPLICIT;             // enable implicit(/explicit) stepping
+  bool use_full_grid = DEFAULT_USE_FG;  // enable full(/sparse) grid
+  bool do_poisson = DEFAULT_DO_POISSON; // do poisson solve for electric field
+
   // FIXME level and degree are unique to dimensions, will
   // need to support inputting level and degree per dimensions
   // in future
@@ -114,25 +120,23 @@ private:
   int max_level =
       DEFAULT_MAX_LEVEL; // max adaptivity level for any given dimension.
   int num_time_steps = DEFAULT_TIME_STEPS; // number of time loop iterations
-  bool use_implicit_stepping =
-      DEFAULT_USE_IMPLICIT;             // enable implicit(/explicit) stepping
-  bool use_full_grid = DEFAULT_USE_FG;  // enable full(/sparse) grid
-  bool do_poisson = DEFAULT_DO_POISSON; // do poisson solve for electric field
-  double cfl = NO_USER_VALUE_FP; // the Courant-Friedrichs-Lewy (CFL) condition
-  double dt =
-      NO_USER_VALUE_FP; // size of time steps. double::min loads default in pde
+
   int wavelet_output_freq = DEFAULT_WRITE_FREQ; // write wavelet space output
                                                 // every this many iterations
   int realspace_output_freq =
       DEFAULT_WRITE_FREQ; // timesteps between realspace output writes to disk
 
+  double cfl = NO_USER_VALUE_FP; // the Courant-Friedrichs-Lewy (CFL) condition
+  double dt =
+      NO_USER_VALUE_FP; // size of time steps. double::min loads default in pde
+
   // default
-  std::string selected_pde = DEFAULT_PDE_STR;
+  std::string pde_str = DEFAULT_PDE_STR;
   // pde to construct/evaluate
   PDE_opts pde_choice = DEFAULT_PDE_OPT;
 
   // default
-  std::string selected_solver = NO_USER_VALUE_STR;
+  std::string solver_str = NO_USER_VALUE_STR;
   // solver to use for implicit timestepping
   solve_opts solver = DEFAULT_SOLVER;
 

--- a/src/program_options.hpp
+++ b/src/program_options.hpp
@@ -33,14 +33,7 @@ enum class PDE_opts
   fokkerplanck_2d_complete,
   diffusion_1,
   diffusion_2,
-  // FIXME the below have not been implemented according to the
-  // new specification. david is working on that in the matlab
-  vlasov4,  // PDE corresponding to Fig. 4 in FIXME
-  vlasov43, // PDE corresponding to Fig. 4.3 in FIXME
-  vlasov5,  // PDE corresponding to Fig. 5 in FIXME
-  vlasov7,  // PDE corresponding to Fig. 7 in FIXME
-  vlasov8,  // PDE corresponding to Fig. 8 in FIXME
-  pde_user  // FIXME will need to add the user supplied PDE choice
+  // FIXME will need to add the user supplied PDE choice
 };
 
 //
@@ -60,12 +53,7 @@ static pde_map_t const pde_mapping = {
     {"fokkerplanck_2d_complete", PDE_opts::fokkerplanck_2d_complete},
     {"diffusion_1", PDE_opts::diffusion_1},
     {"diffusion_2", PDE_opts::diffusion_2},
-    {"pde_user", PDE_opts::pde_user},
-    {"vlasov4", PDE_opts::vlasov4},
-    {"vlasov7", PDE_opts::vlasov7},
-    {"vlasov8", PDE_opts::vlasov8},
-    {"vlasov5", PDE_opts::vlasov5},
-    {"vlasov43", PDE_opts::vlasov43}};
+};
 
 // class to parse command line input
 class parser
@@ -89,23 +77,29 @@ public:
   // construct from command line
   parser(int argc, char **argv);
 
-  // construct from provided values - for testing
+  // construct from provided values - to simplify testing
   parser(PDE_opts const pde_choice, int const level, int const degree,
          double const cfl)
       : level(level), degree(degree), cfl(cfl), pde_choice(pde_choice){};
 
+  bool using_implicit() const;
+  bool using_full_grid() const;
+  bool do_poisson_solve() const;
+
   int get_level() const;
   int get_degree() const;
   int get_max_level() const;
-  double get_dt() const;
   int get_time_steps() const;
-  bool using_implicit() const;
-  bool using_full_grid() const;
-  double get_cfl() const;
-  PDE_opts get_selected_pde() const;
-  bool do_poisson_solve() const;
+
   int get_wavelet_output_freq() const;
   int get_realspace_output_freq() const;
+
+  double get_dt() const;
+  double get_cfl() const;
+
+  std::string get_pde_string() const;
+
+  PDE_opts get_selected_pde() const;
   solve_opts get_selected_solver() const;
 
   bool is_valid() const;
@@ -154,27 +148,28 @@ public:
   options(parser const &user_vals)
       : max_level(user_vals.get_max_level()),
         num_time_steps(user_vals.get_time_steps()),
+        wavelet_output_freq(user_vals.get_wavelet_output_freq()),
+        realspace_output_freq(user_vals.get_realspace_output_freq()),
         use_implicit_stepping(user_vals.using_implicit()),
         use_full_grid(user_vals.using_full_grid()),
         do_poisson_solve(user_vals.do_poisson_solve()),
-        wavelet_output_freq(user_vals.get_wavelet_output_freq()),
-        realspace_output_freq(user_vals.get_realspace_output_freq()){};
+        solver(user_vals.get_selected_solver()){};
 
   bool should_output_wavelet(int const i) const;
   bool should_output_realspace(int const i) const;
 
   int const max_level;
   int const num_time_steps;
+  int const wavelet_output_freq;
+  int const realspace_output_freq;
 
   bool const use_implicit_stepping;
   bool const use_full_grid;
   bool const do_poisson_solve;
 
+  solve_opts const solver;
+
 private:
   // helper for output writing
   bool write_at_step(int const i, int const freq) const;
-
-  int const wavelet_output_freq;
-  int const realspace_output_freq;
-  solve_opts solver;
 };

--- a/src/time_advance_tests.cpp
+++ b/src/time_advance_tests.cpp
@@ -40,7 +40,7 @@ void time_advance_test(int const level, int const degree, PDE<P> &pde,
   }();
   options const o = make_options(args);
 
-  element_table const table(o, pde.num_dims);
+  element_table const table(o, level, pde.num_dims);
 
   // can't run problem with fewer elements than ranks
   // this is asserted on in the distribution component
@@ -151,7 +151,7 @@ void implicit_time_advance_test(int const level, int const degree, PDE<P> &pde,
       make_options({"-l", std::to_string(level), "-d", std::to_string(degree),
                     "--implicit", grid_str});
 
-  element_table const table(o, pde.num_dims);
+  element_table const table(o, level, pde.num_dims);
   auto const plan    = get_plan(num_ranks, table);
   auto const subgrid = plan.at(my_rank);
 

--- a/src/transformations_tests.cpp
+++ b/src/transformations_tests.cpp
@@ -28,7 +28,7 @@ void test_combine_dimensions(PDE<P> const &pde, P const time = 1.0,
   options const o            = make_options(
       {"-d", std::to_string(deg), "-l", std::to_string(lev), grid_str});
 
-  element_table const t(o, dims);
+  element_table const t(o, lev, dims);
 
   std::vector<fk::vector<P>> vectors;
   P counter = 1.0;
@@ -170,7 +170,7 @@ void test_wavelet_to_realspace(PDE<P> const &pde,
   int const degree      = d.get_degree();
 
   basis::wavelet_transform<P, resource::host> const transformer(level, degree);
-  element_table table(make_options({"-l", std::to_string(level)}),
+  element_table table(make_options({"-l", std::to_string(level)}), level,
                       pde.num_dims);
 
   fk::vector<P> const wave_space = [&table, &pde, degree]() {

--- a/testing/tests_general.cpp
+++ b/testing/tests_general.cpp
@@ -16,6 +16,11 @@
 
 options make_options(std::vector<std::string> const arguments)
 {
+  return options(make_parser(arguments));
+}
+
+parser make_parser(std::vector<std::string> const arguments)
+{
   std::vector<char *> argv;
   argv.push_back(const_cast<char *>("asgard"));
   for (const auto &arg : arguments)
@@ -23,5 +28,6 @@ options make_options(std::vector<std::string> const arguments)
     argv.push_back(const_cast<char *>(arg.data()));
   }
   argv.push_back(nullptr);
-  return options(parser(argv.size() - 1, argv.data()));
+
+  return parser(argv.size() - 1, argv.data());
 }

--- a/testing/tests_general.cpp
+++ b/testing/tests_general.cpp
@@ -23,5 +23,5 @@ options make_options(std::vector<std::string> const arguments)
     argv.push_back(const_cast<char *>(arg.data()));
   }
   argv.push_back(nullptr);
-  return options(argv.size() - 1, argv.data());
+  return options(parser(argv.size() - 1, argv.data()));
 }

--- a/testing/tests_general.hpp
+++ b/testing/tests_general.hpp
@@ -105,6 +105,7 @@ dimension<P> make_dummy_dim(
 }
 
 options make_options(std::vector<std::string> const arguments);
+parser make_parser(std::vector<std::string> const arguments);
 
 template<typename T>
 std::string to_string_with_precision(T const a_value, int const precision = 6)


### PR DESCRIPTION
closes #304.

break options storage and options parsing to constify program options.

eliminate redundant values stored in both pde and options - every value should have a single authoritative representation.