### PR TITLE
Fix -Wdtor-name warnings with clang 11+

### DIFF
--- a/src/tensors.hpp
+++ b/src/tensors.hpp
@@ -944,7 +944,7 @@ fk::vector<P, mem, resrc>::vector(fk::matrix<P, omem, resrc> &source,
 {}
 
 template<typename P, mem_type mem, resource resrc>
-fk::vector<P, mem, resrc>::~vector()
+fk::vector<P, mem, resrc>::~vector<P, mem, resrc>()
 {
   if constexpr (mem == mem_type::owner)
   {
@@ -1728,7 +1728,7 @@ fk::matrix<P, mem, resrc>::matrix(fk::vector<P, omem, resrc> &source,
 
 // destructor
 template<typename P, mem_type mem, resource resrc>
-fk::matrix<P, mem, resrc>::~matrix()
+fk::matrix<P, mem, resrc>::~matrix<P, mem, resrc>()
 {
   if constexpr (mem == mem_type::owner)
   {


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Fixes a couple warnings that appear with recent versions of Clang.

https://clang.llvm.org/docs/DiagnosticsReference.html#wdtor-name

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
