### PR TITLE
Add patch to openblas. Use get_tolerance function to fix precision failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,14 +16,21 @@ function (register_project name dir url default_tag)
     set (BUILD_TAG_${dir} ${default_tag} CACHE STRING "Name of the tag to checkout.")
     set (BUILD_REPO_${dir} ${url} CACHE STRING "URL of the repo to clone.")
 
-#  Set up the sub project repository.
+    #Check for optional patch file.
+    set(PATCH_COMMAND "")
+    if(${ARGC} EQUAL 5)
+        find_package(Git)
+        set(_apply_flags --ignore-space-change --whitespace=fix)
+        set(PATCH_COMMAND "${GIT_EXECUTABLE}" reset --hard ${BUILD_TAG_${dir}} COMMAND "${GIT_EXECUTABLE}" apply ${_apply_flags} "${ARGV4}")
+    endif()
+    #  Set up the sub project repository.
     FetchContent_Declare(
         ${name}
         GIT_REPOSITORY ${BUILD_REPO_${dir}}
         GIT_TAG ${BUILD_TAG_${dir}}
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/contrib/${dir}
+	PATCH_COMMAND ${PATCH_COMMAND}
     )
-
     FetchContent_MakeAvailable(${name})
 endfunction ()
 

--- a/contrib/FindLINALG.cmake
+++ b/contrib/FindLINALG.cmake
@@ -53,7 +53,8 @@ if (${ASGARD_BUILD_OPENBLAS})
     register_project (openblas
                       OPENBLAS
                       https://github.com/xianyi/OpenBLAS.git
-                      v0.3.18
+                      v0.3.19
+                      ${CMAKE_SOURCE_DIR}/contrib/openblas.patch
     )
 
 #  Fetch content does not run the install phase so the headers for openblas are

--- a/contrib/openblas.patch
+++ b/contrib/openblas.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/utils.cmake b/cmake/utils.cmake
+index c5ee6538..56c1cb06 100644
+--- a/cmake/utils.cmake
++++ b/cmake/utils.cmake
+@@ -125,7 +125,7 @@ macro(ParseMakefileVars MAKEFILE_IN)
+     if (NOT "${line_match}" STREQUAL "")
+       #message(STATUS "${CMAKE_MATCH_1} first: ${CMAKE_MATCH_2}")
+       set (ElseSeen 0)
+-      if (DEFINED ${CMAKE_MATCH_2})
++      if (${CMAKE_MATCH_2})
+         if (${CMAKE_MATCH_1} STREQUAL "ifdef")
+           #message (STATUS "condition is true")
+           set (IfElse 1)

--- a/src/adapt_tests.cpp
+++ b/src/adapt_tests.cpp
@@ -210,8 +210,8 @@ void test_initial(parser const &problem, std::string const &gold_filepath)
       adaptive_grid.get_initial_condition(*pde, transformer, opts);
 
   auto constexpr tol_factor = get_tolerance<P>(100);
-  auto const my_subgrid   = adaptive_grid.get_subgrid(get_rank());
-  auto const segment_size = element_segment_size(*pde);
+  auto const my_subgrid     = adaptive_grid.get_subgrid(get_rank());
+  auto const segment_size   = element_segment_size(*pde);
   fk::vector<P, mem_type::const_view> const my_gold(
       gold, my_subgrid.col_start * segment_size,
       (my_subgrid.col_stop + 1) * segment_size - 1);

--- a/src/adapt_tests.cpp
+++ b/src/adapt_tests.cpp
@@ -209,7 +209,7 @@ void test_initial(parser const &problem, std::string const &gold_filepath)
   auto const test =
       adaptive_grid.get_initial_condition(*pde, transformer, opts);
 
-  P const tol_factor      = std::is_same<P, double>::value ? 1e-15 : 1e-5;
+  auto constexpr tol_factor = get_tolerance<P>(100);
   auto const my_subgrid   = adaptive_grid.get_subgrid(get_rank());
   auto const segment_size = element_segment_size(*pde);
   fk::vector<P, mem_type::const_view> const my_gold(

--- a/src/basis_tests.cpp
+++ b/src/basis_tests.cpp
@@ -77,8 +77,7 @@ void test_multiwavelet_gen(int const degree, P const tol_factor)
 
 TEMPLATE_TEST_CASE("Multiwavelet", "[transformations]", double, float)
 {
-  TestType const tol_factor =
-      std::is_same<TestType, double>::value ? 1e-14 : 1e-4;
+  auto constexpr tol_factor = get_tolerance<TestType>(100);
 
   SECTION("Multiwavelet generation, degree = 1")
   {
@@ -113,7 +112,7 @@ void test_operator_two_scale(int const levels, int const degree)
       std::to_string(degree) + "_" + std::to_string(levels) + ".dat"));
   fk::matrix<P> const test = operator_two_scale<P>(degree, levels);
 
-  P const tol_factor = 1e-14;
+  auto constexpr tol_factor = get_tolerance<P>(10);
 
   rmse_comparison(gold, test, tol_factor);
 }

--- a/src/batch_tests.cpp
+++ b/src/batch_tests.cpp
@@ -641,7 +641,7 @@ void test_batched_gemm(int const m, int const n, int const k, int const lda,
     return fk::matrix<P, mem_type::const_view>(c, 0, m - 1, 0, n - 1);
   };
 
