### PR TITLE
point to new kronmult lib with less syncthreads

### DIFF
--- a/contrib/contrib.cmake
+++ b/contrib/contrib.cmake
@@ -206,7 +206,7 @@ if(NOT KRON_LIB)
     ExternalProject_Add (kronmult-ext
       UPDATE_COMMAND ""
       PREFIX ${CMAKE_SOURCE_DIR}/contrib/kronmult
-      URL https://github.com/project-asgard/kronmult/archive/v1.2.2.tar.gz
+      URL https://github.com/project-asgard/kronmult/archive/v1.3.tar.gz
       DOWNLOAD_NO_PROGRESS 1
       CMAKE_ARGS ${KRON_ARGS}
       BUILD_IN_SOURCE 1

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -990,6 +990,46 @@ template class batch<double>;
 template class batch<float, resource::host>;
 template class batch<double, resource::host>;
 
+template void batch<float, resource::host>::assign_entry(
+    fk::matrix<float, mem_type::owner, resource::host> const &a,
+    int const position);
+template void batch<float, resource::host>::assign_entry(
+    fk::matrix<float, mem_type::view, resource::host> const &a,
+    int const position);
+template void batch<float, resource::host>::assign_entry(
+    fk::matrix<float, mem_type::const_view, resource::host> const &a,
+    int const position);
+
+template void batch<double, resource::host>::assign_entry(
+    fk::matrix<double, mem_type::owner, resource::host> const &a,
+    int const position);
+template void batch<double, resource::host>::assign_entry(
+    fk::matrix<double, mem_type::view, resource::host> const &a,
+    int const position);
+template void batch<double, resource::host>::assign_entry(
+    fk::matrix<double, mem_type::const_view, resource::host> const &a,
+    int const position);
+
+template void batch<float, resource::device>::assign_entry(
+    fk::matrix<float, mem_type::owner, resource::device> const &a,
+    int const position);
+template void batch<float, resource::device>::assign_entry(
+    fk::matrix<float, mem_type::view, resource::device> const &a,
+    int const position);
+template void batch<float, resource::device>::assign_entry(
+    fk::matrix<float, mem_type::const_view, resource::device> const &a,
+    int const position);
+
+template void batch<double, resource::device>::assign_entry(
+    fk::matrix<double, mem_type::owner, resource::device> const &a,
+    int const position);
+template void batch<double, resource::device>::assign_entry(
+    fk::matrix<double, mem_type::view, resource::device> const &a,
+    int const position);
+template void batch<double, resource::device>::assign_entry(
+    fk::matrix<double, mem_type::const_view, resource::device> const &a,
+    int const position);
+
 template class batch_workspace<float, resource::host>;
 template class batch_workspace<float, resource::device>;
 


### PR DESCRIPTION
during the hackathon, we discovered that we could hoist syncthreads out of kgemm functions and into the transition between dimensions (i.e. between `kronmult[x]` and `kronmult[x-1]` functions. point to the new version of the kronmult library that does this.