### PR TITLE
Avoid call to build_system_matrix

### DIFF
--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -316,7 +316,7 @@ implicit_advance(PDE<P> const &pde,
       time + dt);
   fm::axpy(bc, x, dt);
 
-  if (first_time || update_system)
+  if (solver != solve_opts::gmres && (first_time || update_system))
   {
     first_time = false;
 
@@ -361,11 +361,6 @@ implicit_advance(PDE<P> const &pde,
       return x;
 #endif
     }
-    else if (solver == solve_opts::gmres)
-    {
-      ignore(ipiv);
-      ignore(ipiv_size);
-    }
   } // end first time/update system
 
   if (solver == solve_opts::direct)
@@ -389,8 +384,8 @@ implicit_advance(PDE<P> const &pde,
   else if (solver == solve_opts::gmres)
   {
     P const tolerance  = std::is_same_v<float, P> ? 1e-6 : 1e-12;
-    int const restart  = A.ncols();
-    int const max_iter = A.ncols();
+    int const restart  = A_local_cols;
+    int const max_iter = A_local_cols;
     fk::vector<P> fx(x.size());
     solver::simple_gmres(pde, table, program_opts, grid, fx, x, fk::matrix<P>(),
                          restart, max_iter, tolerance);


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

With `solver == solver_opts::gmres` one no longer needs to resize and build the A matrix. This PR adds a check to skip those steps.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
