### PR TITLE
Add advection_1 PDE

### DIFF
--- a/src/pde.hpp
+++ b/src/pde.hpp
@@ -13,6 +13,8 @@
 #include "quadrature.hpp"
 
 #include "pde/pde_base.hpp"
+
+#include "pde/pde_advection1.hpp"
 #include "pde/pde_continuity1.hpp"
 #include "pde/pde_continuity2.hpp"
 #include "pde/pde_continuity3.hpp"
@@ -84,6 +86,8 @@ std::unique_ptr<PDE<P>> make_PDE(parser const &cli_input)
     return std::make_unique<PDE_diffusion_1d<P>>(cli_input);
   case PDE_opts::diffusion_2:
     return std::make_unique<PDE_diffusion_2d<P>>(cli_input);
+  case PDE_opts::advection_1:
+    return std::make_unique<PDE_advection_1d<P>>(cli_input);
   default:
     std::cout << "Invalid pde choice" << std::endl;
     exit(-1);
@@ -164,6 +168,9 @@ make_PDE(PDE_opts const pde_choice, int const level = parser::NO_USER_VALUE,
 
     case PDE_opts::diffusion_2:
       return fk::vector<int>(std::vector<int>(2, level));
+
+    case PDE_opts::advection_1:
+      return fk::vector<int>(std::vector<int>(1, level));
 
     default:
       std::cout << "Invalid pde choice" << std::endl;

--- a/src/pde/pde_advection1.hpp
+++ b/src/pde/pde_advection1.hpp
@@ -1,0 +1,182 @@
+#pragma once
+#include <algorithm>
+#include <cmath>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <string>
+#include <typeinfo>
+#include <vector>
+
+#include "../tensors.hpp"
+#include "pde_base.hpp"
+
+template<typename P>
+class PDE_advection_1d : public PDE<P>
+{
+public:
+  PDE_advection_1d(parser const &cli_input)
+      : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
+               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               get_dt_, do_poisson_solve_, has_analytic_soln_)
+  {}
+
+private:
+  // these fields will be checked against provided functions to make sure
+  // everything is specified correctly
+
+  static int constexpr num_dims_           = 1;
+  static int constexpr num_sources_        = 1;
+  static int constexpr num_terms_          = 1;
+  static bool constexpr do_poisson_solve_  = false;
+  static bool constexpr has_analytic_soln_ = true;
+
+  //
+  // function definitions needed to build up the "dimension", "term", and
+  // "source" member objects below for this PDE
+  //
+
+  // Initial Conditions ======================================================
+  static fk::vector<P>
+  initial_condition_dim0(fk::vector<P> const &x, P const t = 0)
+  {
+    ignore(t);
+    fk::vector<P> fx(x.size());
+    for (int i = 0; i < x.size(); i++)
+    {
+      fx(i) = std::cos(x(i));
+    }
+    return fx;
+  }
+  // =========================================================================
+
+  // Analytical Solutions ====================================================
+  static fk::vector<P>
+  exact_solution_dim0(fk::vector<P> const &x, P const t = 0)
+  {
+    ignore(t);
+    fk::vector<P> fx(x.size());
+    for (int i = 0; i < x.size(); i++)
+    {
+      fx(i) = std::cos(x(i));
+    }
+    return fx;
+  }
+
+  static P exact_time(P const time)
+  {
+    ignore(time);
+    return 1.0;
+  }
+
+  inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {
+      exact_solution_dim0};
+
+  inline static scalar_func<P> const exact_scalar_func_ = exact_time;
+  // =========================================================================
+
+  // Sources =================================================================
+  static fk::vector<P> source_0_dim0(fk::vector<P> const &x, P const t = 0)
+  {
+    ignore(t);
+    fk::vector<P> fx(x.size());
+    for (int i = 0; i < x.size(); i++)
+    {
+      fx(i) = -2.0 * std::sin(x(i));
+    }
+    return fx;
+  }
+
+  static P source_0_time(P const time)
+  {
+    ignore(time);
+    return 1.0;
+  }
+
+  inline static source<P> const source0_ =
+      source<P>({source_0_dim0}, source_0_time);
+  inline static std::vector<source<P>> const sources_ = {source0_};
+  // =========================================================================
+
+  // Dimensions ==============================================================
+  static P jacobian_dim0(P const x, P const time)
+  {
+    ignore(x);
+    ignore(time);
+
+    return 1.0;
+  }
+
+  inline static dimension<P> const dim0_ = dimension<P>(
+      0.0,  // domain min
+      M_PI, // domain max
+      4,    // levels - default (changed on command line with option -l)
+      3,    // degree - default (changed on command line with option -d)
+      initial_condition_dim0, // initial condition function
+      jacobian_dim0,          // volume
+      "x"                     // name of dimension
+  );
+
+  inline static std::vector<dimension<P>> const dimensions_ = {dim0_};
+  // =========================================================================
+
+  // Terms ===================================================================
+  static P g_func_0(P const x, P const time)
+  {
+    ignore(x);
+    ignore(time);
+    return -2.0;
+  }
+
+  static fk::vector<P> bc_func(fk::vector<P> const &x, P const time)
+  {
+    ignore(time);
+    fk::vector<P> fx(x.size());
+    std::fill(fx.begin(), fx.end(), 1.0);
+    return fx;
+  }
+
+  static P bc_time_func(P const x)
+  {
+    ignore(x);
+    return 1.0;
+  }
+
+  inline static const partial_term<P> partial_term_0 = partial_term<P>(
+      coefficient_type::div,       // type
+      g_func_0,                    // g func
+      partial_term<P>::null_gfunc, // lhs, null_gfunc = 1.0
+      flux_type::downwind, // flux = "-1" (downwind), "0" (central), "+1"
+                           // (upwind)
+      boundary_condition::dirichlet, // left boundary condition type ("D", "N",
+                                     // "P")
+      boundary_condition::neumann,   // right boundary condition type,
+      homogeneity::inhomogeneous,    // left homogeneity
+      homogeneity::homogeneous,      // right homogeneity
+      {bc_func},                     // left boundary condition function list
+      bc_time_func,                  // left boundary time function
+      {},                            // right boundary condition function list
+      partial_term<P>::null_scalar_func, // right boundary time function
+      partial_term<P>::null_gfunc        // surface jacobian
+  );
+
+  inline static term<P> term0_dim0_ =
+      term<P>(false,           // time-dependency
+              "term0",         // term name
+              {partial_term_0} // list of partial terms to build the term
+      );
+
+  inline static std::vector<term<P>> const terms0_ = {term0_dim0_};
+  inline static term_set<P> const terms_           = {terms0_};
+  // =========================================================================
+
+  static P get_dt_(dimension<P> const &dim)
+  {
+    P const x_range = dim.domain_max - dim.domain_min;
+    P const dx      = x_range / std::pow(2, dim.get_level());
+    // return dx; this will be scaled by CFL
+    // from command line
+    return dx;
+  }
+};

