### PR TITLE
Add operator[] to fk::vector

### DIFF
--- a/src/tensors.hpp
+++ b/src/tensors.hpp
@@ -213,14 +213,33 @@ public:
   template<resource r_ = resrc, typename = enable_for_host<r_>>
   std::vector<P> to_std() const;
 
-  //
-  // subscripting operators
-  //
+  /*! subscript operator
+   * \param i position of the element to return
+   * \returns reference to the requested element.
+   */
   template<mem_type m_ = mem, typename = disable_for_const_view<m_>,
            resource r_ = resrc, typename = enable_for_host<r_>>
   P &operator()(int const);
+  /*! subscript operator
+   * \param i position of the element to return
+   * \returns const reference to the requested element.
+   */
   template<resource r_ = resrc, typename = enable_for_host<r_>>
-  P operator()(int const) const;
+  P const &operator()(int const) const;
+
+  /*! array index operator
+   * \param i position of the element to return
+   * \returns reference to the requested element.
+   */
+  template<mem_type m_ = mem, typename = disable_for_const_view<m_>,
+           resource r_ = resrc, typename = enable_for_host<r_>>
+  P &operator[](int const i);
+  /*! array index operator
+   * \param i position of the element to return
+   * \returns const reference to the requested element.
+   */
+  template<resource r_ = resrc, typename = enable_for_host<r_>>
+  P const &operator[](int const i) const;
 
   //
   // comparison operators
@@ -1214,7 +1233,23 @@ P &fk::vector<P, mem, resrc>::operator()(int i)
 
 template<typename P, mem_type mem, resource resrc>
 template<resource, typename>
-P fk::vector<P, mem, resrc>::operator()(int i) const
+P const &fk::vector<P, mem, resrc>::operator()(int i) const
+{
+  expect(i < size_);
+  return data_[i];
+}
+
+// array index operators
+template<typename P, mem_type mem, resource resrc>
+template<mem_type, typename, resource, typename>
+P &fk::vector<P, mem, resrc>::operator[](int i)
+{
+  expect(i < size_);
+  return data_[i];
+}
+template<typename P, mem_type mem, resource resrc>
+template<resource, typename>
+P const &fk::vector<P, mem, resrc>::operator[](int i) const
 {
   expect(i < size_);
   return data_[i];

--- a/src/tensors_tests.cpp
+++ b/src/tensors_tests.cpp
@@ -485,6 +485,33 @@ TEMPLATE_TEST_CASE("fk::vector operators", "[tensors]", double, float, int)
     REQUIRE(gold_cv(4) == 6);
   }
 
+  SECTION("array index operator (modifying)")
+  {
+    fk::vector<TestType> test(5);
+    fk::vector<TestType> own(5);
+    fk::vector<TestType, mem_type::view> test_v(own);
+    // clang-format off
+    test[0] = 2; test[1] = 3; test[2] = 4; test[3] = 5; test[4] = 6;
+    test_v[0] = 2; test_v[1] = 3; test_v[2] = 4; test_v[3] = 5; test_v[4] = 6;
+    // clang-format on
+    REQUIRE(test == gold);
+    REQUIRE(test_v == gold);
+    TestType const val   = test[4];
+    TestType const val_v = test_v[4];
+    REQUIRE(val == 6);
+    REQUIRE(val_v == 6);
+  }
+
+  SECTION("array index operator (const)")
+  {
+    REQUIRE(gold[4] == 6);
+    fk::vector<TestType> gold_copy(gold);
+    fk::vector<TestType, mem_type::view> gold_v(gold_copy);
+    REQUIRE(gold_v[4] == 6);
+    fk::vector<TestType, mem_type::const_view> const gold_cv(gold);
+    REQUIRE(gold_cv[4] == 6);
+  }
+
   SECTION("comparison operator") // this gets used in every REQUIRE
 
   SECTION("comparison (negated) operator")


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Added fk::vector::operator[] as an alternative to the subscript operator.  

This fixes issue #454 

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [x] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?
my laptop, Ubuntu 20.04

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [x] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [x] documentation has been added (if appropriate)
