### PR TITLE
Feature/stage launch (depends on #319)

### DIFF
--- a/contrib/contrib.cmake
+++ b/contrib/contrib.cmake
@@ -206,7 +206,7 @@ if(NOT KRON_LIB)
     ExternalProject_Add (kronmult-ext
       UPDATE_COMMAND ""
       PREFIX ${CMAKE_SOURCE_DIR}/contrib/kronmult
-      URL https://github.com/project-asgard/kronmult/archive/v1.2.2.tar.gz
+      URL https://github.com/project-asgard/kronmult/archive/v1.3.tar.gz
       DOWNLOAD_NO_PROGRESS 1
       CMAKE_ARGS ${KRON_ARGS}
       BUILD_IN_SOURCE 1

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -990,6 +990,46 @@ template class batch<double>;
 template class batch<float, resource::host>;
 template class batch<double, resource::host>;
 
+template void batch<float, resource::host>::assign_entry(
+    fk::matrix<float, mem_type::owner, resource::host> const &a,
+    int const position);
+template void batch<float, resource::host>::assign_entry(
+    fk::matrix<float, mem_type::view, resource::host> const &a,
+    int const position);
+template void batch<float, resource::host>::assign_entry(
+    fk::matrix<float, mem_type::const_view, resource::host> const &a,
+    int const position);
+
+template void batch<double, resource::host>::assign_entry(
+    fk::matrix<double, mem_type::owner, resource::host> const &a,
+    int const position);
+template void batch<double, resource::host>::assign_entry(
+    fk::matrix<double, mem_type::view, resource::host> const &a,
+    int const position);
+template void batch<double, resource::host>::assign_entry(
+    fk::matrix<double, mem_type::const_view, resource::host> const &a,
+    int const position);
+
+template void batch<float, resource::device>::assign_entry(
+    fk::matrix<float, mem_type::owner, resource::device> const &a,
+    int const position);
+template void batch<float, resource::device>::assign_entry(
+    fk::matrix<float, mem_type::view, resource::device> const &a,
+    int const position);
+template void batch<float, resource::device>::assign_entry(
+    fk::matrix<float, mem_type::const_view, resource::device> const &a,
+    int const position);
+
+template void batch<double, resource::device>::assign_entry(
+    fk::matrix<double, mem_type::owner, resource::device> const &a,
+    int const position);
+template void batch<double, resource::device>::assign_entry(
+    fk::matrix<double, mem_type::view, resource::device> const &a,
+    int const position);
+template void batch<double, resource::device>::assign_entry(
+    fk::matrix<double, mem_type::const_view, resource::device> const &a,
+    int const position);
+
 template class batch_workspace<float, resource::host>;
 template class batch_workspace<float, resource::device>;
 

--- a/src/device/kronmult_cuda.cpp
+++ b/src/device/kronmult_cuda.cpp
@@ -79,12 +79,11 @@ void stage_inputs_kronmult(P const *const x, P *const workspace,
 
 #ifdef ASGARD_USE_CUDA
 
-  auto constexpr warp_size     = 32;
-  auto constexpr num_warps     = 8;
-  auto constexpr num_threads   = num_warps * warp_size;
-  auto constexpr num_SMs       = 80; // FIXME volta
-  auto constexpr blocks_per_SM = 32;
-  auto const num_blocks        = num_SMs * blocks_per_SM;
+  auto constexpr warp_size   = 32;
+  auto constexpr num_warps   = 8;
+  auto constexpr num_threads = num_warps * warp_size;
+  int64_t const total_copies = static_cast<int64_t>(num_elems) * num_copies;
+  auto const num_blocks      = (total_copies + num_threads - 1) / num_threads;
 
   stage_inputs_kronmult_kernel<P>
       <<<num_blocks, num_threads>>>(x, workspace, num_elems, num_copies);

--- a/src/device/kronmult_cuda.cpp
+++ b/src/device/kronmult_cuda.cpp
@@ -79,10 +79,12 @@ void stage_inputs_kronmult(P const *const x, P *const workspace,
 
 #ifdef ASGARD_USE_CUDA
 
-  auto constexpr warp_size   = 32;
-  auto constexpr num_warps   = 8;
-  auto constexpr num_threads = num_warps * warp_size;
-  auto const num_blocks      = (num_copies / num_threads) + 1;
+  auto constexpr warp_size     = 32;
+  auto constexpr num_warps     = 8;
+  auto constexpr num_threads   = num_warps * warp_size;
+  auto constexpr num_SMs       = 80; // FIXME volta
+  auto constexpr blocks_per_SM = 32;
+  auto const num_blocks        = num_SMs * blocks_per_SM;
 
   stage_inputs_kronmult_kernel<P>
       <<<num_blocks, num_threads>>>(x, workspace, num_elems, num_copies);


### PR DESCRIPTION
Stage kronmults kernel is not launching with nearly enough threads to saturate GPU bandwidth for the 6d case. Set `num_blocks` = `num_total_copies/threads_per_block` (with rounding guard) to drastically improve performance for high dimension problems.