--- a/src/program_options.hpp
+++ b/src/program_options.hpp
@@ -29,6 +29,7 @@ static solve_map_t const solver_mapping = {
 // the choices for supported PDE types
 enum class PDE_opts
 {
+  advection_1,
   continuity_1,
   continuity_2,
   continuity_3,
@@ -137,7 +138,11 @@ static pde_map_t const pde_mapping = {
                                    PDE_opts::diffusion_1)},
     {"diffusion_2",
      PDE_descriptor("2D (1x-1y) heat equation. df/dt = d^2 f/dx^2 + d^2 f/dy^2",
-                    PDE_opts::diffusion_2)}};
+                    PDE_opts::diffusion_2)},
+    {"advection_1",
+     PDE_descriptor(
+         "1D test using continuity equation. df/dt == -2*df/dx - 2*sin(x)",
+         PDE_opts::advection_1)}};
 
 // class to parse command line input
 class parser


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Adds the 1D advection PDE example implemented during the meeting today. This PDE can be run using `./asgard -p advection_1`.

The MATLAB plotting interface can optionally be used to visualize the PDE:
- Compile ASGarD with the CMake option `-DASGARD_USE_MATLAB=ON`
- Start MATLAB and run `matlab.engine.shareEngine` in the command window.
- Run ASGaRD: `./asgard -p advection_1` and a plot window should appear.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [ ] Bugfix
- [x] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

Ubuntu 20.04

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
