### PR TITLE
perf regression test scripts

### DIFF
--- a/testing/automated/bench.txt
+++ b/testing/automated/bench.txt
@@ -1,4 +1,0 @@
-123456789
--p continuity_2 -l 6 -d 6 -n 3,
--p continuity_3 -l 5 -d 4 -n 3,
--p continuity_6 -l 3 -d 2 -n 3,

--- a/testing/automated/bench.txt
+++ b/testing/automated/bench.txt
@@ -1,0 +1,4 @@
+123456789
+-p continuity_2 -l 6 -d 6 -n 3,
+-p continuity_3 -l 5 -d 4 -n 3,
+-p continuity_6 -l 3 -d 2 -n 3,

--- a/testing/automated/bench_cpu.txt
+++ b/testing/automated/bench_cpu.txt
@@ -1,0 +1,4 @@
+d18e43d1b2559b141be1493626a9ba6ef4a2d6c2
+-p continuity_2 -l 7 -d 8,874.005
+-p continuity_3 -l 5 -d 6,1115.86
+-p continuity_6 -l 2 -d 4,1165.06

--- a/testing/automated/bench_gpu.txt
+++ b/testing/automated/bench_gpu.txt
@@ -1,0 +1,4 @@
+d18e43d1b2559b141be1493626a9ba6ef4a2d6c2
+-p continuity_2 -l 8 -d 9,176.71
+-p continuity_3 -l 6 -d 7,197.895
+-p continuity_6 -l 3 -d 4,377.616

--- a/testing/automated/performance-regression-check.py
+++ b/testing/automated/performance-regression-check.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+# imports
+import csv
+import subprocess
+
+# constants
+BENCH_FILE = 'bench.txt'
+RUN_ENTRIES = 2 # run structure: asgard args, average timestep
+EMPTY_RUN = ""
+ASGARD_PATH = "../../build/asgard" # is there a better way to do this? not relocatable...
+
+# helper
+def is_float(value):
+	try:
+		float(value)
+		return True
+	except ValueError:
+		return False
+
+# execution
+timings = dict()
+with open(BENCH_FILE) as run_details:
+	run_csv = csv.reader(run_details, delimiter=',')
+	commit = next(run_csv)[0]
+	print('bench commit: {}'.format(commit))
+	for run in run_csv:
+		assert(len(run) == RUN_ENTRIES), "run args and avg timestep required for all runs!"
+		asgard_args, avg_timestep_ms = run[:RUN_ENTRIES]
+		print(asgard_args)
+		if is_float(avg_timestep_ms):
+			timings[asgard_args] = avg_timestep_ms
+		else:
+			timings[asgard_args] = EMPTY_RUN
+
+for args, timing in timings.items():
+    print(args)
+    run_cmd = [ASGARD_PATH] + args.split(' ')
+    print(run_cmd)
+    result = subprocess.run(run_cmd, stdout=subprocess.PIPE).stdout.decode('utf-8')	
+    print(result)
+
+        

--- a/testing/automated/performance-regression-check.py
+++ b/testing/automated/performance-regression-check.py
@@ -11,7 +11,7 @@ import os
 # constants
 RUN_ENTRIES = 2 # run structure: asgard args, average timestep
 EMPTY_RUN = ''
-ASGARD_PATH = '../../build/asgard' # is there a better way to do this? not relocatable...
+ASGARD_PATH = './asgard' # is there a better way to do this? not relocatable...
 NUM_THREADS = 8
 
 ## exit codes

--- a/testing/automated/performance-regression-check.py
+++ b/testing/automated/performance-regression-check.py
@@ -3,12 +3,21 @@
 # imports
 import csv
 import subprocess
+import re
+import sys
 
 # constants
 BENCH_FILE = 'bench.txt'
 RUN_ENTRIES = 2 # run structure: asgard args, average timestep
 EMPTY_RUN = ""
 ASGARD_PATH = "../../build/asgard" # is there a better way to do this? not relocatable...
