### PR TITLE
gmres: start with previous value of x

### DIFF
--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -512,7 +512,7 @@ imex_advance(PDE<P> &pde, adapt::distributed_grid<P> const &adaptive_grid,
   P const tolerance  = program_opts.gmres_tolerance;
   int const restart  = program_opts.gmres_inner_iterations;
   int const max_iter = program_opts.gmres_outer_iterations;
-  fk::vector<P> f_2(x.size());
+  fk::vector<P> f_2(x);
   solver::simple_gmres(pde, table, program_opts, grid, f_2, x, fk::matrix<P>(),
                        restart, max_iter, tolerance, imex_flag::imex_implicit);
 
@@ -577,7 +577,7 @@ imex_advance(PDE<P> &pde, adapt::distributed_grid<P> const &adaptive_grid,
   generate_all_coefficients<P>(pde, transformer);
 
   // Final stage f3
-  fk::vector<P> f_3(x.size());
+  fk::vector<P> f_3(x);
   solver::simple_gmres(pde, table, program_opts, grid, f_3, x, fk::matrix<P>(),
                        restart, max_iter, tolerance, imex_flag::imex_implicit);
 

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -386,7 +386,7 @@ implicit_advance(PDE<P> const &pde,
     P const tolerance  = program_opts.gmres_tolerance;
     int const restart  = program_opts.gmres_inner_iterations;
     int const max_iter = program_opts.gmres_outer_iterations;
-    fk::vector<P> fx(x.size());
+    fk::vector<P> fx(x);
     solver::simple_gmres(pde, table, program_opts, grid, fx, x, fk::matrix<P>(),
                          restart, max_iter, tolerance);
     return fx;


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Starting with x at the previous time-step should converge faster.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

my laptop, ubuntu 20.04

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
