### PR TITLE
Fix MATLAB CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,6 +291,8 @@ target_link_libraries (asgard_obj
                        clara
                        $<$<BOOL:${ASGARD_IO_HIGHFIVE}>:highfive>
                        $<$<BOOL:${ASGARD_IO_HIGHFIVE}>:hdf5>
+                       $<$<BOOL:${ASGARD_USE_MATLAB}>:${Matlab_ENGINE_LIBRARY}>
+                       $<$<BOOL:${ASGARD_USE_MATLAB}>:${Matlab_DATAARRAY_LIBRARY}>
 )
 target_include_directories (asgard_obj
                             PUBLIC
@@ -329,6 +331,13 @@ if (ASGARD_USE_CUDA)
                            CUDA::cublas
     )
 endif ()
+
+if (ASGARD_USE_MATLAB)
+    target_include_directories (asgard_obj
+                                SYSTEM PUBLIC
+                                $<BUILD_INTERFACE:${Matlab_INCLUDE_DIRS}>
+    )
+endif()
 
 #-------------------------------------------------------------------------------
 #  Define a asgard executable library.

--- a/src/matlab_plot.cpp
+++ b/src/matlab_plot.cpp
@@ -381,16 +381,13 @@ template<typename P>
 matlab::data::StructArray
 matlab_plot::make_term(term<P> const &term, int const max_lev)
 {
-  std::vector<std::string> names    = {"time_dependent", "name", "data",
-                                    "coefficients", "pterms"};
+  std::vector<std::string> names    = {"time_dependent", "name", "coefficients",
+                                    "pterms"};
   matlab::data::StructArray ml_term = factory_.createStructArray({1}, names);
 
   ml_term[0]["time_dependent"] =
       factory_.createScalar<bool>(term.time_dependent);
-  ml_term[0]["name"]    = factory_.createCharArray(term.name);
-  auto const &term_data = term.get_data();
-  ml_term[0]["data"] =
-      create_array({1, static_cast<size_t>(term_data.size())}, term_data);
+  ml_term[0]["name"]         = factory_.createCharArray(term.name);
   auto const &coeffs         = term.get_coefficients().clone_onto_host();
   ml_term[0]["coefficients"] = matrix_to_array(coeffs);
 


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

With the recent refactor to `CMakeLists.txt`, the `ASGARD_USE_MATLAB` option was broken as linking to Matlab and including Matlab headers was removed. 
This PR adds this back to `CMakeLists.txt` so the `ASGARD_USE_MATLAB=ON` option is fixed.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

Ubuntu 20.04

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
