### PR TITLE
Fix openmp linking with the Intel MKL, round 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ if(ASGARD_USE_MKL)
   if(ASGARD_USE_CUDA)
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --compiler-options -fopenmp")
   else()
-    target_link_libraries( kronmult_cuda PRIVATE OpenMP::OpenMP_CXX) # CMAKE doesn't handle MKL openmp link properly
+    target_compile_options (kronmult_cuda PRIVATE "-fopenmp") # CMAKE doesn't handle MKL openmp link properly
   endif()
 endif()
 
@@ -178,7 +178,7 @@ foreach (component IN LISTS components)
   add_library (${component} src/${component}.cpp)
   target_include_directories (${component} PRIVATE ${CMAKE_BINARY_DIR})
   if(ASGARD_USE_MKL)
-    target_link_libraries( ${component} PRIVATE OpenMP::OpenMP_CXX) # CMAKE doesn't handle MKL openmp link properly
+    target_compile_options (${component} PRIVATE "-fopenmp") # CMAKE doesn't handle MKL openmp link properly
   endif()
 endforeach ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,14 @@ if(ASGARD_USE_MKL)
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --compiler-options -fopenmp")
   else()
     target_compile_options (kronmult_cuda PRIVATE "-fopenmp") # CMAKE doesn't handle MKL openmp link properly
+    if(APPLE) # Need to link against the same openmp library as the MKL.
+      foreach (_lib IN LISTS LINALG_LIBS)
+        if (_lib MATCHES "libiomp5")
+          target_link_libraries(kronmult_cuda PRIVATE ${_lib})
+          break()
+        endif()
+      endforeach()
+    endif()
   endif()
 endif()
 

--- a/src/kronmult_tests.cpp
+++ b/src/kronmult_tests.cpp
@@ -117,7 +117,7 @@ TEMPLATE_TEST_CASE("test kronmult", "[kronmult]", float, double)
 TEMPLATE_TEST_CASE("test kronmult w/ decompose", "[kronmult]", float, double)
 {
   TestType const tol_factor =
-      std::is_same<TestType, double>::value ? 1e-15 : 1e-7;
+      std::is_same<TestType, double>::value ? 1e-15 : 1.1e-7;
 
   SECTION("2d - uniform level")
   {


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes
 
This reverts changes in #379 that fixed a linking error on MacOS but caused failing tests in Linux.

On MacOS `FindBLAS.cmake` is finding the sequential version of the MKL, which doesn't link against openmp. I was able to get the threaded version by copy `/opt/intel/oneapi/compiler/latest/mac/compiler/lib/libiomp5.dylib` to `/opt/intel/oneapi/mkl/latest/lib`. Where's the best place to document and/or report this finding?

`test kronmult w/ decompose` was failing but very close to the tolerance. Increasing the tolerance from 1e-7 to 1.1e-7 is sufficient to fix this.

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [ ] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
