### PR TITLE
fm::gesv: allow RHS to be a matrix

### DIFF
--- a/src/boundary_conditions.cpp
+++ b/src/boundary_conditions.cpp
@@ -302,9 +302,11 @@ std::vector<fk::vector<P>> generate_partial_bcs(
 
     // Apply inverse mat
     std::vector<int> ipiv(degrees_freedom_1d_other);
-    fk::matrix<P, mem_type::const_view> const lhs_mass(
-        terms[dim_num].get_partial_terms()[p_index].get_lhs_mass(), 0,
-        degrees_freedom_1d_other - 1, 0, degrees_freedom_1d_other - 1);
+    auto lhs_mass = terms[dim_num]
+                        .get_partial_terms()[p_index]
+                        .get_lhs_mass()
+                        .extract_submatrix(0, 0, degrees_freedom_1d_other,
+                                           degrees_freedom_1d_other);
     fm::gesv(lhs_mass, partial_bc_vecs.back(), ipiv);
 
     // Apply previous pterms
@@ -328,9 +330,11 @@ std::vector<fk::vector<P>> generate_partial_bcs(
 
   // Apply LHS_mass_mat for this pterm
   std::vector<int> ipiv(degrees_freedom_1d);
-  fk::matrix<P, mem_type::const_view> const lhs_mass(
-      terms[d_index].get_partial_terms()[p_index].get_lhs_mass(), 0,
-      degrees_freedom_1d - 1, 0, degrees_freedom_1d - 1);
+  auto lhs_mass =
+      terms[d_index]
+          .get_partial_terms()[p_index]
+          .get_lhs_mass()
+          .extract_submatrix(0, 0, degrees_freedom_1d, degrees_freedom_1d);
   fm::gesv(lhs_mass, partial_bc_vecs[d_index], ipiv);
 
   for (int p = 0; p < p_index; ++p)

--- a/src/coefficients.cpp
+++ b/src/coefficients.cpp
@@ -46,16 +46,17 @@ void generate_all_coefficients(
 
         // precompute inv(mass) * coeff for each level up to max level
         std::vector<fk::matrix<P>> pterm_coeffs;
+        std::vector<int> ipiv(dim.get_degree() *
+                              fm::two_raised_to(pde.max_level));
         for (int level = 0; level <= pde.max_level; ++level)
         {
           auto const dof = dim.get_degree() * fm::two_raised_to(level);
-          fk::matrix<P> result(dof, dof);
-          auto mass_tmp = mass_coeff.extract_submatrix(0, 0, dof, dof);
+          auto mass_tmp  = mass_coeff.extract_submatrix(0, 0, dof, dof);
 
-          auto pterm_coeff = generate_coefficients<P>(
+          auto result = generate_coefficients<P>(
               dim, partial_terms[k], transformer, level, time, rotate);
 
-          fm::gemm(mass_tmp.invert(), pterm_coeff, result);
+          fm::gesv(mass_tmp, result, ipiv);
           pterm_coeffs.emplace_back(std::move(result));
         }
 

--- a/src/fast_math_tests.cpp
+++ b/src/fast_math_tests.cpp
@@ -799,7 +799,7 @@ TEMPLATE_TEST_CASE("LU Routines", "[fast_math]", float, double)
 
   SECTION("gesv and getrs")
   {
-    fk::matrix<TestType> const A_copy = A_gold;
+    fk::matrix<TestType> A_copy = A_gold;
     std::vector<int> ipiv(A_copy.nrows());
     fk::vector<TestType> x = B_gold;
 
@@ -812,6 +812,13 @@ TEMPLATE_TEST_CASE("LU Routines", "[fast_math]", float, double)
     x = B1_gold;
     fm::getrs(A_copy, x, ipiv);
     rmse_comparison(x, X1_gold, tol_factor);
+
+    // RHS may also be a fk::matrix
+    A_copy = A_gold;
+    fk::matrix<TestType> x_mat({{B_gold[0]}, {B_gold[1]}, {B_gold[2]}});
+    fm::gesv(A_copy, x_mat, ipiv);
+    rmse_comparison(A_copy, LU_gold, tol_factor);
+    rmse_comparison(fk::vector<TestType>(x_mat), X_gold, tol_factor);
   }
 
 #ifdef ASGARD_USE_SCALAPACK

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -230,16 +230,13 @@ public:
     coefficients_.clear();
 
     // precompute inv(mass) * coeff for each level up to max level
+    std::vector<int> ipiv(deg * fm::two_raised_to(max_level));
     for (int level = 0; level <= max_level; ++level)
     {
       auto const dof = deg * fm::two_raised_to(level);
-      fk::matrix<P> result(dof, dof);
+      fk::matrix<P> result(new_coefficients, 0, dof - 1, 0, dof - 1);
       auto mass_tmp = mass_.extract_submatrix(0, 0, dof, dof);
-
-      fm::gemm(mass_tmp.invert(),
-               fk::matrix<P, mem_type::const_view>(new_coefficients, 0, dof - 1,
-                                                   0, dof - 1),
-               result);
+      fm::gesv(mass_tmp, result, ipiv);
       coefficients_.push_back(std::move(result));
     }
   }

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -123,8 +123,7 @@ P simple_gmres(fk::matrix<P> const &A, fk::vector<P> &x, fk::vector<P> const &b,
 
       if (error <= tolerance)
       {
-        auto const proj =
-            fk::matrix<P, mem_type::view>(krylov_proj, 0, i, 0, i);
+        auto proj = fk::matrix<P, mem_type::view>(krylov_proj, 0, i, 0, i);
         std::vector<int> pivots(i + 1);
 
         auto s_view = fk::vector<P, mem_type::view>(krylov_sol, 0, i);
@@ -141,9 +140,9 @@ P simple_gmres(fk::matrix<P> const &A, fk::vector<P> &x, fk::vector<P> const &b,
       done(error, it, i);
       return error; // all done!
     }
-    auto const proj = fk::matrix<P, mem_type::view>(krylov_proj, 0, restart - 1,
-                                                    0, restart - 1);
-    auto s_view     = fk::vector<P, mem_type::view>(krylov_sol, 0, restart - 1);
+    auto proj   = fk::matrix<P, mem_type::view>(krylov_proj, 0, restart - 1, 0,
+                                              restart - 1);
+    auto s_view = fk::vector<P, mem_type::view>(krylov_sol, 0, restart - 1);
     std::vector<int> pivots(restart);
     fm::gesv(proj, s_view, pivots);
     x = x + (fk::matrix<P, mem_type::view>(basis, 0, basis.nrows() - 1, 0,

--- a/src/transformations.hpp
+++ b/src/transformations.hpp
@@ -168,8 +168,8 @@ inline fk::vector<P> transform_and_combine_dimensions(
         dim, v_functions[i], dim.volume_jacobian_dV, transformer, time));
     int const n = dimension_components.back().size();
     std::vector<int> ipiv(n);
-    fk::matrix<P, mem_type::const_view> const lhs_mass(dim.get_mass_matrix(), 0,
-                                                       n - 1, 0, n - 1);
+    fk::matrix<P, mem_type::const_view> lhs_mass(dim.get_mass_matrix(), 0,
+                                                 n - 1, 0, n - 1);
     expect(lhs_mass.nrows() == n);
     expect(lhs_mass.ncols() == n);
     fm::gesv(lhs_mass, dimension_components.back(), ipiv);


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

I added another gesv wrapper that allows for two matrix inputs and updated our code to use it.

This fixes #421 

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [ ] Bugfix
- [x] New feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

my laptop, Ubuntu 20.04

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [x] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [x] documentation has been added (if appropriate)
