### PR TITLE
Replace git submodule with cmake fetch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,7 +289,7 @@ if (ASGARD_USE_OPENMP AND NOT ASGARD_USE_MKL)
    target_link_libraries(kronmult PRIVATE OpenMP::OpenMP_CXX)
 endif ()
 
-target_link_libraries(kronmult_cuda PRIVATE kron)
+target_link_libraries(kronmult_cuda PUBLIC kron)
 
 if (ASGARD_USE_OPENMP AND NOT ASGARD_USE_MKL)
    target_link_libraries(kronmult_cuda PRIVATE OpenMP::OpenMP_CXX)
@@ -390,6 +390,8 @@ configure_file(
 )
 # Include the generated build_info.hpp
 target_include_directories (asgard PRIVATE ${CMAKE_BINARY_DIR})
+
+target_include_directories (kronmult_cuda PRIVATE ${CMAKE_BINARY_DIR})
 
 ###############################################################################
 ## Testing asgard

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ if(ASGARD_USE_CUDA)
   set_target_properties( kronmult_cuda PROPERTIES LINK_FLAGS "-Wl,-rpath,${CMAKE_BINARY_DIR}")
 
 #  Turn on GPU support in kronmult.
-  set (USE_GPU ON)
+  set (USE_GPU ON CACHE BOOL "Turn on kronmult gpu support" FORCE)
 endif()
 
 if(ASGARD_USE_MKL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include (FetchContent)
 find_package (Git)
 
 #  Define a macro to register new projects.
-macro (register_project name dir url default_tag)
+function (register_project name dir url default_tag)
     set (BUILD_TAG_${dir} ${default_tag} CACHE STRING "Name of the tag to checkout.")
     set (BUILD_REPO_${dir} ${url} CACHE STRING "URL of the repo to clone.")
 
@@ -20,32 +20,12 @@ macro (register_project name dir url default_tag)
     FetchContent_Declare(
         ${name}
         GIT_REPOSITORY ${BUILD_REPO_${dir}}
-        GIT_TAG origin/${BUILD_TAG_${dir}}
+        GIT_TAG ${BUILD_TAG_${dir}}
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/contrib/${dir}
     )
 
     FetchContent_MakeAvailable(${name})
-
-    if (GIT_FOUND)
-#  By default cmake clones projects in a headless state. After the repo is
-#  cloned checkout the requested tag so repo is in a working state.
-        execute_process(
-            COMMAND ${GIT_EXECUTABLE} checkout ${BUILD_TAG_${dir}}
-            WORKING_DIRECTORY ${${name}_SOURCE_DIR}
-        )
-
-#  Add a taraget to pull the latest version before building. Note dependency is
-#  registered in the sub project CMakeList.txt. Not sure how this should handle
-#  multiple targets in a project yet. Name must match the subproject pull_
-#  dependency.
-        add_custom_target(
-            pull_${name}
-            ALL
-            COMMAND ${GIT_EXECUTABLE} pull
-            WORKING_DIRECTORY ${${name}_SOURCE_DIR}
-        )
-    endif ()
-endmacro ()
+endfunction ()
 
 #  Changes to the current version of kromult should proceed through a pull
 #  request. By default, a specific tag should be specifed.
@@ -169,8 +149,10 @@ if(ASGARD_USE_CUDA)
   set_target_properties( kronmult_cuda PROPERTIES CUDA_ARCHITECTURES OFF)
   set_target_properties( kronmult_cuda PROPERTIES COMPILE_FLAGS "-arch sm_70 -g -lineinfo --ptxas-options=-O3")
   set_target_properties( kronmult_cuda PROPERTIES LINK_FLAGS "-Wl,-rpath,${CMAKE_BINARY_DIR}")
+
+#  Turn on GPU support in kronmult.
+  set (USE_GPU ON)
 endif()
-#target_include_directories (kronmult_cuda PRIVATE ${CMAKE_SOURCE_DIR}/contrib/kronmult/ ${CMAKE_BINARY_DIR})
 
 if(ASGARD_USE_MKL)
   if(ASGARD_USE_CUDA)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ endfunction ()
 register_project (kronmult
                   KRONMULT
                   https://github.com/project-asgard/kronmult.git
-                  431cc12
+                  4738501
 )
 
 ###############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,7 @@ if(ASGARD_USE_CUDA)
   set_target_properties( kronmult_cuda PROPERTIES COMPILE_FLAGS "-arch sm_70 -g -lineinfo --ptxas-options=-O3")
   set_target_properties( kronmult_cuda PROPERTIES LINK_FLAGS "-Wl,-rpath,${CMAKE_BINARY_DIR}")
 endif()
-target_include_directories (kronmult_cuda PRIVATE ${CMAKE_SOURCE_DIR}/contrib/kronmult/ ${CMAKE_BINARY_DIR})
+#target_include_directories (kronmult_cuda PRIVATE ${CMAKE_SOURCE_DIR}/contrib/kronmult/ ${CMAKE_BINARY_DIR})
 
 if(ASGARD_USE_MKL)
   if(ASGARD_USE_CUDA)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,53 @@ project (asgard
   LANGUAGES CXX
 )
 
+#-------------------------------------------------------------------------------
+#  Setup the kromult external project.
+#-------------------------------------------------------------------------------
+include (FetchContent)
+find_package (Git)
+
+#  Define a macro to register new projects.
+macro (register_project name dir url default_tag)
+    set (BUILD_TAG_${dir} ${default_tag} CACHE STRING "Name of the tag to checkout.")
+
+#  Set up the sub project repository.
+    FetchContent_Declare(
+        ${name}
+        GIT_REPOSITORY ${url}
+        GIT_TAG origin/${BUILD_TAG_${dir}}
+        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${dir}
+    )
+
+    FetchContent_MakeAvailable(${name})
+
+    if (GIT_FOUND)
+#  By default cmake clones projects in a headless state. After the repo is
+#  cloned checkout the requested tag so repo is in a working state.
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} checkout ${BUILD_TAG_${dir}}
+            WORKING_DIRECTORY ${${name}_SOURCE_DIR}
+        )
+
+#  Add a taraget to pull the latest version before building. Note dependency is
+#  registered in the sub project CMakeList.txt. Not sure how this should handle
+#  multiple targets in a project yet. Name must match the subproject pull_
+#  dependency.
+        add_custom_target(
+            pull_${name}
+            ALL
+            COMMAND ${GIT_EXECUTABLE} pull
+            WORKING_DIRECTORY ${${name}_SOURCE_DIR}
+        )
+    endif ()
+endmacro ()
+
+register_project (kronmult
+                  KRONMULT
+                  https://github.com/cianciosa/kronmult.git
+                  master
+)
+
 ###############################################################################
 ## Set up the compiler and general global build options
 ###############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ macro (register_project name dir url default_tag)
         ${name}
         GIT_REPOSITORY ${BUILD_REPO_${dir}}
         GIT_TAG origin/${BUILD_TAG_${dir}}
