### PR TITLE
Fix namespace warnings and MATLAB issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,6 +269,7 @@ target_precompile_headers (asgard_obj
                            PUBLIC
                            $<$<BOOL:${ASGARD_USE_PCH}>:$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/build_info.hpp>>
                            $<$<BOOL:${ASGARD_USE_PCH}>:$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/pde/pde_base.hpp>>
+                           $<$<BOOL:${ASGARD_USE_PCH}>:$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/pde/pde_advection1.hpp>>
                            $<$<BOOL:${ASGARD_USE_PCH}>:$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/pde/pde_continuity1.hpp>>
                            $<$<BOOL:${ASGARD_USE_PCH}>:$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/pde/pde_continuity2.hpp>>
                            $<$<BOOL:${ASGARD_USE_PCH}>:$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/pde/pde_continuity3.hpp>>
@@ -281,6 +282,7 @@ target_precompile_headers (asgard_obj
                            $<$<BOOL:${ASGARD_USE_PCH}>:$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/pde/pde_fokkerplanck1_pitch_C.hpp>>
                            $<$<BOOL:${ASGARD_USE_PCH}>:$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/pde/pde_fokkerplanck1_pitch_E.hpp>>
                            $<$<BOOL:${ASGARD_USE_PCH}>:$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/pde/pde_fokkerplanck2_complete.hpp>>
+                           $<$<BOOL:${ASGARD_USE_PCH}>:$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/pde/pde_vlasov_lb_full_f.hpp>>
 )
 target_link_libraries (asgard_obj
                        PUBLIC

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -177,18 +177,19 @@ int main(int argc, char **argv)
 #ifdef ASGARD_USE_MATLAB
   asgard::ml::matlab_plot ml_plot;
   ml_plot.connect(cli_input.get_ml_session_string());
-  node_out() << "  connected to MATLAB" << '\n';
+  asgard::node_out() << "  connected to MATLAB" << '\n';
 
   asgard::fk::vector<prec> analytic_solution_realspace(real_space_size);
   if (pde->has_analytic_soln)
   {
     // generate the analytic solution at t=0
-    auto const subgrid_init           = adaptive_grid.get_subgrid(get_rank());
-    auto const analytic_solution_init = transform_and_combine_dimensions(
-        *pde, pde->exact_vector_funcs, adaptive_grid.get_table(), transformer,
-        subgrid_init.col_start, subgrid_init.col_stop, degree);
+    auto const subgrid_init = adaptive_grid.get_subgrid(asgard::get_rank());
+    auto const analytic_solution_init =
+        asgard::transform_and_combine_dimensions(
+            *pde, pde->exact_vector_funcs, adaptive_grid.get_table(),
+            transformer, subgrid_init.col_start, subgrid_init.col_stop, degree);
     // transform analytic solution to realspace
-    wavelet_to_realspace<prec>(
+    asgard::wavelet_to_realspace<prec>(
         *pde, analytic_solution_init, adaptive_grid.get_table(), transformer,
         default_workspace_cpu_MB, tmp_workspace, analytic_solution_realspace);
   }
@@ -206,7 +207,7 @@ int main(int argc, char **argv)
   for (int i = 0; i < pde->num_dims; i++)
   {
     sizes[i] = pde->get_dimensions()[i].get_degree() *
-               fm::two_raised_to(pde->get_dimensions()[i].get_level());
+               asgard::fm::two_raised_to(pde->get_dimensions()[i].get_level());
   }
   ml_plot.set_var("initial_condition",
                   ml_plot.create_array(sizes, initial_condition));
@@ -292,10 +293,10 @@ int main(int argc, char **argv)
         {
           analytic_solution_realspace.resize(real_size);
         }
-        wavelet_to_realspace<prec>(*pde, analytic_solution,
-                                   adaptive_grid.get_table(), transformer,
-                                   default_workspace_cpu_MB, transform_wksp,
-                                   analytic_solution_realspace);
+        asgard::wavelet_to_realspace<prec>(
+            *pde, analytic_solution, adaptive_grid.get_table(), transformer,
+            default_workspace_cpu_MB, transform_wksp,
+            analytic_solution_realspace);
       }
 #endif
     }

--- a/src/pde/pde_diffusion1.hpp
+++ b/src/pde/pde_diffusion1.hpp
@@ -185,4 +185,4 @@ private:
     return std::pow(0.25, dim.get_level());
   }
 };
-}; // namespace asgard
+} // namespace asgard

--- a/src/pde/pde_fokkerplanck1_pitch_E.hpp
+++ b/src/pde/pde_fokkerplanck1_pitch_E.hpp
@@ -200,4 +200,4 @@ private:
   inline static scalar_func<P> const exact_scalar_func_ =
       analytic_solution_time;
 };
-}; // namespace asgard
+} // namespace asgard


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

This PR fixes a few minor issues:
- Adds the `advection1` and `vlasov_lb_full_f` PDE to the precompiled header list in CMake.
- Fixes `-Wpedantic` warnings caused by an extra `;` at the end of two namespace declarations. These would appear when `ASGARD_RECOMMENDED_DEFAULTS=ON` was enabled.
- Fixes a few missing `asgard` namespace compiler errors when compiled with `ASGARD_USE_MATLAB=ON`.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

Ubuntu 20.04

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
