### PR TITLE
use new kronmult lib that doesn't block over m and n

### DIFF
--- a/contrib/contrib.cmake
+++ b/contrib/contrib.cmake
@@ -206,7 +206,7 @@ if(NOT KRON_LIB)
     ExternalProject_Add (kronmult-ext
       UPDATE_COMMAND ""
       PREFIX ${CMAKE_SOURCE_DIR}/contrib/kronmult
-      URL https://github.com/project-asgard/kronmult/archive/v1.4.5.tar.gz
+      URL https://github.com/project-asgard/kronmult/archive/v1.4.6.tar.gz
       DOWNLOAD_NO_PROGRESS 1
       CMAKE_ARGS ${KRON_ARGS}
       BUILD_IN_SOURCE 1

--- a/contrib/contrib.cmake
+++ b/contrib/contrib.cmake
@@ -206,7 +206,7 @@ if(NOT KRON_LIB)
     ExternalProject_Add (kronmult-ext
       UPDATE_COMMAND ""
       PREFIX ${CMAKE_SOURCE_DIR}/contrib/kronmult
-      URL https://github.com/project-asgard/kronmult/archive/v1.4.2.tar.gz
+      URL https://github.com/project-asgard/kronmult/archive/v1.4.3.tar.gz
       DOWNLOAD_NO_PROGRESS 1
       CMAKE_ARGS ${KRON_ARGS}
       BUILD_IN_SOURCE 1

--- a/contrib/contrib.cmake
+++ b/contrib/contrib.cmake
@@ -206,7 +206,7 @@ if(NOT KRON_LIB)
     ExternalProject_Add (kronmult-ext
       UPDATE_COMMAND ""
       PREFIX ${CMAKE_SOURCE_DIR}/contrib/kronmult
-      URL https://github.com/project-asgard/kronmult/archive/1.4.1.tar.gz
+      URL https://github.com/project-asgard/kronmult/archive/v1.4.2.tar.gz
       DOWNLOAD_NO_PROGRESS 1
       CMAKE_ARGS ${KRON_ARGS}
       BUILD_IN_SOURCE 1

--- a/contrib/contrib.cmake
+++ b/contrib/contrib.cmake
@@ -206,7 +206,7 @@ if(NOT KRON_LIB)
     ExternalProject_Add (kronmult-ext
       UPDATE_COMMAND ""
       PREFIX ${CMAKE_SOURCE_DIR}/contrib/kronmult
-      URL https://github.com/project-asgard/kronmult/archive/v1.4.3.tar.gz
+      URL https://github.com/project-asgard/kronmult/archive/v1.4.4.tar.gz
       DOWNLOAD_NO_PROGRESS 1
       CMAKE_ARGS ${KRON_ARGS}
       BUILD_IN_SOURCE 1

--- a/contrib/contrib.cmake
+++ b/contrib/contrib.cmake
@@ -206,7 +206,7 @@ if(NOT KRON_LIB)
     ExternalProject_Add (kronmult-ext
       UPDATE_COMMAND ""
       PREFIX ${CMAKE_SOURCE_DIR}/contrib/kronmult
-      URL https://github.com/project-asgard/kronmult/archive/v1.2.2.tar.gz
+      URL https://github.com/project-asgard/kronmult/archive/v1.4.tar.gz
       DOWNLOAD_NO_PROGRESS 1
       CMAKE_ARGS ${KRON_ARGS}
       BUILD_IN_SOURCE 1

--- a/contrib/contrib.cmake
+++ b/contrib/contrib.cmake
@@ -206,7 +206,7 @@ if(NOT KRON_LIB)
     ExternalProject_Add (kronmult-ext
       UPDATE_COMMAND ""
       PREFIX ${CMAKE_SOURCE_DIR}/contrib/kronmult
-      URL https://github.com/project-asgard/kronmult/archive/v1.4.tar.gz
+      URL https://github.com/project-asgard/kronmult/archive/v1.4.1.tar.gz
       DOWNLOAD_NO_PROGRESS 1
       CMAKE_ARGS ${KRON_ARGS}
       BUILD_IN_SOURCE 1

--- a/contrib/contrib.cmake
+++ b/contrib/contrib.cmake
@@ -206,7 +206,7 @@ if(NOT KRON_LIB)
     ExternalProject_Add (kronmult-ext
       UPDATE_COMMAND ""
       PREFIX ${CMAKE_SOURCE_DIR}/contrib/kronmult
-      URL https://github.com/project-asgard/kronmult/archive/v1.4.4.tar.gz
+      URL https://github.com/project-asgard/kronmult/archive/v1.4.5.tar.gz
       DOWNLOAD_NO_PROGRESS 1
       CMAKE_ARGS ${KRON_ARGS}
       BUILD_IN_SOURCE 1

--- a/contrib/contrib.cmake
+++ b/contrib/contrib.cmake
@@ -206,7 +206,7 @@ if(NOT KRON_LIB)
     ExternalProject_Add (kronmult-ext
       UPDATE_COMMAND ""
       PREFIX ${CMAKE_SOURCE_DIR}/contrib/kronmult
-      URL https://github.com/project-asgard/kronmult/archive/v1.4.1.tar.gz
+      URL https://github.com/project-asgard/kronmult/archive/1.4.1.tar.gz
       DOWNLOAD_NO_PROGRESS 1
       CMAKE_ARGS ${KRON_ARGS}
       BUILD_IN_SOURCE 1


### PR DESCRIPTION
removing the blocking loops over m and n have decreased our integer instruction mix and shown good performance during hackathon. point to version of kronmult lib without m/n blocking.