### PR TITLE
Remove unused variant of build_system_matrix

### DIFF
--- a/src/batch.hpp
+++ b/src/batch.hpp
@@ -150,7 +150,4 @@ private:
 template<typename P>
 void build_system_matrix(PDE<P> const &pde, elements::table const &elem_table,
                          fk::matrix<P> &A, element_subgrid const &grid);
-template<typename P>
-void build_system_matrix(PDE<P> const &pde, elements::table const &elem_table,
-                         fk::matrix<P> &A);
 } // namespace asgard

--- a/src/kronmult_tests.cpp
+++ b/src/kronmult_tests.cpp
@@ -45,10 +45,10 @@ void test_kronmult(parser const &parse, int const workspace_size_MB,
   }();
 
   // perform kron product + gemv for gold data
-  fk::vector<P> const gold = [&pde, &table, x, elem_size]() {
+  fk::vector<P> const gold = [&pde, &table, &my_subgrid, x, elem_size]() {
     auto const system_size = elem_size * table.size();
     fk::matrix<P> A(system_size, system_size);
-    build_system_matrix(*pde, table, A);
+    build_system_matrix(*pde, table, A, my_subgrid);
     return A * x;
   }();
 


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

In answering @stefan-schnake's question, I noticed we didn't need the second implementation of `build_system_matrix`. It's only use was in kronmult_test, which we can also pass `element_subgrid`.

This PR removes the unused code.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [ ] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

my laptop, ubuntu 20.04

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
