### PR TITLE
Add sandbox file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,12 @@ endif()
 if (ASGARD_BUILD_TESTS)
   enable_testing ()
 
+  # add sandbox executable, i.e., an executable that is part of the build system
+  # contain all the appropriate link flags and dependencies, but does nothing
+  # other than play with some code
+  add_executable(sandbox ./testing/sandbox.cpp)
+  target_link_libraries (sandbox PUBLIC asgard_obj Catch2::Catch2)
+
   # Define ctest tests and their executables. The _main variant of these targets
   # uses the default main function from the catch two framework. The non _main
   # variant uses a custom defined main in MPI based tests.
@@ -373,6 +379,7 @@ if (ASGARD_BUILD_TESTS)
                              PRIVATE ${CMAKE_BINARY_DIR}
                              PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
   if (${ASGARD_USE_PCH})
+    target_precompile_headers (sandbox REUSE_FROM asgard_obj)
     target_precompile_headers (tests_general REUSE_FROM asgard_obj)
     target_precompile_headers (tests_general_main REUSE_FROM asgard_obj)
   endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,21 +359,6 @@ endif()
 if (ASGARD_BUILD_TESTS)
   enable_testing ()
 
-  set (main_app_link_deps
-       adapt
-       coefficients
-       distribution
-       elements
-       matlab_utilities
-       pde
-       program_options
-       quadrature
-       tensors
-       time_advance
-       tools
-       transformations
-  )
-
   # Define ctest tests and their executables. The _main variant of these targets
   # uses the default main function from the catch two framework. The non _main
   # variant uses a custom defined main in MPI based tests.

--- a/testing/sandbox.cpp
+++ b/testing/sandbox.cpp
@@ -1,0 +1,36 @@
+#include "batch.hpp"
+
+#include "build_info.hpp"
+#include "coefficients.hpp"
+#include "distribution.hpp"
+#include "elements.hpp"
+#include "tools.hpp"
+
+#ifdef ASGARD_IO_HIGHFIVE
+#include "io.hpp"
+#endif
+
+#ifdef ASGARD_USE_MPI
+#include <mpi.h>
+#endif
+
+#include "pde.hpp"
+#include "program_options.hpp"
+#include "tensors.hpp"
+#include "time_advance.hpp"
+#include "transformations.hpp"
+#include <numeric>
+
+#ifdef ASGARD_USE_DOUBLE_PREC
+using prec = double;
+#else
+using prec = float;
+#endif
+
+int main(int, char**)
+{
+  // keep this file clean for each PR
+  // allows someone to easily come here, dump code and start playing
+  // this is good for prototyping and quick-testing features/behavior
+  return 0;
+}


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

In my other projects, I always found it useful to have a sandbox file where I can make quick changes to the code and test methods and features.

For example, I'm trying to improve the generation of permutations, but I need to see what indexes and in what order are created by the current set of methods. There is no documentation to read and there is no easy way to see details such as the matrix row or column major format. The sandbox file is part of the build system, so I can just dump code in there, work on the code, and then move to the appropriate place (or discard, if appropriate).

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [ ] Bugfix
- [X] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [X] No

## What systems has this change been tested on?

Ubuntu 22.04

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [x] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [x] documentation has been added (if appropriate)
