### PR TITLE
Build and run all tests successfully on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ if(ASGARD_USE_MKL)
   if(ASGARD_USE_CUDA)
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --compiler-options -fopenmp")
   else()
-    target_link_libraries(kronmult_cuda PRIVATE OpenMP::OpenMP_CXX) # CMAKE doesn't handle MKL openmp link properly
+    target_link_libraries( kronmult_cuda PRIVATE OpenMP::OpenMP_CXX) # CMAKE doesn't handle MKL openmp link properly
   endif()
 endif()
 
@@ -178,7 +178,7 @@ foreach (component IN LISTS components)
   add_library (${component} src/${component}.cpp)
   target_include_directories (${component} PRIVATE ${CMAKE_BINARY_DIR})
   if(ASGARD_USE_MKL)
-    target_compile_options (${component} PRIVATE "-fopenmp") # CMAKE doesn't handle MKL openmp link properly
+    target_link_libraries( ${component} PRIVATE OpenMP::OpenMP_CXX) # CMAKE doesn't handle MKL openmp link properly
   endif()
 endforeach ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ if(ASGARD_USE_MKL)
   if(ASGARD_USE_CUDA)
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --compiler-options -fopenmp")
   else()
-    target_compile_options (kronmult_cuda PRIVATE "-fopenmp") # CMAKE doesn't handle MKL openmp link properly
+    target_link_libraries(kronmult_cuda PRIVATE OpenMP::OpenMP_CXX) # CMAKE doesn't handle MKL openmp link properly
   endif()
 endif()
 
@@ -365,7 +365,7 @@ if (ASGARD_BUILD_TESTS)
          set(test_ranks ${ASGARD_TESTING_RANKS})
         endif ()
         add_test (NAME ${component}-test-mpi
-                  COMMAND mpirun -n ${test_ranks} ${component}-tests
+                  COMMAND mpirun -n ${test_ranks} ./${component}-tests
                   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} )
       endif()
     endif ()


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

I encountered a linking error building ASGarD on my macbook pro. I fixed this by using the `OpenMP::OpenMP_CXX` target to set both appropriate compiler and linker flags.

```
[ 20%] Linking CXX shared library libkronmult_cuda.dylib
/usr/local/Cellar/cmake/3.19.3/bin/cmake -E cmake_link_script CMakeFiles/kronmult_cuda.dir/link.txt --verbose=1
/usr/local/bin/g++-10  -Wall -Wextra -Wpedantic -O3 -DNDEBUG -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk -mmacosx-version-min=10.15 -dynamiclib -Wl,-headerpad_max_install_names -o libkronmult_cuda.dylib -install_name @rpath/libkronmult_cuda.dylib CMakeFiles/kronmult_cuda.dir/src/device/kronmult_cuda.cpp.o  -Wl,-rpath,/Users/svh/Documents/asgard/build/contrib/kronmult contrib/kronmult/libkron.dylib 
Undefined symbols for architecture x86_64:
  "_GOMP_parallel", referenced from:
      __Z21stage_inputs_kronmultIfEvPKT_PS0_ii in kronmult_cuda.cpp.o
      __Z21stage_inputs_kronmultIdEvPKT_PS0_ii in kronmult_cuda.cpp.o
      __Z16prepare_kronmultIfEvPKiPKPT_iS3_S3_S3_PS3_S6_S6_S6_iiiiiii in kronmult_cuda.cpp.o
      __Z16prepare_kronmultIdEvPKiPKPT_iS3_S3_S3_PS3_S6_S6_S6_iiiiiii in kronmult_cuda.cpp.o
      __Z13call_kronmultIfEviPPT_S2_S2_PKPKS0_iii in kronmult_cuda.cpp.o
      __Z13call_kronmultIdEviPPT_S2_S2_PKPKS0_iii in kronmult_cuda.cpp.o
  "_omp_get_num_threads", referenced from:
      __Z28stage_inputs_kronmult_kernelIfEvPKT_PS0_ii._omp_fn.0 in kronmult_cuda.cpp.o
      __Z28stage_inputs_kronmult_kernelIdEvPKT_PS0_ii._omp_fn.0 in kronmult_cuda.cpp.o
      __Z23prepare_kronmult_kernelIfEvPKiPKPT_iS3_S3_S3_PS3_S6_S6_S6_iiiiiii._omp_fn.0 in kronmult_cuda.cpp.o
      __Z23prepare_kronmult_kernelIdEvPKiPKPT_iS3_S3_S3_PS3_S6_S6_S6_iiiiiii._omp_fn.0 in kronmult_cuda.cpp.o
      __Z18kronmult2_xbatchedIfEviPKPKT_iPPS0_S6_S6_i._omp_fn.0 in kronmult_cuda.cpp.o
      __Z18kronmult6_xbatchedIfEviPKPKT_iPPS0_S6_S6_i._omp_fn.0 in kronmult_cuda.cpp.o
      __Z18kronmult3_xbatchedIfEviPKPKT_iPPS0_S6_S6_i._omp_fn.0 in kronmult_cuda.cpp.o
      ...
  "_omp_get_thread_num", referenced from:
      __Z28stage_inputs_kronmult_kernelIfEvPKT_PS0_ii._omp_fn.0 in kronmult_cuda.cpp.o
      __Z28stage_inputs_kronmult_kernelIdEvPKT_PS0_ii._omp_fn.0 in kronmult_cuda.cpp.o
      __Z23prepare_kronmult_kernelIfEvPKiPKPT_iS3_S3_S3_PS3_S6_S6_S6_iiiiiii._omp_fn.0 in kronmult_cuda.cpp.o
      __Z23prepare_kronmult_kernelIdEvPKiPKPT_iS3_S3_S3_PS3_S6_S6_S6_iiiiiii._omp_fn.0 in kronmult_cuda.cpp.o
      __Z18kronmult2_xbatchedIfEviPKPKT_iPPS0_S6_S6_i._omp_fn.0 in kronmult_cuda.cpp.o
      __Z18kronmult6_xbatchedIfEviPKPKT_iPPS0_S6_S6_i._omp_fn.0 in kronmult_cuda.cpp.o
      __Z18kronmult3_xbatchedIfEviPKPKT_iPPS0_S6_S6_i._omp_fn.0 in kronmult_cuda.cpp.o
      ...
ld: symbol(s) not found for architecture x86_64
```

In addition any tests using MPI failed with the error below. Adding `./` before the executable seems to fix this.
https://stackoverflow.com/questions/47472153/mpi-mpirun-execvp-error-no-such-file-or-directory 

```
% ctest -R time_advance-test-mpi --output-on-failure
Test project /Users/svh/Documents/asgard/build
    Start 20: time_advance-test-mpi
1/1 Test #20: time_advance-test-mpi ............***Failed    0.07 sec
[proxy:0:0@mac102014] HYDU_create_process (utils/launch/launch.c:74): execvp error on file time_advance-tests (No such file or directory)
[proxy:0:0@mac102014] HYDU_create_process (utils/launch/launch.c:74): execvp error on file time_advance-tests (No such file or directory)
[proxy:0:0@mac102014] HYDU_create_process (utils/launch/launch.c:74): execvp error on file time_advance-tests (No such file or directory)
[proxy:0:0@mac102014] HYDU_create_process (utils/launch/launch.c:74): execvp error on file time_advance-tests (No such file or directory)
```

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

MacOS 10.15, GCC 10, OpenMPI, MKL

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [ ] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
