### PR TITLE
clear_and_resize overflows with large numbers of rows and cols

### DIFF
--- a/src/tensors.hpp
+++ b/src/tensors.hpp
@@ -2686,12 +2686,12 @@ fk::matrix<P, mem, resrc>::clear_and_resize(int const rows, int const cols)
   if constexpr (resrc == resource::host)
   {
     delete[] data_;
-    data_ = new P[rows * cols]();
+    data_ = new P[int64_t{rows} * cols]();
   }
   else
   {
     delete_device(data_);
-    allocate_device(data_, rows * cols);
+    allocate_device(data_, int64_t{rows} * cols);
   }
 
   nrows_  = rows;
@@ -2878,7 +2878,7 @@ fk::matrix<P, mem, resrc>::matrix(fk::vector<P, omem, resrc> const &source,
   expect(num_rows > 0);
   expect(num_cols > 0);
 
-  int const size = num_rows * num_cols;
+  int64_t const size = int64_t{num_rows} * num_cols;
   expect(start_index + size <= source.size());
 
   data_   = nullptr;


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

I found another integer overflow in clear_and_resize that caused the PDE @stefan-schnake sent me to crash. I also found and fixed a similar issue in one the matrix constructors.

`OMP_NUM_THREADS=24 time ./asgard -p lenard_bernstein_3 -d 3 -t 0.01 -s direct -n 10 -l "4 4 4" -i -f` now runs to completion on fusiont5

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

fusiont5

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