-  P const tol_factor = std::is_same<P, double>::value ? 1e-15 : 1e-6;
+  auto constexpr tol_factor = get_tolerance<P>(10);
 
   for (int i = 0; i < num_batch; ++i)
   {
@@ -864,7 +864,8 @@ void test_batched_gemv(int const m, int const n, int const lda,
 
   batched_gemv(a_batch, x_batch, y_batch, alpha, beta);
 
-  P const tol_factor = 1e-17;
+  auto constexpr tol_factor = get_tolerance<P>(10);
+
   for (int i = 0; i < num_batch; ++i)
   {
     if constexpr (resrc == resource::host)

--- a/src/boundary_conditions_tests.cpp
+++ b/src/boundary_conditions_tests.cpp
@@ -174,8 +174,7 @@ TEMPLATE_TEST_CASE("problem separability", "[boundary_condition]", double,
             unscaled_parts_0[0], unscaled_parts_0[1], *pde, start_element,
             stop_element, test_time);
 
-    TestType const tol_factor =
-        std::is_same<TestType, double>::value ? 1e-17 : 1e-8;
+    auto constexpr tol_factor = get_tolerance<TestType>(10);
     rmse_comparison(bc_advanced_0, bc_advanced_1, tol_factor);
   }
 
@@ -228,8 +227,8 @@ TEMPLATE_TEST_CASE("problem separability", "[boundary_condition]", double,
       fk::vector<TestType, mem_type::const_view> const bc_section(
           bc_init, index, index + bc_advanced.size() - 1);
 
-      TestType const tol_factor =
-          std::is_same<TestType, double>::value ? 1e-17 : 1e-4;
+      auto constexpr tol_factor = get_tolerance<TestType>(10);
+
       rmse_comparison(bc_section, bc_advanced, tol_factor);
 
       index += bc_advanced.size();
@@ -240,8 +239,7 @@ TEMPLATE_TEST_CASE("problem separability", "[boundary_condition]", double,
 TEMPLATE_TEST_CASE("compute_boundary_conditions", "[boundary_condition]",
                    double, float)
 {
-  TestType const tol_factor =
-      std::is_same<TestType, double>::value ? 1e-15 : 1e-6;
+  auto constexpr tol_factor = get_tolerance<TestType>(10);
 
   std::string const gold_filename_prefix =
       "../testing/generated-inputs/"
@@ -277,8 +275,7 @@ TEMPLATE_TEST_CASE("compute_boundary_conditions", "[boundary_condition]",
 TEMPLATE_TEST_CASE("boundary_conditions_vector", "[boundary_condition]", double,
                    float)
 {
-  TestType const tol_factor =
-      std::is_same<TestType, double>::value ? 1e-13 : 1e-4;
+  auto constexpr tol_factor = get_tolerance<TestType>(1000);
 
   SECTION("diffusion_1 level 2 degree 2")
   {

--- a/src/coefficients_tests.cpp
+++ b/src/coefficients_tests.cpp
@@ -6,7 +6,7 @@
 
 template<typename P>
 void test_coefficients(parser const &parse, std::string const &gold_path,
-                       P const tol_factor = 1e-15, bool const rotate = true)
+                       P const tol_factor = get_tolerance<P>(10), bool const rotate = true)
 {
   auto pde = make_PDE<P>(parse);
   options const opts(parse);
@@ -50,7 +50,7 @@ TEMPLATE_TEST_CASE("diffusion 2 (single term)", "[coefficients]", double, float)
   auto const pde_choice = PDE_opts::diffusion_2;
   auto const gold_path =
       "../testing/generated-inputs/coefficients/diffusion2_coefficients";
-  TestType const tol_factor = std::is_same_v<double, TestType> ? 1e-13 : 1e-4;
+  auto constexpr tol_factor = get_tolerance<TestType>(1000);
 
   SECTION("level 3, degree 5")
   {
@@ -74,7 +74,7 @@ TEMPLATE_TEST_CASE("diffusion 1 (single term)", "[coefficients]", double, float)
   auto const pde_choice = PDE_opts::diffusion_1;
   auto const gold_path =
       "../testing/generated-inputs/coefficients/diffusion1_coefficients";
-  TestType const tol_factor = std::is_same_v<double, TestType> ? 1e-12 : 1e-3;
+  auto constexpr tol_factor = get_tolerance<TestType>(10000);
 
   SECTION("level 5, degree 6")
   {
@@ -91,7 +91,7 @@ TEMPLATE_TEST_CASE("continuity 1 (single term)", "[coefficients]", double,
   auto const pde_choice = PDE_opts::continuity_1;
   auto const gold_path =
       "../testing/generated-inputs/coefficients/continuity1_coefficients";
-  TestType const tol_factor = std::is_same_v<double, TestType> ? 1e-14 : 1e-4;
+  auto constexpr tol_factor = get_tolerance<TestType>(1000);
 
   SECTION("level 2, degree 2 (default)")
   {
@@ -107,7 +107,7 @@ TEMPLATE_TEST_CASE("continuity 2 terms", "[coefficients]", double, float)
   auto const pde_choice = PDE_opts::continuity_2;
   auto const gold_path =
       "../testing/generated-inputs/coefficients/continuity2_coefficients";
-  TestType const tol_factor = std::is_same_v<double, TestType> ? 1e-14 : 1e-6;
+  auto constexpr tol_factor = get_tolerance<TestType>(10);
 
   SECTION("level 4, degree 3")
   {
@@ -131,7 +131,7 @@ TEMPLATE_TEST_CASE("continuity 3 terms", "[coefficients]", double, float)
   auto const gold_path =
       "../testing/generated-inputs/coefficients/continuity3_coefficients";
   auto const pde_choice     = PDE_opts::continuity_3;
-  TestType const tol_factor = std::is_same_v<double, TestType> ? 1e-14 : 1e-5;
+  auto constexpr tol_factor = get_tolerance<TestType>(100);
 
   SECTION("level 4, degree 4")
   {
@@ -155,7 +155,7 @@ TEMPLATE_TEST_CASE("continuity 6 terms", "[coefficients]", double, float)
   auto const gold_path =
       "../testing/generated-inputs/coefficients/continuity6_coefficients";
   auto const pde_choice     = PDE_opts::continuity_6;
-  TestType const tol_factor = std::is_same_v<double, TestType> ? 1e-14 : 1e-5;
+  auto constexpr tol_factor = get_tolerance<TestType>(1000);
 
   SECTION("level 2, degree 4")
   {
@@ -180,8 +180,7 @@ TEMPLATE_TEST_CASE("fokkerplanck1_pitch_E case1 terms", "[coefficients]",
   auto const pde_choice = PDE_opts::fokkerplanck_1d_pitch_E_case1;
   auto const gold_path  = "../testing/generated-inputs/coefficients/"
                          "fokkerplanck1_pitch_E_case1_coefficients";
-  TestType const tol_factor =
-      std::is_same<TestType, double>::value ? 1e-13 : 1e-5;
+  auto constexpr tol_factor = get_tolerance<TestType>(10);
 
   SECTION("level 4, degree 3")
   {
@@ -198,8 +197,7 @@ TEMPLATE_TEST_CASE("fokkerplanck1_pitch_E case2 terms", "[coefficients]",
   auto const pde_choice = PDE_opts::fokkerplanck_1d_pitch_E_case2;
   auto const gold_path  = "../testing/generated-inputs/coefficients/"
                          "fokkerplanck1_pitch_E_case2_coefficients";
-  TestType const tol_factor =
-      std::is_same<TestType, double>::value ? 1e-13 : 1e-5;
+  auto constexpr tol_factor = get_tolerance<TestType>(10);
 
   SECTION("level 4, degree 3")
   {

--- a/src/coefficients_tests.cpp
+++ b/src/coefficients_tests.cpp
@@ -6,7 +6,8 @@
 
 template<typename P>
 void test_coefficients(parser const &parse, std::string const &gold_path,
-                       P const tol_factor = get_tolerance<P>(10), bool const rotate = true)
+                       P const tol_factor = get_tolerance<P>(10),
+                       bool const rotate  = true)
 {
   auto pde = make_PDE<P>(parse);
   options const opts(parse);

--- a/src/fast_math_tests.cpp
+++ b/src/fast_math_tests.cpp
@@ -800,8 +800,7 @@ TEMPLATE_TEST_CASE("LU Routines", "[fast_math]", float, double)
 
     fm::gesv(A_copy, x, ipiv);
 
-    TestType const tol_factor =
-        std::is_same<TestType, double>::value ? 1e-16 : 1e-7;
+    auto constexpr tol_factor = get_tolerance<TestType>(10);
 
     rmse_comparison(A_copy, LU_gold, tol_factor);
     rmse_comparison(x, X_gold, tol_factor);
@@ -837,8 +836,7 @@ TEMPLATE_TEST_CASE("LU Routines", "[fast_math]", float, double)
 
     std::vector<int> ipiv(A_distr_info.local_rows() + A_distr_info.mb());
 
-    TestType const tol_factor =
-        std::is_same<TestType, double>::value ? 1e-16 : 1e-7;
+    auto constexpr tol_factor = get_tolerance<TestType>(10);
 
     fm::gesv(A_distr, A_distr_info, x_distr, x_distr_info, ipiv);
 

--- a/src/kronmult_tests.cpp
+++ b/src/kronmult_tests.cpp
@@ -61,8 +61,7 @@ void test_kronmult(parser const &parse, int const workspace_size_MB,
 
 TEMPLATE_TEST_CASE("test kronmult", "[kronmult]", float, double)
 {
-  TestType const tol_factor =
-      std::is_same<TestType, double>::value ? 1e-15 : 1e-7;
+  auto constexpr tol_factor = get_tolerance<TestType>(10);
 
   SECTION("1d")
   {
@@ -116,8 +115,7 @@ TEMPLATE_TEST_CASE("test kronmult", "[kronmult]", float, double)
 
 TEMPLATE_TEST_CASE("test kronmult w/ decompose", "[kronmult]", float, double)
 {
-  TestType const tol_factor =
-      std::is_same<TestType, double>::value ? 1e-15 : 1.1e-7;
+  auto constexpr tol_factor = get_tolerance<TestType>(10);
 
   SECTION("2d - uniform level")
   {

--- a/src/lib_dispatch_tests.cpp
+++ b/src/lib_dispatch_tests.cpp
@@ -950,7 +950,7 @@ void test_batched_gemm(int const m, int const n, int const k, int const lda,
     }
     else
     {
-      P const tol_factor = std::is_same<P, double>::value ? 1e-15 : 1e-7;
+      auto constexpr tol_factor = get_tolerance<P>(10);
       rmse_comparison(effect_c(matrices[2][i].clone_onto_host()),
                       effect_c(matrices[3][i].clone_onto_host()), tol_factor);
     }
@@ -1179,7 +1179,7 @@ TEMPLATE_TEST_CASE_SIG("batched gemv", "[lib_dispatch]",
                        (double, resource::host), (double, resource::device),
                        (float, resource::host), (float, resource::device))
 {
-  TestType const tol_factor = 1e-18;
+  auto constexpr tol_factor = get_tolerance<TestType>(10);
 
   SECTION("batched gemv: no trans, alpha = 1.0, beta = 0.0")
   {
@@ -1264,8 +1264,7 @@ TEMPLATE_TEST_CASE("LU Routines", "[lib_dispatch]", float, double)
     lib_dispatch::gesv(&rows_A, &cols_B, A_copy.data(), &lda, ipiv.data(),
                        x.data(), &ldb, &info);
 
-    TestType const tol_factor =
-        std::is_same<TestType, double>::value ? 1e-16 : 1e-7;
+    auto constexpr tol_factor = get_tolerance<TestType>(10);
 
     REQUIRE(info == 0);
     rmse_comparison(A_copy, LU_gold, tol_factor);

--- a/src/pde_tests.cpp
+++ b/src/pde_tests.cpp
@@ -16,7 +16,7 @@ void test_initial_condition(PDE<P> const &pde, std::string const base_dir,
         base_dir + "initial_dim" + std::to_string(i) + ".dat"));
     auto const fx   = pde.get_dimensions()[i].initial_condition(x, 0);
 
-    P const tol_factor = std::is_same<P, double>::value ? 1e-15 : 1e-5;
+    auto constexpr tol_factor = get_tolerance<P>(10);
 
     rmse_comparison(fx, gold, tol_factor);
   }
@@ -31,7 +31,7 @@ void test_exact_solution(PDE<P> const &pde, std::string const base_dir,
     return;
   }
 
-  P const tol_factor = std::is_same<P, double>::value ? 1e-15 : 1e-5;
+  auto constexpr tol_factor = get_tolerance<P>(10);
 
   for (auto i = 0; i < pde.num_dims; ++i)
   {
@@ -50,7 +50,7 @@ template<typename P>
 void test_source_vectors(PDE<P> const &pde, std::string const base_dir,
                          fk::vector<P> const &x, P const time)
 {
-  P const tol_factor = std::is_same<P, double>::value ? 1e-15 : 1e-5;
+  auto constexpr tol_factor = get_tolerance<P>(10);
 
   for (auto i = 0; i < pde.num_sources; ++i)
   {

--- a/src/time_advance_tests.cpp
+++ b/src/time_advance_tests.cpp
@@ -124,8 +124,8 @@ TEMPLATE_TEST_CASE("time advance - diffusion 2", "[time_advance]", double,
 
   SECTION("diffusion2, explicit, sparse grid, level 3, degree 3")
   {
-    int const degree = 3;
-    int const level  = 3;
+    int const degree          = 3;
+    int const level           = 3;
     auto constexpr tol_factor = get_tolerance<TestType>(100);
 
     std::string const gold_base = "../testing/generated-inputs/time_advance/"
@@ -141,9 +141,9 @@ TEMPLATE_TEST_CASE("time advance - diffusion 2", "[time_advance]", double,
 
   SECTION("diffusion2, explicit, sparse grid, level 4, degree 4")
   {
-    int const degree = 4;
-    int const level  = 4;
-    auto constexpr tol_factor = get_tolerance<TestType>(1000000);
+    int const degree            = 4;
+    int const level             = 4;
+    auto constexpr tol_factor   = get_tolerance<TestType>(1000000);
     std::string const gold_base = "../testing/generated-inputs/time_advance/"
                                   "diffusion2_sg_l4_d4_t";
 
@@ -157,7 +157,7 @@ TEMPLATE_TEST_CASE("time advance - diffusion 2", "[time_advance]", double,
 
   SECTION("diffusion2, explicit/non-uniform level, sparse grid, degree 2")
   {
-    int const degree = 2;
+    int const degree          = 2;
     auto constexpr tol_factor = get_tolerance<TestType>(100);
 
     fk::vector<int> const levels{4, 5};
@@ -345,7 +345,7 @@ TEMPLATE_TEST_CASE("time advance - continuity 1", "[time_advance]", float,
   TestType const cfl = 0.01;
 
   auto constexpr tol_factor = get_tolerance<TestType>(10);
- 
+
   auto const num_dims = 1;
 
   SECTION("continuity1, explicit, level 2, degree 2, sparse grid")
@@ -399,8 +399,8 @@ TEMPLATE_TEST_CASE("time advance - continuity 2", "[time_advance]", float,
 {
   std::string const pde_choice = "continuity_2";
   TestType const cfl           = 0.01;
-  auto constexpr tol_factor = get_tolerance<TestType>(10);
-  auto const num_dims = 2;
+  auto constexpr tol_factor    = get_tolerance<TestType>(10);
+  auto const num_dims          = 2;
 
   SECTION("continuity2, explicit, level 2, degree 2, sparse grid")
   {
@@ -468,8 +468,8 @@ TEMPLATE_TEST_CASE("time advance - continuity 3", "[time_advance]", float,
 {
   std::string const pde_choice = "continuity_3";
   TestType const cfl           = 0.01;
-  auto constexpr tol_factor = get_tolerance<TestType>(10);
-  auto const num_dims = 3;
+  auto constexpr tol_factor    = get_tolerance<TestType>(10);
+  auto const num_dims          = 3;
 
   SECTION("continuity3, explicit, level 2, degree 2, sparse grid")
   {
@@ -525,8 +525,8 @@ TEMPLATE_TEST_CASE("time advance - continuity 6", "[time_advance]", float,
 {
   std::string const pde_choice = "continuity_6";
   TestType const cfl           = 0.01;
-  auto constexpr tol_factor = get_tolerance<TestType>(10);
-  auto const num_dims = 6;
+  auto constexpr tol_factor    = get_tolerance<TestType>(10);
+  auto const num_dims          = 6;
 
   SECTION("continuity6, level 2, degree 3, sparse grid")
   {
@@ -564,8 +564,8 @@ TEMPLATE_TEST_CASE("time advance - fokkerplanck_1d_pitch_C", "[time_advance]",
 {
   std::string const pde_choice = "fokkerplanck_1d_pitch_C";
   TestType const cfl           = 0.01;
-  auto constexpr tol_factor = get_tolerance<TestType>(10);
-  auto const num_dims = 1;
+  auto constexpr tol_factor    = get_tolerance<TestType>(10);
+  auto const num_dims          = 1;
 
   SECTION("fokkerplanck_1d_pitch_C, level 2, degree 2, sparse grid")
   {
@@ -592,8 +592,8 @@ TEMPLATE_TEST_CASE("time advance - fokkerplanck_1d_4p3", "[time_advance]",
 
   SECTION("fokkerplanck_1d_4p3, level 2, degree 2, sparse grid")
   {
-    int const degree = 2;
-    int const level  = 2;
+    int const degree          = 2;
+    int const level           = 2;
     auto constexpr tol_factor = get_tolerance<TestType>(10);
 
     std::string const gold_base =
@@ -613,8 +613,8 @@ TEMPLATE_TEST_CASE("time advance - fokkerplanck_1d_pitch_E_case1",
 {
   std::string const pde_choice = "fokkerplanck_1d_pitch_E_case1";
   TestType const cfl           = 0.01;
-  auto constexpr tol_factor = get_tolerance<TestType>(10);
-  auto const num_dims = 1;
+  auto constexpr tol_factor    = get_tolerance<TestType>(10);
+  auto const num_dims          = 1;
 
   SECTION("fokkerplanck_1d_pitch_E_case1, level 2, degree 2, sparse grid")
   {
@@ -637,8 +637,8 @@ TEMPLATE_TEST_CASE("time advance - fokkerplanck_1d_pitch_E_case2",
 {
   std::string const pde_choice = "fokkerplanck_1d_pitch_E_case2";
   TestType const cfl           = 0.01;
-  auto constexpr tol_factor = get_tolerance<TestType>(10);
-  auto const num_dims = 1;
+  auto constexpr tol_factor    = get_tolerance<TestType>(10);
+  auto const num_dims          = 1;
 
   SECTION("fokkerplanck_1d_pitch_E_case2, level 2, degree 2, sparse grid")
   {
@@ -671,8 +671,8 @@ TEMPLATE_TEST_CASE("implicit time advance - fokkerplanck_2d_complete",
 #endif
   SECTION("fokkerplanck_2d_complete, level 3, degree 3, sparse grid")
   {
-    int const level  = 3;
-    int const degree = 3;
+    int const level           = 3;
+    int const degree          = 3;
     auto constexpr tol_factor = get_tolerance<TestType>(10);
 
     std::string const gold_base = "../testing/generated-inputs/time_advance/"
@@ -696,8 +696,8 @@ TEMPLATE_TEST_CASE("implicit time advance - fokkerplanck_2d_complete",
 
   SECTION("fokkerplanck_2d_complete, level 4, degree 3, sparse grid")
   {
-    int const level  = 4;
-    int const degree = 3;
+    int const level           = 4;
+    int const degree          = 3;
     auto constexpr tol_factor = get_tolerance<TestType>(10);
 
     std::string const gold_base = "../testing/generated-inputs/time_advance/"
@@ -721,8 +721,8 @@ TEMPLATE_TEST_CASE("implicit time advance - fokkerplanck_2d_complete",
 
   SECTION("fokkerplanck_2d_complete, level 5, degree 3, sparse grid")
   {
-    int const level  = 5;
-    int const degree = 3;
+    int const level           = 5;
+    int const degree          = 3;
     auto constexpr tol_factor = get_tolerance<TestType>(10);
 
     std::string const gold_base = "../testing/generated-inputs/time_advance/"
@@ -773,8 +773,8 @@ TEMPLATE_TEST_CASE("implicit time advance - fokkerplanck_2d_complete",
 TEMPLATE_TEST_CASE("implicit time advance - diffusion 1", "[time_advance]",
                    double, float)
 {
-  TestType const cfl     = 0.01;
-  std::string pde_choice = "diffusion_1";
+  TestType const cfl        = 0.01;
+  std::string pde_choice    = "diffusion_1";
   auto constexpr tol_factor = get_tolerance<TestType>(100);
 
   auto const num_dims = 1;
@@ -812,8 +812,8 @@ TEMPLATE_TEST_CASE("implicit time advance - diffusion 1", "[time_advance]",
 TEMPLATE_TEST_CASE("implicit time advance - diffusion 2", "[time_advance]",
                    double, float)
 {
-  std::string pde_choice = "diffusion_2";
-  TestType const cfl     = 0.01;
+  std::string pde_choice    = "diffusion_2";
+  TestType const cfl        = 0.01;
   auto constexpr tol_factor = get_tolerance<TestType>(100);
 
   auto const num_dims = 2;
@@ -919,8 +919,8 @@ TEMPLATE_TEST_CASE("implicit time advance - diffusion 2", "[time_advance]",
 TEMPLATE_TEST_CASE("implicit time advance - continuity 1", "[time_advance]",
                    double)
 {
-  std::string pde_choice = "continuity_1";
-  TestType const cfl     = 0.01;
+  std::string pde_choice    = "continuity_1";
+  TestType const cfl        = 0.01;
   auto constexpr tol_factor = get_tolerance<TestType>(10);
 
   auto const num_dims = 1;
@@ -1004,8 +1004,8 @@ TEMPLATE_TEST_CASE("implicit time advance - continuity 1", "[time_advance]",
 TEMPLATE_TEST_CASE("implicit time advance - continuity 2", "[time_advance]",
                    float, double)
 {
-  std::string pde_choice = "continuity_2";
-  TestType const cfl     = 0.01;
+  std::string pde_choice    = "continuity_2";
+  TestType const cfl        = 0.01;
   auto constexpr tol_factor = get_tolerance<TestType>(10);
 
   auto const num_dims = 2;
@@ -1065,8 +1065,8 @@ TEMPLATE_TEST_CASE("implicit time advance - continuity 2", "[time_advance]",
 
   SECTION("continuity2, level 4, degree 3, sparse grid, iterative")
   {
-    int const degree = 3;
-    int const level  = 4;
+    int const degree          = 3;
+    int const level           = 4;
     auto constexpr tol_factor = get_tolerance<TestType>(10);
 
     auto const gold_base = "../testing/generated-inputs/time_advance/"

--- a/src/time_advance_tests.cpp
+++ b/src/time_advance_tests.cpp
@@ -24,7 +24,7 @@ static auto constexpr num_steps = 5;
 
 template<typename P>
 void time_advance_test(parser const &parse, std::string const &filepath,
-                       P const tolerance_factor = 1e-6)
+                       P const tolerance_factor)
 {
   auto const num_ranks = get_num_ranks();
   if (num_ranks > 1 && parse.using_implicit() &&
@@ -109,8 +109,7 @@ TEMPLATE_TEST_CASE("time advance - diffusion 2", "[time_advance]", double,
     int const degree = 2;
     int const level  = 2;
 
-    TestType const tol_factor =
-        std::is_same<TestType, double>::value ? 1e-15 : 1e-5;
+    auto constexpr tol_factor = get_tolerance<TestType>(100);
 
     std::string const gold_base = "../testing/generated-inputs/time_advance/"
                                   "diffusion2_sg_l2_d2_t";
@@ -127,8 +126,7 @@ TEMPLATE_TEST_CASE("time advance - diffusion 2", "[time_advance]", double,
   {
     int const degree = 3;
     int const level  = 3;
-    TestType const tol_factor =
-        std::is_same<TestType, double>::value ? 1e-15 : 1e-5;
+    auto constexpr tol_factor = get_tolerance<TestType>(100);
 
     std::string const gold_base = "../testing/generated-inputs/time_advance/"
                                   "diffusion2_sg_l3_d3_t";
@@ -145,8 +143,7 @@ TEMPLATE_TEST_CASE("time advance - diffusion 2", "[time_advance]", double,
   {
     int const degree = 4;
     int const level  = 4;
-    TestType const tol_factor =
-        std::is_same<TestType, double>::value ? 1e-12 : 1e-1;
+    auto constexpr tol_factor = get_tolerance<TestType>(1000000);
     std::string const gold_base = "../testing/generated-inputs/time_advance/"
                                   "diffusion2_sg_l4_d4_t";
 
@@ -161,8 +158,7 @@ TEMPLATE_TEST_CASE("time advance - diffusion 2", "[time_advance]", double,
   SECTION("diffusion2, explicit/non-uniform level, sparse grid, degree 2")
   {
     int const degree = 2;
-    TestType const tol_factor =
-        std::is_same<TestType, double>::value ? 1e-15 : 1e-5;
+    auto constexpr tol_factor = get_tolerance<TestType>(100);
 
     fk::vector<int> const levels{4, 5};
     std::string const gold_base = "../testing/generated-inputs/time_advance/"
@@ -314,8 +310,7 @@ TEMPLATE_TEST_CASE("time advance - diffusion 1", "[time_advance]", double,
     int const level             = 3;
     std::string const gold_base = "../testing/generated-inputs/time_advance/"
                                   "diffusion1_sg_l3_d3_t";
-    TestType const tol_factor =
-        std::is_same<TestType, double>::value ? 1e-15 : 1e-5;
+    auto constexpr tol_factor = get_tolerance<TestType>(100);
 
     auto const full_grid = false;
     parser const parse(
@@ -331,8 +326,7 @@ TEMPLATE_TEST_CASE("time advance - diffusion 1", "[time_advance]", double,
     int const level             = 4;
     std::string const gold_base = "../testing/generated-inputs/time_advance/"
                                   "diffusion1_sg_l4_d4_t";
-    TestType const tol_factor =
-        std::is_same<TestType, double>::value ? 1e-11 : 1e-2;
+    auto const tol_factor = get_tolerance<TestType>(100000);
 
     auto const full_grid = false;
     parser const parse(
@@ -350,9 +344,8 @@ TEMPLATE_TEST_CASE("time advance - continuity 1", "[time_advance]", float,
 
   TestType const cfl = 0.01;
 
-  TestType const tol_factor =
-      std::is_same<TestType, double>::value ? 1e-16 : 1e-7;
-
+  auto constexpr tol_factor = get_tolerance<TestType>(10);
+ 
   auto const num_dims = 1;
 
   SECTION("continuity1, explicit, level 2, degree 2, sparse grid")
@@ -406,8 +399,7 @@ TEMPLATE_TEST_CASE("time advance - continuity 2", "[time_advance]", float,
 {
   std::string const pde_choice = "continuity_2";
   TestType const cfl           = 0.01;
-  TestType const tol_factor =
-      std::is_same<TestType, double>::value ? 1e-17 : 1e-7;
+  auto constexpr tol_factor = get_tolerance<TestType>(10);
   auto const num_dims = 2;
 
   SECTION("continuity2, explicit, level 2, degree 2, sparse grid")
@@ -476,8 +468,7 @@ TEMPLATE_TEST_CASE("time advance - continuity 3", "[time_advance]", float,
 {
   std::string const pde_choice = "continuity_3";
   TestType const cfl           = 0.01;
-  TestType const tol_factor =
-      std::is_same<TestType, double>::value ? 1e-17 : 1e-8;
+  auto constexpr tol_factor = get_tolerance<TestType>(10);
   auto const num_dims = 3;
 
   SECTION("continuity3, explicit, level 2, degree 2, sparse grid")
@@ -520,8 +511,8 @@ TEMPLATE_TEST_CASE("time advance - continuity 3", "[time_advance]", float,
                                   get_level_string(levels) + "d4_t";
     auto const full_grid = false;
 
-    TestType const tol_factor =
-        std::is_same<TestType, double>::value ? 1e-17 : 1e-7;
+    auto constexpr tol_factor = get_tolerance<TestType>(10);
+
     parser const parse(pde_choice, levels, degree, cfl, full_grid,
                        parser::DEFAULT_MAX_LEVEL, num_steps);
 
@@ -534,8 +525,7 @@ TEMPLATE_TEST_CASE("time advance - continuity 6", "[time_advance]", float,
 {
   std::string const pde_choice = "continuity_6";
   TestType const cfl           = 0.01;
-  TestType const tol_factor =
-      std::is_same<TestType, double>::value ? 1e-15 : 1e-6;
+  auto constexpr tol_factor = get_tolerance<TestType>(10);
   auto const num_dims = 6;
 
   SECTION("continuity6, level 2, degree 3, sparse grid")
@@ -574,8 +564,7 @@ TEMPLATE_TEST_CASE("time advance - fokkerplanck_1d_pitch_C", "[time_advance]",
 {
   std::string const pde_choice = "fokkerplanck_1d_pitch_C";
   TestType const cfl           = 0.01;
-  TestType const tol_factor =
-      std::is_same<TestType, double>::value ? 1e-15 : 1e-6;
+  auto constexpr tol_factor = get_tolerance<TestType>(10);
   auto const num_dims = 1;
 
   SECTION("fokkerplanck_1d_pitch_C, level 2, degree 2, sparse grid")
@@ -605,9 +594,7 @@ TEMPLATE_TEST_CASE("time advance - fokkerplanck_1d_4p3", "[time_advance]",
   {
     int const degree = 2;
     int const level  = 2;
-
-    TestType const tol_factor =
-        std::is_same<TestType, double>::value ? 1e-16 : 1e-6;
+    auto constexpr tol_factor = get_tolerance<TestType>(10);
 
     std::string const gold_base =
         "../testing/generated-inputs/time_advance/fokkerplanck1_4p3_sg_l2_d2_t";
@@ -626,8 +613,7 @@ TEMPLATE_TEST_CASE("time advance - fokkerplanck_1d_pitch_E_case1",
 {
   std::string const pde_choice = "fokkerplanck_1d_pitch_E_case1";
   TestType const cfl           = 0.01;
-  TestType const tol_factor =
-      std::is_same<TestType, double>::value ? 1e-15 : 1e-5;
+  auto constexpr tol_factor = get_tolerance<TestType>(10);
   auto const num_dims = 1;
 
   SECTION("fokkerplanck_1d_pitch_E_case1, level 2, degree 2, sparse grid")
@@ -651,8 +637,7 @@ TEMPLATE_TEST_CASE("time advance - fokkerplanck_1d_pitch_E_case2",
 {
   std::string const pde_choice = "fokkerplanck_1d_pitch_E_case2";
   TestType const cfl           = 0.01;
-  TestType const tol_factor =
-      std::is_same<TestType, double>::value ? 1e-15 : 1e-5;
+  auto constexpr tol_factor = get_tolerance<TestType>(10);
   auto const num_dims = 1;
 
   SECTION("fokkerplanck_1d_pitch_E_case2, level 2, degree 2, sparse grid")
@@ -688,9 +673,7 @@ TEMPLATE_TEST_CASE("implicit time advance - fokkerplanck_2d_complete",
   {
     int const level  = 3;
     int const degree = 3;
-
-    TestType const tol_factor =
-        std::is_same<TestType, double>::value ? 1e-15 : 1e-6;
+    auto constexpr tol_factor = get_tolerance<TestType>(10);
 
     std::string const gold_base = "../testing/generated-inputs/time_advance/"
                                   "fokkerplanck2_complete_implicit_sg_l3_d3_t";
@@ -715,9 +698,7 @@ TEMPLATE_TEST_CASE("implicit time advance - fokkerplanck_2d_complete",
   {
     int const level  = 4;
     int const degree = 3;
-
-    TestType const tol_factor =
-        std::is_same<TestType, double>::value ? 1e-15 : 1e-5;
+    auto constexpr tol_factor = get_tolerance<TestType>(10);
 
     std::string const gold_base = "../testing/generated-inputs/time_advance/"
                                   "fokkerplanck2_complete_implicit_sg_l4_d3_t";
@@ -742,9 +723,7 @@ TEMPLATE_TEST_CASE("implicit time advance - fokkerplanck_2d_complete",
   {
     int const level  = 5;
     int const degree = 3;
-
-    TestType const tol_factor =
-        std::is_same<TestType, double>::value ? 1e-15 : 1e-5;
+    auto constexpr tol_factor = get_tolerance<TestType>(10);
 
     std::string const gold_base = "../testing/generated-inputs/time_advance/"
                                   "fokkerplanck2_complete_implicit_sg_l5_d3_t";
@@ -771,9 +750,7 @@ TEMPLATE_TEST_CASE("implicit time advance - fokkerplanck_2d_complete",
   {
     int const degree = 3;
     fk::vector<int> const levels{2, 3};
-
-    TestType const tol_factor =
-        std::is_same<TestType, double>::value ? 1e-15 : 1e-5;
+    auto constexpr tol_factor = get_tolerance<TestType>(10);
 
     std::string const gold_base = "../testing/generated-inputs/time_advance/"
                                   "fokkerplanck2_complete_implicit_sg_l" +
@@ -798,8 +775,7 @@ TEMPLATE_TEST_CASE("implicit time advance - diffusion 1", "[time_advance]",
 {
   TestType const cfl     = 0.01;
   std::string pde_choice = "diffusion_1";
-  TestType const tol_factor =
-      std::is_same<TestType, double>::value ? 1e-15 : 1e-5;
+  auto constexpr tol_factor = get_tolerance<TestType>(100);
 
   auto const num_dims = 1;
   auto const implicit = true;
@@ -838,8 +814,7 @@ TEMPLATE_TEST_CASE("implicit time advance - diffusion 2", "[time_advance]",
 {
   std::string pde_choice = "diffusion_2";
   TestType const cfl     = 0.01;
-  TestType const tol_factor =
-      std::is_same<TestType, double>::value ? 1e-15 : 1e-5;
+  auto constexpr tol_factor = get_tolerance<TestType>(100);
 
   auto const num_dims = 2;
   auto const implicit = true;
@@ -946,9 +921,7 @@ TEMPLATE_TEST_CASE("implicit time advance - continuity 1", "[time_advance]",
 {
   std::string pde_choice = "continuity_1";
   TestType const cfl     = 0.01;
-
-  TestType const tol_factor =
-      std::is_same<TestType, double>::value ? 1e-16 : 1e-8;
+  auto constexpr tol_factor = get_tolerance<TestType>(10);
 
   auto const num_dims = 1;
   auto const implicit = true;
@@ -1033,9 +1006,7 @@ TEMPLATE_TEST_CASE("implicit time advance - continuity 2", "[time_advance]",
 {
   std::string pde_choice = "continuity_2";
   TestType const cfl     = 0.01;
-
-  TestType const tol_factor =
-      std::is_same<TestType, double>::value ? 1e-16 : 1e-7;
+  auto constexpr tol_factor = get_tolerance<TestType>(10);
 
   auto const num_dims = 2;
   auto const implicit = true;
@@ -1096,9 +1067,7 @@ TEMPLATE_TEST_CASE("implicit time advance - continuity 2", "[time_advance]",
   {
     int const degree = 3;
     int const level  = 4;
-
-    TestType const tol_factor =
-        std::is_same<TestType, double>::value ? 1e-14 : 1e-7;
+    auto constexpr tol_factor = get_tolerance<TestType>(10);
 
     auto const gold_base = "../testing/generated-inputs/time_advance/"
                            "continuity2_implicit_l4_d3_t";

--- a/src/transformations_tests.cpp
+++ b/src/transformations_tests.cpp
@@ -236,7 +236,7 @@ TEMPLATE_TEST_CASE("wavelet_to_realspace", "[transformations]", double, float)
         "../testing/generated-inputs/transformations/"
         "wavelet_to_realspace_continuity_2.dat";
 
-    auto constexpr tol_factor = get_tolerance<TestType>(1000);
+    auto constexpr tol_factor = get_tolerance<TestType>(100000);
     test_wavelet_to_realspace(*pde, gold_filename, tol_factor);
   }
 

--- a/src/transformations_tests.cpp
+++ b/src/transformations_tests.cpp
@@ -100,8 +100,7 @@ TEMPLATE_TEST_CASE("combine dimensions", "[transformations]", double, float)
 TEMPLATE_TEST_CASE("forward multi-wavelet transform", "[transformations]",
                    double, float)
 {
-  TestType const tol_factor =
-      std::is_same<TestType, double>::value ? 1e-16 : 1e-6;
+  auto constexpr tol_factor = get_tolerance<TestType>(10);
 
   SECTION("transform(2, 2, -1, 1, double)")
   {
@@ -224,8 +223,7 @@ TEMPLATE_TEST_CASE("wavelet_to_realspace", "[transformations]", double, float)
         "../testing/generated-inputs/transformations/"
         "wavelet_to_realspace_continuity_1.dat";
 
-    TestType const tol_factor =
-        std::is_same<TestType, double>::value ? 1e-11 : 1e-2;
+    auto constexpr tol_factor = get_tolerance<TestType>(100000);
     test_wavelet_to_realspace(*pde, gold_filename, tol_factor);
   }
 
@@ -238,8 +236,7 @@ TEMPLATE_TEST_CASE("wavelet_to_realspace", "[transformations]", double, float)
         "../testing/generated-inputs/transformations/"
         "wavelet_to_realspace_continuity_2.dat";
 
-    TestType const tol_factor =
-        std::is_same<TestType, double>::value ? 1e-13 : 1e-4;
+    auto constexpr tol_factor = get_tolerance<TestType>(1000);
     test_wavelet_to_realspace(*pde, gold_filename, tol_factor);
   }
 
@@ -252,8 +249,7 @@ TEMPLATE_TEST_CASE("wavelet_to_realspace", "[transformations]", double, float)
         "../testing/generated-inputs/transformations/"
         "wavelet_to_realspace_continuity_3.dat";
 
-    TestType const tol_factor =
-        std::is_same<TestType, double>::value ? 1e-14 : 1e-5;
+    auto constexpr tol_factor = get_tolerance<TestType>(10);
     test_wavelet_to_realspace(*pde, gold_filename, tol_factor);
   }
 }
@@ -293,8 +289,7 @@ TEMPLATE_TEST_CASE("gen_realspace_transform", "[transformations]", double,
         "matrix_plot_D_";
     auto const pde = make_PDE<TestType>(PDE_opts::continuity_1, level, degree);
 
-    TestType const tol_factor =
-        std::is_same<TestType, double>::value ? 1e-12 : 1e-2;
+auto constexpr tol_factor = get_tolerance<TestType>(10000);
     test_gen_realspace_transform(*pde, gold_filename, tol_factor);
   }
 
@@ -307,9 +302,7 @@ TEMPLATE_TEST_CASE("gen_realspace_transform", "[transformations]", double,
         "continuity_2/"
         "matrix_plot_D_";
     auto const pde = make_PDE<TestType>(PDE_opts::continuity_2, level, degree);
-
-    TestType const tol_factor =
-        std::is_same<TestType, double>::value ? 1e-12 : 1e-4;
+    auto constexpr tol_factor = get_tolerance<TestType>(1000);
     test_gen_realspace_transform(*pde, gold_filename, tol_factor);
   }
 
@@ -322,8 +315,7 @@ TEMPLATE_TEST_CASE("gen_realspace_transform", "[transformations]", double,
         "continuity_3/"
         "matrix_plot_D_";
     auto const pde = make_PDE<TestType>(PDE_opts::continuity_3, level, degree);
-    TestType const tol_factor =
-        std::is_same<TestType, double>::value ? 1e-14 : 1e-4;
+    auto constexpr tol_factor = get_tolerance<TestType>(100);
     test_gen_realspace_transform(*pde, gold_filename, tol_factor);
   }
 
@@ -337,8 +329,7 @@ TEMPLATE_TEST_CASE("gen_realspace_transform", "[transformations]", double,
         "matrix_plot_D_";
     auto const pde = make_PDE<TestType>(PDE_opts::continuity_6, level, degree);
 
-    TestType const tol_factor =
-        std::is_same<TestType, double>::value ? 1e-14 : 1e-6;
+    auto constexpr tol_factor = get_tolerance<TestType>(10);
     test_gen_realspace_transform(*pde, gold_filename, tol_factor);
   }
 }

--- a/src/transformations_tests.cpp
+++ b/src/transformations_tests.cpp
@@ -289,7 +289,7 @@ TEMPLATE_TEST_CASE("gen_realspace_transform", "[transformations]", double,
         "matrix_plot_D_";
     auto const pde = make_PDE<TestType>(PDE_opts::continuity_1, level, degree);
 
-auto constexpr tol_factor = get_tolerance<TestType>(10000);
+    auto constexpr tol_factor = get_tolerance<TestType>(10000);
     test_gen_realspace_transform(*pde, gold_filename, tol_factor);
   }
 

--- a/testing/tests_general.hpp
+++ b/testing/tests_general.hpp
@@ -15,6 +15,12 @@
 #include <utility>
 #include <vector>
 
+template<typename P>
+constexpr P get_tolerance(int ulp)
+{
+  return std::numeric_limits<P>::epsilon()*ulp;
+}
+
 /* These functions implement: norm( v0 - v1 ) < tolerance * max( norm(v0),
  * norm(v1) )*/
 template<typename P, mem_type mem, mem_type omem>
@@ -31,7 +37,7 @@ void rmse_comparison(fk::vector<P, mem> const &v0,
       static_cast<P>(1.0),
       std::max(std::abs(*std::max_element(v0.begin(), v0.end(), abs_compare)),
                std::abs(*std::max_element(v1.begin(), v1.end(), abs_compare))));
-  Catch::StringMaker<P>::precision = 15;
+  Catch::StringMaker<P>::precision = 20;
   REQUIRE((diff_norm / max) < (tolerance * std::sqrt(v0.size())));
 }
 


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

This brings in changes suggested in https://github.com/xianyi/OpenBLAS/issues/3494 to fix a failing OpenBLAS test on processors with AVX512 support.

We had a few tests failing because the tolerance was set for double and not float. Instead of setting different values for float and double, I created a small function that returns std::numeric_limits<T>::epsilon*ulp where ulp is an integer setting units last position.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
