### PR TITLE
Remove diff coefficient type

### DIFF
--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -127,7 +127,6 @@ enum class coefficient_type
   grad,
   mass,
   div,
-  diff
 };
 
 enum class flux_type


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Removes `cofficient_type::diff` since it is no longer needed and is not currently used in the code.

Closes #451.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [ ] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

Ubuntu 20.04

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