+
+TIMESTEP_BEGIN = 'explicit_time_advance - avg: '
+TIMESTEP_END = ' min:'
+COMMIT_BEGIN = 'Commit Summary: '
+COMMIT_END = '\n'
+ 
+TOLERANCE = 5 # percent change in runtime we will accept
 
 # helper
 def is_float(value):
@@ -18,6 +27,36 @@ def is_float(value):
 	except ValueError:
 		return False
 
+def find_first_between(haystack, begin, end):
+	find = re.search(begin + '(.*)' + end, haystack)
+	if find is None: 
+		return find
+	needle = find.group(1)
+	return needle
+
+def parse_timestep_avg(result):
+    time = find_first_between(result, TIMESTEP_BEGIN, TIMESTEP_END)
+    assert(is_float(time)), 'parsed avg timestep should be a float'
+    print('time: ' + time)
+    return(float(time))
+
+def parse_commit(result):
+	commit = find_first_between(result, COMMIT_BEGIN, COMMIT_END)
+	assert(commit is not None), 'failed to parse commit hash'
+	return commit
+
+def within_performance_range(old_time, new_time):
+	if old_time == new_time:
+		diff = 0
+	try:
+		diff = (abs(old_time - new_time) / old_time) * 100.0
+	except ZeroDivisionError:
+		diff = float('inf')
+	if diff > tolerance:
+		print('difference = {}, failed!'.format(diff))
+		return False
+	return True	
+
 # execution
 timings = dict()
 with open(BENCH_FILE) as run_details:
@@ -25,19 +64,36 @@ with open(BENCH_FILE) as run_details:
 	commit = next(run_csv)[0]
 	print('bench commit: {}'.format(commit))
 	for run in run_csv:
-		assert(len(run) == RUN_ENTRIES), "run args and avg timestep required for all runs!"
+		assert(len(run) == RUN_ENTRIES), 'run args and avg timestep required for all runs'
 		asgard_args, avg_timestep_ms = run[:RUN_ENTRIES]
 		print(asgard_args)
 		if is_float(avg_timestep_ms):
-			timings[asgard_args] = avg_timestep_ms
+			timings[asgard_args] = float(avg_timestep_ms)
 		else:
 			timings[asgard_args] = EMPTY_RUN
 
+empty_keys = [args for args, time in timings.items() if time == EMPTY_RUN]
+assert(len(empty_keys) == 0 or len(empty_keys) == len(timings)), 'timings must be all present (check run) or none present (set run)' 
+no_data = (len(empty_keys) == len(timings))
+
+# run asgard to collect timing
+new_times = dict()
 for args, timing in timings.items():
-    print(args)
-    run_cmd = [ASGARD_PATH] + args.split(' ')
-    print(run_cmd)
-    result = subprocess.run(run_cmd, stdout=subprocess.PIPE).stdout.decode('utf-8')	
-    print(result)
+	run_cmd = [ASGARD_PATH] + args.split(' ')
+	result = subprocess.run(run_cmd, stdout=subprocess.PIPE).stdout.decode('utf-8')	
+	new_time = parse_timestep_avg(result)
+	if no_data:	# setting new benchmark
+		new_times[args] = new_time
+		commit = parse_commit(result)
+	else:
+		if not within_performance_range(timing, new_time):
+			sys.exit(1)
+
+# write benchmark if not present
+if no_data:
+	with open(BENCH_FILE,'w') as bench:
+		bench.write('{}\n'.format(commit))
+		for args, time in new_times.items():
+			bench.write('{},{}\n'.format(args, time)) 
 
         


### PR DESCRIPTION
simple first stab at end to end performance regression for CPU / non-CPU:

setup script reads builds/run configs from config file (yaml?). parses end-to-end timings for each build/run config, stores with commit hash in bench file.

for each build/run config, a jenkins job is assigned to pull appropriate data from bench file, run same build/run config. script pases end-to-end timings, compares with bench file.

deviation of 5% up or down triggers failure reported in custom message on github: "significant performance changes detected, see build log".