### PR TITLE
Added penalty term to PDE operator.  Still needs to be added to BCs

### DIFF
--- a/src/basis.cpp
+++ b/src/basis.cpp
@@ -437,8 +437,7 @@ template<typename P, resource resrc>
 wavelet_transform<P, resrc>::wavelet_transform(int const max_level_in,
                                                int const max_degree,
                                                bool const quiet)
-    : max_level(max_level_in), degree(max_degree),
-      dense_blocks_(max_level * 2)
+    : max_level(max_level_in), degree(max_degree), dense_blocks_(max_level * 2)
 {
   // this is to get around unused warnings
   // because can't unpack only some args w structured binding (until

--- a/src/basis.cpp
+++ b/src/basis.cpp
@@ -434,10 +434,10 @@ namespace basis
 {
 // FIXME assumes same degree for all dimensions
 template<typename P, resource resrc>
-wavelet_transform<P, resrc>::wavelet_transform(options const &program_opts,
+wavelet_transform<P, resrc>::wavelet_transform(int const max_level_in,
                                                int const max_degree,
                                                bool const quiet)
-    : max_level(program_opts.max_level), degree(max_degree),
+    : max_level(max_level_in), degree(max_degree),
       dense_blocks_(max_level * 2)
 {
   // this is to get around unused warnings

--- a/src/basis.hpp
+++ b/src/basis.hpp
@@ -39,13 +39,13 @@ public:
 
   wavelet_transform(options const &program_opts, int const max_degree,
                     bool const quiet = true)
-      : wavelet_transform(program_opts.max_level, max_degree,
-                    quiet){}
+      : wavelet_transform(program_opts.max_level, max_degree, quiet)
+  {}
 
   wavelet_transform(options const &program_opts, PDE<P> const &pde,
                     bool const quiet = true)
-      : wavelet_transform(program_opts.max_level, pde.get_dimensions()[0].get_degree(),
-                          quiet)
+      : wavelet_transform(program_opts.max_level,
+                          pde.get_dimensions()[0].get_degree(), quiet)
   {}
 
   // apply the fmwt matrix to coefficients

--- a/src/basis.hpp
+++ b/src/basis.hpp
@@ -34,12 +34,17 @@ template<typename P, resource resrc>
 class wavelet_transform
 {
 public:
-  wavelet_transform(options const &program_opts, int const max_degree,
+  wavelet_transform(int const max_level_in, int const max_degree,
                     bool const quiet = true);
+
+  wavelet_transform(options const &program_opts, int const max_degree,
+                    bool const quiet = true)
+      : wavelet_transform(program_opts.max_level, max_degree,
+                    quiet){}
 
   wavelet_transform(options const &program_opts, PDE<P> const &pde,
                     bool const quiet = true)
-      : wavelet_transform(program_opts, pde.get_dimensions()[0].get_degree(),
+      : wavelet_transform(program_opts.max_level, pde.get_dimensions()[0].get_degree(),
                           quiet)
   {}
 

--- a/src/coefficients.cpp
+++ b/src/coefficients.cpp
@@ -108,7 +108,7 @@ fk::matrix<P> generate_coefficients(
   // setup jacobi of variable x and define coeff_mat
   auto const num_cells = fm::two_raised_to(level);
 
-  auto const grid_spacing = (dim.domain_max - dim.domain_min) / num_cells;
+  auto const grid_spacing       = (dim.domain_max - dim.domain_min) / num_cells;
   auto const degrees_freedom_1d = dim.get_degree() * num_cells;
   fk::matrix<P> coefficients(degrees_freedom_1d, degrees_freedom_1d);
 
@@ -205,7 +205,7 @@ fk::matrix<P> generate_coefficients(
       {
         output = legendre_prime_t * tmp * (-1);
       }
-      // If pterm.coeff_type == coefficient_type::penalty is true, there's 
+      // If pterm.coeff_type == coefficient_type::penalty is true, there's
       // no volume term so the output is zeros.
       return output;
     }();
@@ -219,22 +219,21 @@ fk::matrix<P> generate_coefficients(
     coefficients.set_submatrix(current, current, curr_block);
 
     if (pterm.coeff_type == coefficient_type::grad ||
-        pterm.coeff_type == coefficient_type::div  ||
-        pterm.coeff_type == coefficient_type::penalty )
+        pterm.coeff_type == coefficient_type::div ||
+        pterm.coeff_type == coefficient_type::penalty)
     {
       // setup numerical flux choice/boundary conditions
       //
       // - <funcCoef*{q},p>
       //----------------------------------------------
       // Numerical Flux is defined as
-      // Flux = {{{f}}} + C/2*[[u]]
+      // Flux = {{f}} + C/2*[[u]]
       //      = ( f_L + f_R )/2 + FunCoef*( u_R - u_L )/2
       // [[v]] = v_R - v_L
 
       // FIXME G functions should accept G(x,p,t,dat), since we don't know how
       // the dat is going to be used in the G function (above it is used as
       // linear multuplication but this is not always true)
-
 
       // Penalty term is just <|gfunc|/2[[f]],[[v]]> so we need to remove the central
       // flux <gfunc{{f}},[[v]]> from the operators
@@ -248,49 +247,53 @@ fk::matrix<P> generate_coefficients(
       // get the "trace" values
       // (values at the left and right of each element for all k)
       // -------------------------------------------------------------------------
-      // More detailed explanation 
-      // Each trace_value_ evaluates <FLUX_f,[[v]]> 
-      // where v is a DG functions with support on I_i. The 
+      // More detailed explanation
+      // Each trace_value_ evaluates <FLUX_f,[[v]]>
+      // where v is a DG functions with support on I_i. The
       // difference between the trace_values_ varies with the edge the flux
       // is evaluated on and the support of the DG function f.
       // The legendre_poly_X is the trace of f and legende_poly_X_t is for v
       // We will use f=p_X for the polynomials where X=L (left boundary of cell)
-      // or X=R (right boundary of cell).  Similar for v but depends on the support
+      // or X=R (right boundary of cell).  Similar for v but depends on the
+      // support
 
-      // trace_value_1 is the interaction on x_{i-1/2} --  
+      // trace_value_1 is the interaction on x_{i-1/2} --
       // the edge between cell I_{i-1} and I_i or the left boundary of I_i.
       // f is a DG function with support on I_{i-1}
       // In this case:  {{f}} = p_R/2, [[f]] = p_R, [[v]] = -p_L
       auto trace_value_1 =
-          (legendre_poly_L_t * legendre_poly_R) * central_coeff
-          * (-1 * flux_left / 2) +
+          (legendre_poly_L_t * legendre_poly_R) * central_coeff *
+              (-1 * flux_left / 2) +
           (legendre_poly_L_t * legendre_poly_R) *
               (+1 * pterm.get_flux_scale() * std::abs(flux_left) / 2 * -1);
 
-      // trace_value_2 is the interaction on x_{i-1/2} --  
+      // trace_value_2 is the interaction on x_{i-1/2} --
       // the edge between cell I_{i-1} and I_i or the left boundary of I_i.
       // f is a DG function with support on I_{i}
       // In this case:  {{f}} = p_L/2, [[f]] = -p_L, [[v]] = -p_L
       auto trace_value_2 =
-          (legendre_poly_L_t * legendre_poly_L) * central_coeff * (-1 * flux_left / 2) +
+          (legendre_poly_L_t * legendre_poly_L) * central_coeff *
+              (-1 * flux_left / 2) +
           (legendre_poly_L_t * legendre_poly_L) *
               (-1 * pterm.get_flux_scale() * std::abs(flux_left) / 2 * -1);
 
-      // trace_value_3 is the interaction on x_{i+1/2} --  
+      // trace_value_3 is the interaction on x_{i+1/2} --
       // the edge between cell I_i and I_{i+1} or the right boundary of I_i.
       // f is a DG function with support on I_{i}
-      // In this case:  {{f}} = p_R/2, [[f]] = p_R, [[v]] = p_R        
+      // In this case:  {{f}} = p_R/2, [[f]] = p_R, [[v]] = p_R
       auto trace_value_3 =
-          (legendre_poly_R_t * legendre_poly_R) * central_coeff * (+1 * flux_right / 2) +
+          (legendre_poly_R_t * legendre_poly_R) * central_coeff *
+              (+1 * flux_right / 2) +
           (legendre_poly_R_t * legendre_poly_R) *
               (+1 * pterm.get_flux_scale() * std::abs(flux_right) / 2 * +1);
 
-      // trace_value_4 is the interaction on x_{i+1/2} --  
+      // trace_value_4 is the interaction on x_{i+1/2} --
       // the edge between cell I_i and I_{i+1} or the right boundary of I_i.
       // f is a DG function with support on I_{i+1}
-      // In this case:  {{f}} = p_L/2, [[f]] = -p_L, [[v]] = p_R 
+      // In this case:  {{f}} = p_L/2, [[f]] = -p_L, [[v]] = p_R
       auto trace_value_4 =
-          (legendre_poly_R_t * legendre_poly_L) * central_coeff * (+1 * flux_right / 2) +
+          (legendre_poly_R_t * legendre_poly_L) * central_coeff *
+              (+1 * flux_right / 2) +
           (legendre_poly_R_t * legendre_poly_L) *
               (-1 * pterm.get_flux_scale() * std::abs(flux_right) / 2 * +1);
 
@@ -303,11 +306,12 @@ fk::matrix<P> generate_coefficients(
       // Dirichlet Boundary Conditions
       // For div and grad, the boundary is not part of the bilinear operator,
       // but instead tranferred to the source.  Similar to an inflow condition.
-      // For penalty, the operator <|gfunc|/2*f,v> is applied for the case where f
-      // and v share the same volume support
-      
-      // If statement checking coeff_type is because gfunc can evaluate to nan in 
-      // 1/0 case.  Ex: gfunc = x, domain = [0,4] (possible in spherical coordinates)
+      // For penalty, the operator <|gfunc|/2*f,v> is applied for the case where
+      // f and v share the same volume support
+
+      // If statement checking coeff_type is because gfunc can evaluate to nan
+      // in 1/0 case.  Ex: gfunc = x, domain = [0,4] (possible in spherical
+      // coordinates)
 
       if (left == boundary_condition::dirichlet) // left dirichlet
       {
@@ -315,15 +319,17 @@ fk::matrix<P> generate_coefficients(
         {
           trace_value_1 =
               (legendre_poly_L_t * (legendre_poly_L - legendre_poly_L)) * (-1);
-          if (pterm.coeff_type == coefficient_type::penalty) {
-            trace_value_2 =
-              (legendre_poly_L_t * legendre_poly_L) *
-              (-1.0 * pterm.get_flux_scale() * std::abs(flux_left) / 2.0 * -1.0);
-          } 
+          if (pterm.coeff_type == coefficient_type::penalty)
+          {
+            trace_value_2 = (legendre_poly_L_t * legendre_poly_L) *
+                            (-1.0 * pterm.get_flux_scale() *
+                             std::abs(flux_left) / 2.0 * -1.0);
+          }
           else
           {
-            trace_value_2 = 
-              (legendre_poly_L_t * (legendre_poly_L - legendre_poly_L)) * (-1);
+            trace_value_2 =
+                (legendre_poly_L_t * (legendre_poly_L - legendre_poly_L)) *
+                (-1);
           }
           trace_value_3 =
               (legendre_poly_R_t * legendre_poly_R) * (+1 * flux_right / 2) +
@@ -350,15 +356,15 @@ fk::matrix<P> generate_coefficients(
                   (-1 * pterm.get_flux_scale() * std::abs(flux_left) / 2 * -1);
           if (pterm.coeff_type == coefficient_type::penalty)
           {
-            trace_value_3 = 
-              (legendre_poly_R_t * legendre_poly_R) *
-              (+1 * pterm.get_flux_scale() * std::abs(flux_right) / 2 * +1);
-              
+            trace_value_3 =
+                (legendre_poly_R_t * legendre_poly_R) *
+                (+1 * pterm.get_flux_scale() * std::abs(flux_right) / 2 * +1);
           }
           else
-          { 
+          {
             trace_value_3 =
-              (legendre_poly_R_t * (legendre_poly_R - legendre_poly_R)) * (+1);
+                (legendre_poly_R_t * (legendre_poly_R - legendre_poly_R)) *
+                (+1);
           }
           trace_value_4 =
               (legendre_poly_R_t * (legendre_poly_R - legendre_poly_R)) * (+1);
@@ -372,9 +378,9 @@ fk::matrix<P> generate_coefficients(
       // only work for derivatives greater than 1
 
       // Neumann boundary conditions
-      // For div and grad, the interior trace is used to calculate the flux, similar
-      // to an outflow boundary condition. 
-      // For penalty, nothing is added.
+      // For div and grad, the interior trace is used to calculate the flux,
+      // similar to an outflow boundary condition. For penalty, nothing is
+      // added.
 
       if (left == boundary_condition::neumann) // left neumann
       {
@@ -383,12 +389,15 @@ fk::matrix<P> generate_coefficients(
           trace_value_1 =
               (legendre_poly_L_t * (legendre_poly_L - legendre_poly_L)) * (-1);
           if (pterm.coeff_type == coefficient_type::penalty)
-          { 
-            trace_value_2 = (legendre_poly_L_t * (legendre_poly_L - legendre_poly_L)) * (-1);
-          }
-          else {
+          {
             trace_value_2 =
-              (legendre_poly_L_t * legendre_poly_L) * (-1 * flux_left);
+                (legendre_poly_L_t * (legendre_poly_L - legendre_poly_L)) *
+                (-1);
+          }
+          else
+          {
+            trace_value_2 =
+                (legendre_poly_L_t * legendre_poly_L) * (-1 * flux_left);
           }
           trace_value_3 =
               (legendre_poly_R_t * legendre_poly_R) * (+1 * flux_right / 2) +
@@ -416,12 +425,13 @@ fk::matrix<P> generate_coefficients(
           if (pterm.coeff_type == coefficient_type::penalty)
           {
             trace_value_3 =
-              (legendre_poly_R_t * (legendre_poly_R - legendre_poly_R)) * (+1);
+                (legendre_poly_R_t * (legendre_poly_R - legendre_poly_R)) *
+                (+1);
           }
-          else 
+          else
           {
             trace_value_3 =
-              (legendre_poly_R_t * legendre_poly_R) * (+1 * flux_right);
+                (legendre_poly_R_t * legendre_poly_R) * (+1 * flux_right);
           }
           trace_value_4 =
               (legendre_poly_R_t * (legendre_poly_R - legendre_poly_R)) * (+1);

--- a/src/coefficients.cpp
+++ b/src/coefficients.cpp
@@ -205,10 +205,8 @@ fk::matrix<P> generate_coefficients(
       {
         output = legendre_prime_t * tmp * (-1);
       }
-      else if (pterm.coeff_type == coefficient_type::penalty)
-      {
-        // output is zeros (no volume term)
-      }
+      // If pterm.coeff_type == coefficient_type::penalty is true, there's 
+      // no volume term so the output is zeros.
       return output;
     }();
 
@@ -229,7 +227,7 @@ fk::matrix<P> generate_coefficients(
       // - <funcCoef*{q},p>
       //----------------------------------------------
       // Numerical Flux is defined as
-      // Flux = {{f}} + C/2*[[u]]
+      // Flux = {{{f}}} + C/2*[[u]]
       //      = ( f_L + f_R )/2 + FunCoef*( u_R - u_L )/2
       // [[v]] = v_R - v_L
 
@@ -237,8 +235,8 @@ fk::matrix<P> generate_coefficients(
       // the dat is going to be used in the G function (above it is used as
       // linear multuplication but this is not always true)
 
-      // Penalty term is just <|gfunc|/2[[f]],[[v]]> so we need to remove the central
-      // flux <gfunc{f},[[v]]> from the operators
+      // Penalty term is just <|gfunc|/2[[[f]]],[[v]]> so we need to remove the central
+      // flux <gfunc{{f}},[[v]]> from the operators
       P central_coeff = 1.0;
       if ( pterm.coeff_type == coefficient_type::penalty ){
         central_coeff = 0.0;
@@ -250,7 +248,7 @@ fk::matrix<P> generate_coefficients(
           pterm.g_func(x_right, time) * pterm.dv_func(x_right, time);
 
       // get the "trace" values
-      // (values at the left and right of each element for all k).
+      // (values at the left and right of each element for all k)
       // -------------------------------------------------------------------------
       // More detailed explanation 
       // Each trace_value_ evaluates <FLUX_f,[[v]]> 
@@ -264,7 +262,7 @@ fk::matrix<P> generate_coefficients(
       // trace_value_1 is the interaction on x_{i-1/2} --  
       // the edge between cell I_{i-1} and I_i or the left boundary of I_i.
       // f is a DG function with support on I_{i-1}
-      // In this case:  {f} = p_R/2, [f] = p_R, [v] = -p_L
+      // In this case:  {{f}} = p_R/2, [[f]] = p_R, [[v]] = -p_L
       auto trace_value_1 =
           (legendre_poly_L_t * legendre_poly_R) * central_coeff
           * (-1 * flux_left / 2) +
@@ -274,7 +272,7 @@ fk::matrix<P> generate_coefficients(
       // trace_value_2 is the interaction on x_{i-1/2} --  
       // the edge between cell I_{i-1} and I_i or the left boundary of I_i.
       // f is a DG function with support on I_{i}
-      // In this case:  {f} = p_L/2, [f] = -p_L, [v] = -p_L
+      // In this case:  {{f}} = p_L/2, [[f]] = -p_L, [[v]] = -p_L
       auto trace_value_2 =
           (legendre_poly_L_t * legendre_poly_L) * central_coeff * (-1 * flux_left / 2) +
           (legendre_poly_L_t * legendre_poly_L) *
@@ -283,7 +281,7 @@ fk::matrix<P> generate_coefficients(
       // trace_value_3 is the interaction on x_{i+1/2} --  
       // the edge between cell I_i and I_{i+1} or the right boundary of I_i.
       // f is a DG function with support on I_{i}
-      // In this case:  {f} = p_R/2, [f] = p_R, [v] = p_R        
+      // In this case:  {{f}} = p_R/2, [[f]] = p_R, [[v]] = p_R        
       auto trace_value_3 =
           (legendre_poly_R_t * legendre_poly_R) * central_coeff * (+1 * flux_right / 2) +
           (legendre_poly_R_t * legendre_poly_R) *
@@ -292,7 +290,7 @@ fk::matrix<P> generate_coefficients(
       // trace_value_4 is the interaction on x_{i+1/2} --  
       // the edge between cell I_i and I_{i+1} or the right boundary of I_i.
       // f is a DG function with support on I_{i+1}
-      // In this case:  {f} = p_L/2, [f] = -p_L, [v] = p_R 
+      // In this case:  {{f}} = p_L/2, [[f]] = -p_L, [[v]] = p_R 
       auto trace_value_4 =
           (legendre_poly_R_t * legendre_poly_L) * central_coeff * (+1 * flux_right / 2) +
           (legendre_poly_R_t * legendre_poly_L) *

--- a/src/coefficients.cpp
+++ b/src/coefficients.cpp
@@ -235,9 +235,10 @@ fk::matrix<P> generate_coefficients(
       // the dat is going to be used in the G function (above it is used as
       // linear multuplication but this is not always true)
 
-      // Penalty term is just <|gfunc|/2[[f]],[[v]]> so we need to remove the central
-      // flux <gfunc{{f}},[[v]]> from the operators
-      P const central_coeff = pterm.coeff_type == coefficient_type::penalty ? 0.0 : 1.0;
+      // Penalty term is just <|gfunc|/2[[f]],[[v]]> so we need to remove the
+      // central flux <gfunc{{f}},[[v]]> from the operators
+      P const central_coeff =
+          pterm.coeff_type == coefficient_type::penalty ? 0.0 : 1.0;
 
       P const flux_left =
           pterm.g_func(x_left, time) * pterm.dv_func(x_left, time);

--- a/src/coefficients.cpp
+++ b/src/coefficients.cpp
@@ -235,12 +235,10 @@ fk::matrix<P> generate_coefficients(
       // the dat is going to be used in the G function (above it is used as
       // linear multuplication but this is not always true)
 
-      // Penalty term is just <|gfunc|/2[[[f]]],[[v]]> so we need to remove the central
+
+      // Penalty term is just <|gfunc|/2[[f]],[[v]]> so we need to remove the central
       // flux <gfunc{{f}},[[v]]> from the operators
-      P central_coeff = 1.0;
-      if ( pterm.coeff_type == coefficient_type::penalty ){
-        central_coeff = 0.0;
-      }
+      P const central_coeff = pterm.coeff_type == coefficient_type::penalty ? 0.0 : 1.0;
 
       P const flux_left =
           pterm.g_func(x_left, time) * pterm.dv_func(x_left, time);

--- a/src/coefficients_tests.cpp
+++ b/src/coefficients_tests.cpp
@@ -3,6 +3,8 @@
 #include "pde.hpp"
 #include "tensors.hpp"
 #include "tests_general.hpp"
+#include "pde/pde_base.hpp"
+#include "basis.hpp"
 
 static auto const coefficients_base_dir = gold_base_dir / "coefficients";
 
@@ -389,5 +391,42 @@ TEMPLATE_TEST_CASE("vlasov terms", "[coefficients]", double, float)
 
     // parser const test_parse(pde_choice, levels, degree);
     test_coefficients<TestType>(test_parse, gold_path, tol_factor);
+  }
+}
+
+TEMPLATE_TEST_CASE("penalty check", "[coefficients]", double, float)
+{
+  vector_func<TestType> ic = {partial_term<TestType>::null_vector_func};
+  g_func_type<TestType> gfunc = partial_term<TestType>::null_gfunc;
+
+  
+
+  SECTION("level 4, degree 3")
+  {
+    int const level = 4;
+    int const degree = 3;
+    basis::wavelet_transform<TestType,resource::host> waves(level,degree,true);
+
+    dimension<TestType> dim(0.0,1.0,level,degree,ic,gfunc,"x");
+    partial_term<TestType> central(coefficient_type::div,gfunc,gfunc,
+          flux_type::central,
+          boundary_condition::periodic,
+          boundary_condition::periodic);
+
+    partial_term<TestType> penalty(coefficient_type::penalty,gfunc,gfunc,
+          flux_type::upwind,
+          boundary_condition::periodic,
+          boundary_condition::periodic); 
+
+    partial_term<TestType> upwind(coefficient_type::div,gfunc,gfunc,
+          flux_type::upwind,
+          boundary_condition::periodic,
+          boundary_condition::periodic);  
+
+    auto central_mat = generate_coefficients(dim,central,waves,level,TestType{0.0},true);
+    auto penalty_mat = generate_coefficients(dim,penalty,waves,level,TestType{0.0},true);
+    auto  upwind_mat = generate_coefficients(dim,upwind ,waves,level,TestType{0.0},true);
+
+    rmse_comparison(central_mat + penalty_mat, upwind_mat, get_tolerance<TestType>(10));
   }
 }

--- a/src/coefficients_tests.cpp
+++ b/src/coefficients_tests.cpp
@@ -1,10 +1,10 @@
+#include "basis.hpp"
 #include "coefficients.hpp"
 #include "matlab_utilities.hpp"
 #include "pde.hpp"
+#include "pde/pde_base.hpp"
 #include "tensors.hpp"
 #include "tests_general.hpp"
-#include "pde/pde_base.hpp"
-#include "basis.hpp"
 
 static auto const coefficients_base_dir = gold_base_dir / "coefficients";
 
@@ -396,37 +396,37 @@ TEMPLATE_TEST_CASE("vlasov terms", "[coefficients]", double, float)
 
 TEMPLATE_TEST_CASE("penalty check", "[coefficients]", double, float)
 {
-  vector_func<TestType> ic = {partial_term<TestType>::null_vector_func};
+  vector_func<TestType> ic    = {partial_term<TestType>::null_vector_func};
   g_func_type<TestType> gfunc = partial_term<TestType>::null_gfunc;
-
-  
 
   SECTION("level 4, degree 3")
   {
-    int const level = 4;
+    int const level  = 4;
     int const degree = 3;
-    basis::wavelet_transform<TestType,resource::host> waves(level,degree,true);
+    basis::wavelet_transform<TestType, resource::host> waves(level, degree,
+                                                             true);
 
-    dimension<TestType> dim(0.0,1.0,level,degree,ic,gfunc,"x");
-    partial_term<TestType> central(coefficient_type::div,gfunc,gfunc,
-          flux_type::central,
-          boundary_condition::periodic,
-          boundary_condition::periodic);
+    dimension<TestType> dim(0.0, 1.0, level, degree, ic, gfunc, "x");
+    partial_term<TestType> central(
+        coefficient_type::div, gfunc, gfunc, flux_type::central,
+        boundary_condition::periodic, boundary_condition::periodic);
 
-    partial_term<TestType> penalty(coefficient_type::penalty,gfunc,gfunc,
-          flux_type::upwind,
-          boundary_condition::periodic,
-          boundary_condition::periodic); 
+    partial_term<TestType> penalty(
+        coefficient_type::penalty, gfunc, gfunc, flux_type::upwind,
+        boundary_condition::periodic, boundary_condition::periodic);
 
-    partial_term<TestType> upwind(coefficient_type::div,gfunc,gfunc,
-          flux_type::upwind,
-          boundary_condition::periodic,
-          boundary_condition::periodic);  
+    partial_term<TestType> upwind(
+        coefficient_type::div, gfunc, gfunc, flux_type::upwind,
+        boundary_condition::periodic, boundary_condition::periodic);
 
-    auto central_mat = generate_coefficients(dim,central,waves,level,TestType{0.0},true);
-    auto penalty_mat = generate_coefficients(dim,penalty,waves,level,TestType{0.0},true);
-    auto  upwind_mat = generate_coefficients(dim,upwind ,waves,level,TestType{0.0},true);
+    auto central_mat =
+        generate_coefficients(dim, central, waves, level, TestType{0.0}, true);
+    auto penalty_mat =
+        generate_coefficients(dim, penalty, waves, level, TestType{0.0}, true);
+    auto upwind_mat =
+        generate_coefficients(dim, upwind, waves, level, TestType{0.0}, true);
 
-    rmse_comparison(central_mat + penalty_mat, upwind_mat, get_tolerance<TestType>(10));
+    rmse_comparison(central_mat + penalty_mat, upwind_mat,
+                    get_tolerance<TestType>(10));
   }
 }

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -391,7 +391,7 @@ public:
 
   // prevent potential copies from being created
   parameter_manager(parameter_manager<P> const &) = delete;
-  void operator=(parameter_manager<P> const &)  = delete;
+  void operator=(parameter_manager<P> const &)    = delete;
 
   std::shared_ptr<parameter<P>> get_parameter(std::string const name)
   {

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -72,6 +72,7 @@ enum class coefficient_type
   grad,
   mass,
   div,
+  penalty
 };
 
 enum class flux_type

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -391,7 +391,7 @@ public:
 
   // prevent potential copies from being created
   parameter_manager(parameter_manager<P> const &) = delete;
-  void operator=(parameter_manager<P> const &)    = delete;
+  void operator=(parameter_manager<P> const &)  = delete;
 
   std::shared_ptr<parameter<P>> get_parameter(std::string const name)
   {

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -391,7 +391,7 @@ public:
 
   // prevent potential copies from being created
   parameter_manager(parameter_manager<P> const &) = delete;
-  void operator=(parameter_manager<P> const &) = delete;
+  void operator=(parameter_manager<P> const &)    = delete;
 
   std::shared_ptr<parameter<P>> get_parameter(std::string const name)
   {

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -391,7 +391,7 @@ public:
 
   // prevent potential copies from being created
   parameter_manager(parameter_manager<P> const &) = delete;
-  void operator=(parameter_manager<P> const &)    = delete;
+  void operator=(parameter_manager<P> const &) = delete;
 
   std::shared_ptr<parameter<P>> get_parameter(std::string const name)
   {


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Deals with #492.  Penalty term added for interior fluxes and homogenous (Dirichlet) boundary data.  Inhomogeneous boundary conditions need to be added in the future but this requires some extra checks in the boundary condition routines. 

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [ ] Bugfix
- [x] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [ x] No

## What systems has this change been tested on?

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [ ] this PR is up to date with current the current state of 'develop'
- [ ] code added or changed in the PR has been clang-formatted
- [x] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [x] documentation has been added (if appropriate)
