### PR TITLE
reduce likelihood of integer overflow in fk::matrix::size()

### DIFF
--- a/src/tensors.hpp
+++ b/src/tensors.hpp
@@ -712,13 +712,13 @@ public:
   // for owners: stride == nrows
   // for views:  stride == owner's nrows
   int stride() const { return stride_; }
-  int size() const { return nrows() * ncols(); }
+  int64_t size() const { return int64_t{nrows()} * ncols(); }
   // just get a pointer. cannot deref/assign. for e.g. blas
   // use subscript operators for general purpose access
   P *data(int const i = 0, int const j = 0) const
   {
     // return data_ + i * stride() + j; // row-major
-    return data_ + j * stride() + i; // column-major
+    return data_ + int64_t{j} * stride() + int64_t{i}; // column-major
   }
 
   //
@@ -834,7 +834,7 @@ private:
 
 template<typename P>
 inline void
-allocate_device(P *&ptr, int const num_elems, bool const initialize = true)
+allocate_device(P *&ptr, int64_t const num_elems, bool const initialize = true)
 {
 #ifdef ASGARD_USE_CUDA
   auto success = cudaMalloc((void **)&ptr, num_elems * sizeof(P));
@@ -1806,7 +1806,8 @@ fk::vector<P, mem, resrc>::vector(fk::matrix<P, omem, resrc> const &source,
 
   if (size_ > 0)
   {
-    data_ = source.data(column_index * source.stride() + row_start);
+    data_ = source.data(int64_t{column_index} * source.stride() +
+                        int64_t{row_start});
   }
 }
 
@@ -1838,11 +1839,11 @@ fk::matrix<P, mem, resrc>::matrix(int const m, int const n)
 
   if constexpr (resrc == resource::host)
   {
-    data_ = new P[nrows() * ncols()]();
+    data_ = new P[size()]();
   }
   else
   {
-    allocate_device(data_, nrows() * ncols());
+    allocate_device(data_, size());
   }
 }
 


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

@stefan-schnake sent me a PDE where `fk::matrix::size() >  INT_MAX`. I made a first pass at making size an `int64_t` which should be large enough for 300 GB matrices.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ]  Yes
- [x] No

## What systems has this change been tested on?

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [?] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