-        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${dir}
+        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/contrib/${dir}
     )
 
     FetchContent_MakeAvailable(${name})
@@ -47,10 +47,12 @@ macro (register_project name dir url default_tag)
     endif ()
 endmacro ()
 
+#  Changes to the current version of kromult should proceed through a pull
+#  request. By default, a specific tag should be specifed.
 register_project (kronmult
                   KRONMULT
                   https://github.com/project-asgard/kronmult.git
-                  master
+                  431cc12
 )
 
 ###############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,12 @@ find_package (Git)
 #  Define a macro to register new projects.
 macro (register_project name dir url default_tag)
     set (BUILD_TAG_${dir} ${default_tag} CACHE STRING "Name of the tag to checkout.")
+    set (BUILD_REPO_${dir} ${url} CACHE STRING "URL of the repo to clone.")
 
 #  Set up the sub project repository.
     FetchContent_Declare(
         ${name}
-        GIT_REPOSITORY ${url}
+        GIT_REPOSITORY ${BUILD_REPO_${dir}}
         GIT_TAG origin/${BUILD_TAG_${dir}}
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${dir}
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ endmacro ()
 
 register_project (kronmult
                   KRONMULT
-                  https://github.com/cianciosa/kronmult.git
+                  https://github.com/project-asgard/kronmult.git
                   master
 )
 

--- a/contrib/contrib.cmake
+++ b/contrib/contrib.cmake
@@ -197,8 +197,8 @@ if((NOT EXISTS ${KRON_INCLUDE_DIR}/CMakeLists.txt))
 
     # we have a submodule setup for kron, assume it is under external/kron
     # now we need to clone this submodule
-    execute_process(COMMAND git submodule update --init -- contrib/kronmult
-                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+#    execute_process(COMMAND git submodule update --init -- contrib/kronmult
+#                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
     set(KRON_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/contrib/kronmult/
         CACHE PATH "kronmult include directory")
@@ -206,4 +206,4 @@ if((NOT EXISTS ${KRON_INCLUDE_DIR}/CMakeLists.txt))
     # also install it
     install(DIRECTORY ${KRON_INCLUDE_DIR}/kronmult DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 endif()
-    add_subdirectory("${CMAKE_SOURCE_DIR}/contrib/kronmult")
+#    add_subdirectory("${CMAKE_SOURCE_DIR}/contrib/kronmult")

--- a/contrib/contrib.cmake
+++ b/contrib/contrib.cmake
@@ -184,26 +184,26 @@ endif ()
 # link to Ed D'Azevedo's kronmult library, or download/build if not present
 #
 ###############################################################################
-if(ASGARD_USE_CUDA)
-    set(USE_GPU 1)
-endif()
+#if(ASGARD_USE_CUDA)
+#    set(USE_GPU 1)
+#endif()
 
-set(KRON_PATH "${CMAKE_CURRENT_BINARY_DIR}/contrib/kronmult/")
-set(KRON_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/contrib/kronmult/")
+#set(KRON_PATH "${CMAKE_CURRENT_BINARY_DIR}/contrib/kronmult/")
+#set(KRON_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/contrib/kronmult/")
 
-if((NOT EXISTS ${KRON_INCLUDE_DIR}/CMakeLists.txt))
-    # we couldn't find the CMakeLists.txt for KRON or they don't exist
-    message("Unable to find kronmult submodule")
+#if((NOT EXISTS ${KRON_INCLUDE_DIR}/CMakeLists.txt))
+#    # we couldn't find the CMakeLists.txt for KRON or they don't exist
+#    message("Unable to find kronmult submodule")
 
-    # we have a submodule setup for kron, assume it is under external/kron
-    # now we need to clone this submodule
+#    # we have a submodule setup for kron, assume it is under external/kron
+#    # now we need to clone this submodule
 #    execute_process(COMMAND git submodule update --init -- contrib/kronmult
 #                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-    set(KRON_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/contrib/kronmult/
-        CACHE PATH "kronmult include directory")
+#    set(KRON_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/contrib/kronmult/
+#        CACHE PATH "kronmult include directory")
 
-    # also install it
-    install(DIRECTORY ${KRON_INCLUDE_DIR}/kronmult DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-endif()
+#    # also install it
+#    install(DIRECTORY ${KRON_INCLUDE_DIR}/kronmult DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+#endif()
 #    add_subdirectory("${CMAKE_SOURCE_DIR}/contrib/kronmult")

--- a/contrib/contrib.cmake
+++ b/contrib/contrib.cmake
@@ -175,35 +175,3 @@ if (ASGARD_BUILD_TESTS)
     ${CMAKE_SOURCE_DIR}
   )
 endif ()
-
-
-
-###############################################################################
-## E.D.'s kronmult library
-#
-# link to Ed D'Azevedo's kronmult library, or download/build if not present
-#
-###############################################################################
-#if(ASGARD_USE_CUDA)
-#    set(USE_GPU 1)
-#endif()
-
-#set(KRON_PATH "${CMAKE_CURRENT_BINARY_DIR}/contrib/kronmult/")
-#set(KRON_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/contrib/kronmult/")
-
-#if((NOT EXISTS ${KRON_INCLUDE_DIR}/CMakeLists.txt))
-#    # we couldn't find the CMakeLists.txt for KRON or they don't exist
-#    message("Unable to find kronmult submodule")
-
-#    # we have a submodule setup for kron, assume it is under external/kron
-#    # now we need to clone this submodule
-#    execute_process(COMMAND git submodule update --init -- contrib/kronmult
-#                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-#    set(KRON_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/contrib/kronmult/
-#        CACHE PATH "kronmult include directory")
-
-#    # also install it
-#    install(DIRECTORY ${KRON_INCLUDE_DIR}/kronmult DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-#endif()
-#    add_subdirectory("${CMAKE_SOURCE_DIR}/contrib/kronmult")

--- a/src/adapt.cpp
+++ b/src/adapt.cpp
@@ -313,8 +313,6 @@ fk::vector<P> distributed_grid<P>::refine_elements(
   auto const remapper = remap_for_addtl(table_.size() - added);
   auto const y        = redistribute_vector(x, plan_, new_plan, remapper);
   plan_               = distribution_plan(new_plan);
-//  plan_.clear();
-//  plan_.insert(new_plan.begin(), new_plan.end());
 
   return y;
 }
@@ -341,8 +339,6 @@ fk::vector<P> distributed_grid<P>::remove_elements(
   auto const remapper = remap_for_delete(all_remove_indices, table_.size());
   auto const y        = redistribute_vector(x, plan_, new_plan, remapper);
   plan_               = distribution_plan(new_plan);
-//  plan_.clear();
-//  plan_.insert(new_plan.begin(), new_plan.end());
   return y;
 }
 

--- a/src/adapt.cpp
+++ b/src/adapt.cpp
@@ -312,7 +312,7 @@ fk::vector<P> distributed_grid<P>::refine_elements(
   auto const new_plan = get_plan(get_num_ranks(), table_);
   auto const remapper = remap_for_addtl(table_.size() - added);
   auto const y        = redistribute_vector(x, plan_, new_plan, remapper);
-  plan_               = distribution_plan(new_plan);
+  plan_               = new_plan;
 
   return y;
 }
@@ -338,7 +338,7 @@ fk::vector<P> distributed_grid<P>::remove_elements(
   auto const new_plan = get_plan(get_num_ranks(), table_);
   auto const remapper = remap_for_delete(all_remove_indices, table_.size());
   auto const y        = redistribute_vector(x, plan_, new_plan, remapper);
-  plan_               = distribution_plan(new_plan);
+  plan_               = new_plan;
   return y;
 }
 

--- a/src/adapt.cpp
+++ b/src/adapt.cpp
@@ -309,12 +309,10 @@ fk::vector<P> distributed_grid<P>::refine_elements(
   }
 
   auto const added    = table_.add_elements(all_child_ids, opts.max_level);
-  auto const &&new_plan = get_plan(get_num_ranks(), table_);
+  auto const new_plan = get_plan(get_num_ranks(), table_);
   auto const remapper = remap_for_addtl(table_.size() - added);
   auto const y        = redistribute_vector(x, plan_, new_plan, remapper);
   plan_               = distribution_plan(new_plan);
-//  plan_.clear();
-//  plan_.insert(new_plan.begin(), new_plan.end());
 
   return y;
 }
@@ -341,8 +339,6 @@ fk::vector<P> distributed_grid<P>::remove_elements(
   auto const remapper = remap_for_delete(all_remove_indices, table_.size());
   auto const y        = redistribute_vector(x, plan_, new_plan, remapper);
   plan_               = distribution_plan(new_plan);
-//  plan_.clear();
-//  plan_.insert(new_plan.begin(), new_plan.end());
   return y;
 }
 

--- a/src/adapt.cpp
+++ b/src/adapt.cpp
@@ -309,7 +309,7 @@ fk::vector<P> distributed_grid<P>::refine_elements(
   }
 
   auto const added    = table_.add_elements(all_child_ids, opts.max_level);
-  auto const &&new_plan = get_plan(get_num_ranks(), table_);
+  auto const new_plan = get_plan(get_num_ranks(), table_);
   auto const remapper = remap_for_addtl(table_.size() - added);
   auto const y        = redistribute_vector(x, plan_, new_plan, remapper);
   plan_               = distribution_plan(new_plan);

--- a/src/adapt.cpp
+++ b/src/adapt.cpp
@@ -309,10 +309,12 @@ fk::vector<P> distributed_grid<P>::refine_elements(
   }
 
   auto const added    = table_.add_elements(all_child_ids, opts.max_level);
-  auto const new_plan = get_plan(get_num_ranks(), table_);
+  auto const &&new_plan = get_plan(get_num_ranks(), table_);
   auto const remapper = remap_for_addtl(table_.size() - added);
   auto const y        = redistribute_vector(x, plan_, new_plan, remapper);
-  plan_               = new_plan;
+  plan_               = distribution_plan(new_plan);
+//  plan_.clear();
+//  plan_.insert(new_plan.begin(), new_plan.end());
 
   return y;
 }
@@ -338,7 +340,9 @@ fk::vector<P> distributed_grid<P>::remove_elements(
   auto const new_plan = get_plan(get_num_ranks(), table_);
   auto const remapper = remap_for_delete(all_remove_indices, table_.size());
   auto const y        = redistribute_vector(x, plan_, new_plan, remapper);
-  plan_               = new_plan;
+  plan_               = distribution_plan(new_plan);
+//  plan_.clear();
+//  plan_.insert(new_plan.begin(), new_plan.end());
   return y;
 }
 


### PR DESCRIPTION
NOTE: This cannot be merged until the kronmult https://github.com/project-asgard/kronmult/pull/9 is merged since it requires changes from that pull request.

## Proposed changes

This change defines a macro function for registering external cmake based projects. Once an external project is registered, a developer may configure their build to point to other forks or other branches using the new  build setting

- `BUILD_REPO_<NAME>`
- `BUILD_TAG_<NAME>`

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [ ] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [x] Yes
- [ ] No

## What systems has this change been tested on?
This has been tested with CUDA support on an ubuntu 18.04 install. Tests for

- kronmult-test
- time_advance-test-mpi
- time_advance-test
- kronmult_cuda-test

currently fail.

MacOS build still fail due to issues referenced in https://github.com/project-asgard/asgard/issues/387 in the adapt library.

## Checklist

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
