### PR TITLE
Fix term selection option

### DIFF
--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -375,7 +375,7 @@ class PDE
 {
 public:
   PDE(parser const &cli_input, int const num_dims_in, int const num_sources_in,
-      int const num_terms_in, std::vector<dimension<P>> const dimensions,
+      int const max_num_terms, std::vector<dimension<P>> const dimensions,
       term_set<P> const terms, std::vector<source<P>> const sources_in,
       std::vector<vector_func<P>> const exact_vector_funcs_in,
       scalar_func<P> const exact_time_in, dt_func<P> const get_dt,
@@ -383,7 +383,7 @@ public:
       bool const has_analytic_soln_in         = false,
       std::vector<moment<P>> const moments_in = {})
       : num_dims(num_dims_in), num_sources(num_sources_in),
-        num_terms(get_num_terms(cli_input, num_terms_in)),
+        num_terms(get_num_terms(cli_input, max_num_terms)),
         max_level(get_max_level(cli_input, dimensions)), sources(sources_in),
         exact_vector_funcs(exact_vector_funcs_in), moments(moments_in),
         exact_time(exact_time_in), do_poisson_solve(do_poisson_solve_in),
@@ -395,7 +395,7 @@ public:
     expect(num_terms > 0);
 
     expect(dimensions.size() == static_cast<unsigned>(num_dims));
-    expect(terms.size() == static_cast<unsigned>(num_terms_in));
+    expect(terms.size() == static_cast<unsigned>(max_num_terms));
     expect(sources.size() == static_cast<unsigned>(num_sources));
 
     // ensure analytic solution functions were provided if this flag is set
@@ -428,7 +428,7 @@ public:
     if (num_active_terms != 0)
     {
       auto const active_terms = cli_input.get_active_terms();
-      for (auto i = num_terms_in - 1; i >= 0; --i)
+      for (auto i = max_num_terms - 1; i >= 0; --i)
       {
         if (active_terms(i) == 0)
         {

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -395,7 +395,7 @@ public:
     expect(num_terms > 0);
 
     expect(dimensions.size() == static_cast<unsigned>(num_dims));
-    expect(terms.size() == static_cast<unsigned>(num_terms));
+    expect(terms.size() == static_cast<unsigned>(num_terms_in));
     expect(sources.size() == static_cast<unsigned>(num_sources));
 
     // ensure analytic solution functions were provided if this flag is set
@@ -428,7 +428,7 @@ public:
     if (num_active_terms != 0)
     {
       auto const active_terms = cli_input.get_active_terms();
-      for (auto i = num_terms - 1; i >= 0; --i)
+      for (auto i = num_terms_in - 1; i >= 0; --i)
       {
         if (active_terms(i) == 0)
         {
@@ -650,7 +650,8 @@ private:
     if (num_active_terms != 0 && num_active_terms != num_terms_in)
     {
       std::cerr << "failed to parse dimension-many active terms - parsed "
-                << num_active_terms << " terms, expected " << num_terms << "\n";
+                << num_active_terms << " terms, expected " << num_terms_in
+                << "\n";
       exit(1);
     }
     if (num_active_terms == num_terms_in)

--- a/src/pde_tests.cpp
+++ b/src/pde_tests.cpp
@@ -386,3 +386,15 @@ TEMPLATE_TEST_CASE("testing vlasov full f implementations", "[pde]", double,
     test_initial_condition<TestType>(*pde, base_dir, x);
   }
 }
+
+TEST_CASE("testing pde term selection", "[pde]")
+{
+  std::string const pde_choice   = "fokkerplanck_2d_complete_case4";
+  std::string const active_terms = "1 1 0 1 0 1";
+
+  parser const parse = make_parser({"-p", pde_choice, "--terms", active_terms});
+  auto const pde     = make_PDE<float>(parse);
+
+  REQUIRE(pde->num_terms == 4);
+  REQUIRE(pde->get_terms().size() == 4);
+}


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

This fixes the PDE individual term selection option (`--terms`) after changes in #442. A few leftover shadowed `num_terms` are changed to use `num_terms_in` when parsing the input term string.

Some term selection examples to test:
- `./asgard -p diffusion_2 --terms "1 0"`
- `./asgard -p fokkerplanck_2d_complete_case4 --terms "1 0 1 1 0 0"`

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

Ubuntu 20.04

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
