### PR TITLE
g_func, dv_func: use nullptr instead of null_gfunc

### DIFF
--- a/src/asgard_dimension.hpp
+++ b/src/asgard_dimension.hpp
@@ -90,8 +90,7 @@ struct dimension_description
       precision const domain_min, precision const domain_max,
       int const grid_level, int const basis_degree,
       std::string const dimension_name,
-      g_func_type<precision> const volume_jacobian_dV =
-          [](precision const, precision const) -> precision { return 1.0; })
+      g_func_type<precision> const volume_jacobian_dV = nullptr)
       : d_min(domain_min), d_max(domain_max), level(grid_level),
         degree(basis_degree), name(dimension_name), jacobian(volume_jacobian_dV)
   {

--- a/src/boundary_conditions.cpp
+++ b/src/boundary_conditions.cpp
@@ -153,9 +153,8 @@ fk::vector<P> generate_scaled_bc(unscaled_bc_parts<P> const &left_bc_parts,
 
 template<typename P>
 fk::vector<P>
-compute_left_boundary_condition(g_func_type<P> const g_func,
-                                g_func_type<P> const dv_func, P const time,
-                                dimension<P> const &dim,
+compute_left_boundary_condition(g_func_type<P> g_func, g_func_type<P> dv_func,
+                                P const time, dimension<P> const &dim,
                                 vector_func<P> const bc_func)
 {
   P const domain_min    = dim.domain_min;
@@ -165,6 +164,13 @@ compute_left_boundary_condition(g_func_type<P> const g_func,
 
   int const level  = dim.get_level();
   int const degree = dim.get_degree();
+
+  if (!g_func)
+    g_func = partial_term<P>::null_gfunc;
+  expect(g_func);
+  if (!dv_func)
+    dv_func = partial_term<P>::null_gfunc;
+  expect(dv_func);
 
   P const total_cells = std::pow(2, level);
 
@@ -209,9 +215,8 @@ compute_left_boundary_condition(g_func_type<P> const g_func,
 
 template<typename P>
 fk::vector<P>
-compute_right_boundary_condition(g_func_type<P> const g_func,
-                                 g_func_type<P> const dv_func, P const time,
-                                 dimension<P> const &dim,
+compute_right_boundary_condition(g_func_type<P> g_func, g_func_type<P> dv_func,
+                                 P const time, dimension<P> const &dim,
                                  vector_func<P> const bc_func)
 {
   P const domain_min    = dim.domain_min;
@@ -222,6 +227,13 @@ compute_right_boundary_condition(g_func_type<P> const g_func,
 
   int const level  = dim.get_level();
   int const degree = dim.get_degree();
+
+  if (!g_func)
+    g_func = partial_term<P>::null_gfunc;
+  expect(g_func);
+  if (!dv_func)
+    dv_func = partial_term<P>::null_gfunc;
+  expect(dv_func);
 
   P const total_cells = std::pow(2, level);
 
@@ -285,7 +297,10 @@ std::vector<fk::vector<P>> generate_partial_bcs(
         dimensions[dim_num].get_degree() *
         fm::two_raised_to(dimensions[dim_num].get_level());
     auto const &f = bc_funcs[dim_num];
-    auto const &g = terms[dim_num].get_partial_terms()[p_index].g_func;
+    auto g        = terms[dim_num].get_partial_terms()[p_index].g_func;
+    if (!g)
+      g = partial_term<P>::null_gfunc;
+    expect(g);
     vector_func<P> const bc_func = [f, g](fk::vector<P> const &x, P const &t) {
       // evaluate f(x,t) * g(x,t)
       fk::vector<P> fx(f(x, t));
@@ -373,24 +388,20 @@ template fk::vector<float> boundary_conditions::generate_scaled_bc(
 
 template fk::vector<double>
 boundary_conditions::compute_left_boundary_condition(
-    g_func_type<double> const g_func, g_func_type<double> const dv_func,
-    double const time, dimension<double> const &dim,
-    vector_func<double> const bc_func);
+    g_func_type<double> g_func, g_func_type<double> dv_func, double const time,
+    dimension<double> const &dim, vector_func<double> const bc_func);
 template fk::vector<float> boundary_conditions::compute_left_boundary_condition(
-    g_func_type<float> const g_func, g_func_type<float> const dv_func,
-    float const time, dimension<float> const &dim,
-    vector_func<float> const bc_func);
+    g_func_type<float> g_func, g_func_type<float> dv_func, float const time,
+    dimension<float> const &dim, vector_func<float> const bc_func);
 
 template fk::vector<double>
 boundary_conditions::compute_right_boundary_condition(
-    g_func_type<double> const g_func, g_func_type<double> const dv_func,
-    double const time, dimension<double> const &dim,
-    vector_func<double> const bc_func);
+    g_func_type<double> g_func, g_func_type<double> dv_func, double const time,
+    dimension<double> const &dim, vector_func<double> const bc_func);
 template fk::vector<float>
 boundary_conditions::compute_right_boundary_condition(
-    g_func_type<float> const g_func, g_func_type<float> const dv_func,
-    float const time, dimension<float> const &dim,
-    vector_func<float> const bc_func);
+    g_func_type<float> g_func, g_func_type<float> dv_func, float const time,
+    dimension<float> const &dim, vector_func<float> const bc_func);
 
 template std::vector<fk::vector<double>>
 boundary_conditions::generate_partial_bcs(

--- a/src/boundary_conditions.hpp
+++ b/src/boundary_conditions.hpp
@@ -26,15 +26,13 @@ fk::vector<P> generate_scaled_bc(unscaled_bc_parts<P> const &left_bc_parts,
 
 template<typename P>
 fk::vector<P>
-compute_left_boundary_condition(g_func_type<P> const g_func,
-                                g_func_type<P> const dv_func, P const time,
-                                dimension<P> const &dim,
+compute_left_boundary_condition(g_func_type<P> g_func, g_func_type<P> dv_func,
+                                P const time, dimension<P> const &dim,
                                 vector_func<P> const bc_func);
 template<typename P>
 fk::vector<P>
-compute_right_boundary_condition(g_func_type<P> const g_func,
-                                 g_func_type<P> const dv_func, P const time,
-                                 dimension<P> const &dim,
+compute_right_boundary_condition(g_func_type<P> g_func, g_func_type<P> dv_func,
+                                 P const time, dimension<P> const &dim,
                                  vector_func<P> const bc_func);
 
 template<typename P>

--- a/src/boundary_conditions_tests.cpp
+++ b/src/boundary_conditions_tests.cpp
@@ -160,7 +160,7 @@ TEMPLATE_TEST_CASE("problem separability", "[boundary_condition]", double,
     generate_dimension_mass_mat<TestType>(*pde, transformer);
     generate_all_coefficients<TestType>(*pde, transformer);
 
-    /* initialize bc vector at test_time */
+    // initialize bc vector at test_time
     TestType const test_time = 5;
     int const start_element  = 0;
     int const stop_element   = table.size() - 1;

--- a/src/coefficients.cpp
+++ b/src/coefficients.cpp
@@ -122,7 +122,11 @@ fk::matrix<P> generate_coefficients(
     }
     else
     {
-      return [](P const x, P const t) { return P{1.0}; };
+      return [](P const x, P const t) {
+        ignore(x);
+        ignore(t);
+        return P{1.0};
+      };
     }
   }();
 

--- a/src/coefficients.cpp
+++ b/src/coefficients.cpp
@@ -77,10 +77,10 @@ void generate_dimension_mass_mat(
     auto &dim = pde.get_dimensions()[i];
 
     partial_term<P> const lhs_mass_pterm = partial_term<P>(
-        coefficient_type::mass, nullptr, nullptr,
-        flux_type::central, boundary_condition::periodic,
-        boundary_condition::periodic, homogeneity::homogeneous,
-        homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
+        coefficient_type::mass, nullptr, nullptr, flux_type::central,
+        boundary_condition::periodic, boundary_condition::periodic,
+        homogeneity::homogeneous, homogeneity::homogeneous, {},
+        partial_term<P>::null_scalar_func, {},
         partial_term<P>::null_scalar_func, dim.volume_jacobian_dV);
     auto mass_mat = generate_coefficients<P>(dim, lhs_mass_pterm, transformer,
                                              pde.max_level, 0.0, true);
@@ -244,7 +244,7 @@ fk::matrix<P> generate_coefficients(
       P const central_coeff =
           pterm.coeff_type == coefficient_type::penalty ? 0.0 : 1.0;
 
-      P const flux_left = g_func(x_left, time) * dv_func(x_left, time);
+      P const flux_left  = g_func(x_left, time) * dv_func(x_left, time);
       P const flux_right = g_func(x_right, time) * dv_func(x_right, time);
 
       // get the "trace" values

--- a/src/coefficients_tests.cpp
+++ b/src/coefficients_tests.cpp
@@ -396,8 +396,8 @@ TEMPLATE_TEST_CASE("vlasov terms", "[coefficients]", double, float)
 
 TEMPLATE_TEST_CASE("penalty check", "[coefficients]", double, float)
 {
-  vector_func<TestType> ic    = {partial_term<TestType>::null_vector_func};
-  g_func_type<TestType> gfunc = partial_term<TestType>::null_gfunc;
+  vector_func<TestType> ic = {partial_term<TestType>::null_vector_func};
+  g_func_type<TestType> gfunc;
 
   SECTION("level 4, degree 3")
   {

--- a/src/coefficients_tests.cpp
+++ b/src/coefficients_tests.cpp
@@ -111,7 +111,7 @@ TEMPLATE_TEST_CASE("continuity 2 terms", "[coefficients]", double, float)
 {
   auto const pde_choice = PDE_opts::continuity_2;
   auto const gold_path  = coefficients_base_dir / "continuity2_coefficients";
-  auto constexpr tol_factor = get_tolerance<TestType>(10);
+  auto constexpr tol_factor = get_tolerance<TestType>(100);
 
   SECTION("level 4, degree 3")
   {

--- a/src/pde/pde_advection1.hpp
+++ b/src/pde/pde_advection1.hpp
@@ -102,13 +102,6 @@ private:
   // =========================================================================
 
   // Dimensions ==============================================================
-  static P jacobian_dim0(P const x, P const time)
-  {
-    ignore(x);
-    ignore(time);
-
-    return 1.0;
-  }
 
   inline static dimension<P> const dim0_ = dimension<P>(
       0.0,  // domain min
@@ -116,7 +109,7 @@ private:
       4,    // levels - default (changed on command line with option -l)
       3,    // degree - default (changed on command line with option -d)
       initial_condition_dim0, // initial condition function
-      jacobian_dim0,          // volume
+      nullptr,                // volume
       "x"                     // name of dimension
   );
 
@@ -148,7 +141,7 @@ private:
   inline static const partial_term<P> partial_term_0 = partial_term<P>(
       coefficient_type::div,       // type
       g_func_0,                    // g func
-      partial_term<P>::null_gfunc, // lhs, null_gfunc = 1.0
+      nullptr, // lhs, null_gfunc = 1.0
       flux_type::downwind, // flux = "-1" (downwind), "0" (central), "+1"
                            // (upwind)
       boundary_condition::dirichlet, // left boundary condition type ("D", "N",
@@ -160,7 +153,7 @@ private:
       bc_time_func,                  // left boundary time function
       {},                            // right boundary condition function list
       partial_term<P>::null_scalar_func, // right boundary time function
-      partial_term<P>::null_gfunc        // surface jacobian
+      nullptr                            // surface jacobian
   );
 
   inline static term<P> term0_dim0_ =

--- a/src/pde/pde_advection1.hpp
+++ b/src/pde/pde_advection1.hpp
@@ -139,11 +139,11 @@ private:
   }
 
   inline static const partial_term<P> partial_term_0 = partial_term<P>(
-      coefficient_type::div,       // type
-      g_func_0,                    // g func
-      nullptr, // lhs, null_gfunc = 1.0
-      flux_type::downwind, // flux = "-1" (downwind), "0" (central), "+1"
-                           // (upwind)
+      coefficient_type::div, // type
+      g_func_0,              // g func
+      nullptr,               // lhs, null_gfunc = 1.0
+      flux_type::downwind,   // flux = "-1" (downwind), "0" (central), "+1"
+                             // (upwind)
       boundary_condition::dirichlet, // left boundary condition type ("D", "N",
                                      // "P")
       boundary_condition::neumann,   // right boundary condition type,

--- a/src/pde/pde_advection1.hpp
+++ b/src/pde/pde_advection1.hpp
@@ -141,7 +141,7 @@ private:
   inline static const partial_term<P> partial_term_0 = partial_term<P>(
       coefficient_type::div, // type
       g_func_0,              // g func
-      nullptr,               // lhs, null_gfunc = 1.0
+      nullptr,               // lhs
       flux_type::downwind,   // flux = "-1" (downwind), "0" (central), "+1"
                              // (upwind)
       boundary_condition::dirichlet, // left boundary condition type ("D", "N",

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -106,11 +106,11 @@ template<typename P>
 class partial_term
 {
 public:
-  static double null_gfunc(double const x, double const t)
+  static P null_gfunc(P const x, P const t)
   {
     ignore(x);
     ignore(t);
-    return 1.0;
+    return P{1.0};
   }
 
   static P null_scalar_func(P const p) { return p; }
@@ -124,8 +124,8 @@ public:
   }
 
   partial_term(coefficient_type const coeff_type_in,
-               g_func_type<P> const g_func_in        = null_gfunc,
-               g_func_type<P> const lhs_mass_func_in = null_gfunc,
+               g_func_type<P> const g_func_in        = nullptr,
+               g_func_type<P> const lhs_mass_func_in = nullptr,
                flux_type const flux_in               = flux_type::central,
                boundary_condition const left_in  = boundary_condition::neumann,
                boundary_condition const right_in = boundary_condition::neumann,
@@ -135,7 +135,7 @@ public:
                scalar_func<P> const left_bc_time_func_in = null_scalar_func,
                std::vector<vector_func<P>> const right_bc_funcs_in = {},
                scalar_func<P> const right_bc_time_func_in = null_scalar_func,
-               g_func_type<P> const dv_func_in            = null_gfunc)
+               g_func_type<P> const dv_func_in            = nullptr)
 
       : coeff_type(coeff_type_in), g_func(g_func_in),
         lhs_mass_func(lhs_mass_func_in), flux(set_flux(flux_in)), left(left_in),

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -251,14 +251,6 @@ private:
 template<typename P>
 class term
 {
-  static P g_func_default(P const x, P const time)
-  {
-    // suppress compiler warnings
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
 public:
   term(bool const time_dependent_in, std::string const name_in,
        std::initializer_list<partial_term<P>> const partial_terms,

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -106,13 +106,6 @@ template<typename P>
 class partial_term
 {
 public:
-  static P null_gfunc(P const x, P const t)
-  {
-    ignore(x);
-    ignore(t);
-    return P{1.0};
-  }
-
   static P null_scalar_func(P const p) { return p; }
 
   static fk::vector<P> null_vector_func(fk::vector<P> x, P const t = 0)

--- a/src/pde/pde_continuity1.hpp
+++ b/src/pde/pde_continuity1.hpp
@@ -103,14 +103,6 @@ private:
     return fx;
   }
 
-  static P volume_jacobian_dV_dim0(P const x, P const time)
-  {
-    // suppress compiler warnings
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
   static P exact_time(P const time) { return std::sin(time); }
 
   // specify source functions...
@@ -156,28 +148,20 @@ private:
     return -1.0;
   }
 
-  static P lhs_mass_func(P const x, P const time)
-  {
-    // suppress compiler warnings
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
   // define dimensions
   inline static dimension<P> const dim0_ =
-      dimension<P>(-1.0,                    // domain min
-                   1.0,                     // domain max
-                   2,                       // levels
-                   2,                       // degree
-                   initial_condition_dim0,  // initial condition
-                   volume_jacobian_dV_dim0, // volume portion
-                   "x");                    // name
+      dimension<P>(-1.0,                   // domain min
+                   1.0,                    // domain max
+                   2,                      // levels
+                   2,                      // degree
+                   initial_condition_dim0, // initial condition
+                   nullptr,                // volume portion
+                   "x");                   // name
 
   inline static std::vector<dimension<P>> const dimensions_ = {dim0_};
 
   inline static const partial_term<P> partial_term_0 = partial_term<P>(
-      coefficient_type::div, g_func_0, lhs_mass_func, flux_type::downwind,
+      coefficient_type::div, g_func_0, nullptr, flux_type::downwind,
       boundary_condition::periodic, boundary_condition::periodic);
 
   // define terms (1 in this case)

--- a/src/pde/pde_continuity2.hpp
+++ b/src/pde/pde_continuity2.hpp
@@ -85,22 +85,6 @@ private:
     return fx;
   }
 
-  static P volume_jacobian_dV_dim0(P const x, P const time)
-  {
-    // suppress compiler warnings
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
-  static P volume_jacobian_dV_dim1(P const x, P const time)
-  {
-    // suppress compiler warnings
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
   static P exact_time(P const time) { return std::sin(2.0 * time); }
 
   // specify source functions...
@@ -180,15 +164,6 @@ private:
     return dx;
   }
 
-  // g-funcs for terms (optional)
-  static P g_func_identity(P const x, P const time)
-  {
-    // suppress compiler warnings
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
   static P g_func_t0_d0(P const x, P const time)
   {
     // suppress compiler warnings
@@ -207,29 +182,29 @@ private:
 
   // define dimensions
   inline static dimension<P> const dim0_ =
-      dimension<P>(-1.0,                    // domain min
-                   1.0,                     // domain max
-                   2,                       // levels
-                   2,                       // degree
-                   initial_condition_dim0,  // initial condition
-                   volume_jacobian_dV_dim0, // volume portion
-                   "x");                    // name
+      dimension<P>(-1.0,                   // domain min
+                   1.0,                    // domain max
+                   2,                      // levels
+                   2,                      // degree
+                   initial_condition_dim0, // initial condition
+                   nullptr,                // volume portion
+                   "x");                   // name
 
   inline static dimension<P> const dim1_ =
-      dimension<P>(-2.0,                    // domain min
-                   2.0,                     // domain max
-                   2,                       // levels
-                   2,                       // degree
-                   initial_condition_dim1,  // initial condition
-                   volume_jacobian_dV_dim1, // volume portion
-                   "y");                    // name
+      dimension<P>(-2.0,                   // domain min
+                   2.0,                    // domain max
+                   2,                      // levels
+                   2,                      // degree
+                   initial_condition_dim1, // initial condition
+                   nullptr,                // volume portion
+                   "y");                   // name
 
   inline static std::vector<dimension<P>> const dimensions_ = {dim0_, dim1_};
 
   // define terms
   // term 0
   inline static const partial_term<P> partial_term_t0_d0 = partial_term<P>(
-      coefficient_type::div, g_func_t0_d0, g_func_identity, flux_type::downwind,
+      coefficient_type::div, g_func_t0_d0, nullptr, flux_type::downwind,
       boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const term0_dim0_ = term<P>(false, // time-dependent
@@ -237,7 +212,7 @@ private:
                                                     {partial_term_t0_d0});
 
   inline static partial_term<P> const partial_term_t0_d1 =
-      partial_term<P>(coefficient_type::mass, g_func_identity, g_func_identity,
+      partial_term<P>(coefficient_type::mass, nullptr, nullptr,
                       flux_type::central, boundary_condition::periodic,
                       boundary_condition::periodic);
 
@@ -250,7 +225,7 @@ private:
   // term 1
   // NOTE: double check this mass term, as it is empty in the matlab version?
   inline static partial_term<P> const partial_term_t1_d0 =
-      partial_term<P>(coefficient_type::mass, g_func_identity, g_func_identity,
+      partial_term<P>(coefficient_type::mass, nullptr, nullptr,
                       flux_type::central, boundary_condition::periodic,
                       boundary_condition::periodic);
 
@@ -259,7 +234,7 @@ private:
                                                     {partial_term_t1_d0});
 
   inline static partial_term<P> const partial_term_t1_d1 = partial_term<P>(
-      coefficient_type::div, g_func_t1_d1, g_func_identity, flux_type::downwind,
+      coefficient_type::div, g_func_t1_d1, nullptr, flux_type::downwind,
       boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const term1_dim1_ = term<P>(false, // time-dependent

--- a/src/pde/pde_continuity2.hpp
+++ b/src/pde/pde_continuity2.hpp
@@ -211,10 +211,9 @@ private:
                                                     "v_x.d_dx", // name
                                                     {partial_term_t0_d0});
 
-  inline static partial_term<P> const partial_term_t0_d1 =
-      partial_term<P>(coefficient_type::mass, nullptr, nullptr,
-                      flux_type::central, boundary_condition::periodic,
-                      boundary_condition::periodic);
+  inline static partial_term<P> const partial_term_t0_d1 = partial_term<P>(
+      coefficient_type::mass, nullptr, nullptr, flux_type::central,
+      boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const term0_dim1_ = term<P>(false,   // time-dependent
                                                     "massY", // name
@@ -224,10 +223,9 @@ private:
 
   // term 1
   // NOTE: double check this mass term, as it is empty in the matlab version?
-  inline static partial_term<P> const partial_term_t1_d0 =
-      partial_term<P>(coefficient_type::mass, nullptr, nullptr,
-                      flux_type::central, boundary_condition::periodic,
-                      boundary_condition::periodic);
+  inline static partial_term<P> const partial_term_t1_d0 = partial_term<P>(
+      coefficient_type::mass, nullptr, nullptr, flux_type::central,
+      boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const term1_dim0_ = term<P>(false,   // time-dependent
                                                     "massX", // name

--- a/src/pde/pde_continuity3.hpp
+++ b/src/pde/pde_continuity3.hpp
@@ -288,10 +288,9 @@ private:
   // define terms
 
   // default mass matrix (only for lev_x=lev_y=etc)
-  inline static partial_term<P> const partial_term_I_ =
-      partial_term<P>(coefficient_type::mass, nullptr, nullptr,
-                      flux_type::central, boundary_condition::periodic,
-                      boundary_condition::periodic);
+  inline static partial_term<P> const partial_term_I_ = partial_term<P>(
+      coefficient_type::mass, nullptr, nullptr, flux_type::central,
+      boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const I_ = term<P>(false,  // time-dependent
                                            "mass", // name

--- a/src/pde/pde_continuity3.hpp
+++ b/src/pde/pde_continuity3.hpp
@@ -95,14 +95,6 @@ private:
     return fx;
   }
 
-  static P volume_jacobian_dV(P const x, P const time)
-  {
-    // suppress compiler warnings
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
   static P exact_time(P const time) { return std::sin(2.0 * time); }
 
   // specify source functions...
@@ -240,15 +232,6 @@ private:
     return dt;
   }
 
-  // g-funcs for terms (optional)
-  static P g_func_identity(P const x, P const time)
-  {
-    // suppress compiler warnings
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
   static P g_func_t0_d0(P const x, P const time)
   {
     // suppress compiler warnings
@@ -278,7 +261,7 @@ private:
                    2,                      // levels
                    5,                      // degree
                    initial_condition_dim0, // initial condition
-                   volume_jacobian_dV,
+                   nullptr,
                    "x"); // name
 
   inline static dimension<P> const dim1_ =
@@ -287,7 +270,7 @@ private:
                    2,                      // levels
                    4,                      // degree
                    initial_condition_dim1, // initial condition
-                   volume_jacobian_dV,
+                   nullptr,
                    "y"); // name
 
   inline static dimension<P> const dim2_ =
@@ -296,7 +279,7 @@ private:
                    2,                      // levels
                    3,                      // degree
                    initial_condition_dim2, // initial condition
-                   volume_jacobian_dV,
+                   nullptr,
                    "z"); // name
 
   inline static std::vector<dimension<P>> const dimensions_ = {dim0_, dim1_,
@@ -306,7 +289,7 @@ private:
 
   // default mass matrix (only for lev_x=lev_y=etc)
   inline static partial_term<P> const partial_term_I_ =
-      partial_term<P>(coefficient_type::mass, g_func_identity, g_func_identity,
+      partial_term<P>(coefficient_type::mass, nullptr, nullptr,
                       flux_type::central, boundary_condition::periodic,
                       boundary_condition::periodic);
 
@@ -316,7 +299,7 @@ private:
 
   // term 0
   inline static partial_term<P> const partial_term_t0_d0 = partial_term<P>(
-      coefficient_type::div, g_func_t0_d0, g_func_identity, flux_type::downwind,
+      coefficient_type::div, g_func_t0_d0, nullptr, flux_type::downwind,
       boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const term0_dim0_ = term<P>(false, // time-dependent
@@ -327,7 +310,7 @@ private:
 
   // term 1
   inline static partial_term<P> const partial_term_t1_d1 = partial_term<P>(
-      coefficient_type::div, g_func_t1_d1, g_func_identity, flux_type::downwind,
+      coefficient_type::div, g_func_t1_d1, nullptr, flux_type::downwind,
       boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const term1_dim1_ = term<P>(false, // time-dependent
@@ -338,7 +321,7 @@ private:
 
   // term 2
   inline static partial_term<P> const partial_term_t2_d2 = partial_term<P>(
-      coefficient_type::div, g_func_t2_d2, g_func_identity, flux_type::downwind,
+      coefficient_type::div, g_func_t2_d2, nullptr, flux_type::downwind,
       boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const term2_dim2_ = term<P>(false, // time-dependent

--- a/src/pde/pde_continuity6.hpp
+++ b/src/pde/pde_continuity6.hpp
@@ -716,10 +716,9 @@ private:
   static P constexpr az = 2;
 
   // default mass matrix (only for lev_x=lev_y=etc)
-  inline static partial_term<P> const partial_term_I_ =
-      partial_term<P>(coefficient_type::mass, nullptr, nullptr,
-                      flux_type::central, boundary_condition::periodic,
-                      boundary_condition::periodic);
+  inline static partial_term<P> const partial_term_I_ = partial_term<P>(
+      coefficient_type::mass, nullptr, nullptr, flux_type::central,
+      boundary_condition::periodic, boundary_condition::periodic);
   inline static term<P> const I_ = term<P>(false,   // time-dependent
                                            "massY", // name
                                            {partial_term_I_});

--- a/src/pde/pde_continuity6.hpp
+++ b/src/pde/pde_continuity6.hpp
@@ -125,14 +125,6 @@ private:
     return fx;
   }
 
-  static P volume_jacobian_dV(P const x, P const time)
-  {
-    // suppress compiler warnings
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
   static P exact_time(P const time) { return std::sin(targ * time); }
 
   // define exact soln
@@ -620,13 +612,6 @@ private:
 
   // g-funcs for terms (optional)
 
-  static P g_func_identity(P const x, P const time)
-  {
-    // suppress compiler warnings
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
   static P gx(P const x, P const time)
   {
     // suppress compiler warnings
@@ -676,7 +661,7 @@ private:
                                                      2,    // levels
                                                      2,    // degree
                                                      f0,   // initial condition
-                                                     volume_jacobian_dV,
+                                                     nullptr,
                                                      "x"); // name
 
   inline static dimension<P> const y_ = dimension<P>(-2.0, // domain min
@@ -684,7 +669,7 @@ private:
                                                      2,    // levels
                                                      2,    // degree
                                                      f0,   // initial condition
-                                                     volume_jacobian_dV,
+                                                     nullptr,
                                                      "y"); // name
 
   inline static dimension<P> const z_ = dimension<P>(-3.0, // domain min
@@ -692,7 +677,7 @@ private:
                                                      2,    // levels
                                                      2,    // degree
                                                      f0,   // initial condition
-                                                     volume_jacobian_dV,
+                                                     nullptr,
                                                      "z"); // name
 
   inline static dimension<P> const vx_ = dimension<P>(-10.0, // domain min
@@ -700,7 +685,7 @@ private:
                                                       2,     // levels
                                                       2,     // degree
                                                       f0, // initial condition
-                                                      volume_jacobian_dV,
+                                                      nullptr,
                                                       "vx"); // name
 
   inline static dimension<P> const vy_ = dimension<P>(-20.0, // domain min
@@ -708,7 +693,7 @@ private:
                                                       2,     // levels
                                                       2,     // degree
                                                       f0, // initial condition
-                                                      volume_jacobian_dV,
+                                                      nullptr,
                                                       "vy"); // name
 
   inline static dimension<P> const vz_ = dimension<P>(-30.0, // domain min
@@ -716,7 +701,7 @@ private:
                                                       2,     // levels
                                                       2,     // degree
                                                       f0, // initial condition
-                                                      volume_jacobian_dV,
+                                                      nullptr,
                                                       "z"); // name
 
   inline static std::vector<dimension<P>> const dimensions_ = {x_,  y_,  z_,
@@ -732,7 +717,7 @@ private:
 
   // default mass matrix (only for lev_x=lev_y=etc)
   inline static partial_term<P> const partial_term_I_ =
-      partial_term<P>(coefficient_type::mass, g_func_identity, g_func_identity,
+      partial_term<P>(coefficient_type::mass, nullptr, nullptr,
                       flux_type::central, boundary_condition::periodic,
                       boundary_condition::periodic);
   inline static term<P> const I_ = term<P>(false,   // time-dependent
@@ -741,7 +726,7 @@ private:
 
   // term 0
   inline static partial_term<P> const partial_term_0_x_ = partial_term<P>(
-      coefficient_type::div, gx, g_func_identity, flux_type::downwind,
+      coefficient_type::div, gx, nullptr, flux_type::downwind,
       boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const term0_x_ = term<P>(false,      // time-dependent
@@ -751,7 +736,7 @@ private:
                                                       I_,       I_, I_};
   // term 1
   inline static partial_term<P> const partial_term_1_y_ = partial_term<P>(
-      coefficient_type::div, gy, g_func_identity, flux_type::downwind,
+      coefficient_type::div, gy, nullptr, flux_type::downwind,
       boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const term1_y_ = term<P>(false,      // time-dependent
@@ -761,7 +746,7 @@ private:
                                                       I_, I_,       I_};
   // term 2
   inline static partial_term<P> const partial_term_2_z_ = partial_term<P>(
-      coefficient_type::div, gz, g_func_identity, flux_type::downwind,
+      coefficient_type::div, gz, nullptr, flux_type::downwind,
       boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const term2_z_ = term<P>(false,      // time-dependent
@@ -772,7 +757,7 @@ private:
                                                       I_, I_, I_};
   // term 3
   inline static partial_term<P> const partial_term_3_vx_ = partial_term<P>(
-      coefficient_type::div, gvx, g_func_identity, flux_type::downwind,
+      coefficient_type::div, gvx, nullptr, flux_type::downwind,
       boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const term3_vx_ = term<P>(false,       // time-dependent
@@ -783,7 +768,7 @@ private:
                                                       term3_vx_, I_, I_};
   // term 4
   inline static partial_term<P> const partial_term_4_vy_ = partial_term<P>(
-      coefficient_type::div, gvy, g_func_identity, flux_type::downwind,
+      coefficient_type::div, gvy, nullptr, flux_type::downwind,
       boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const term4_vy_ = term<P>(false,       // time-dependent
@@ -794,7 +779,7 @@ private:
                                                       I_, term4_vy_, I_};
   // term 5
   inline static partial_term<P> const partial_term_5_vz_ = partial_term<P>(
-      coefficient_type::div, gvz, g_func_identity, flux_type::downwind,
+      coefficient_type::div, gvz, nullptr, flux_type::downwind,
       boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const term5_vz_ = term<P>(false,       // time-dependent

--- a/src/pde/pde_diffusion1.hpp
+++ b/src/pde/pde_diffusion1.hpp
@@ -47,10 +47,9 @@ private:
   inline static std::vector<dimension<P>> const dimensions_ = {dim_0};
 
   /* Define terms */
-  inline static const partial_term<P> partial_term_0 =
-      partial_term<P>(coefficient_type::div, nullptr,
-                      nullptr, flux_type::downwind,
-                      boundary_condition::neumann, boundary_condition::neumann);
+  inline static const partial_term<P> partial_term_0 = partial_term<P>(
+      coefficient_type::div, nullptr, nullptr, flux_type::downwind,
+      boundary_condition::neumann, boundary_condition::neumann);
 
   static fk::vector<P> bc_func(fk::vector<P> const x, P const t)
   {
@@ -73,11 +72,10 @@ private:
   // TODO: Add interior penalty terms?
   // TODO: update nu value, check initial conditions
   inline static const partial_term<P> partial_term_1 = partial_term<P>(
-      coefficient_type::grad, nullptr, nullptr,
-      flux_type::upwind, boundary_condition::dirichlet,
-      boundary_condition::dirichlet, homogeneity::inhomogeneous,
-      homogeneity::inhomogeneous, {bc_func}, bc_time_func, {bc_func},
-      bc_time_func);
+      coefficient_type::grad, nullptr, nullptr, flux_type::upwind,
+      boundary_condition::dirichlet, boundary_condition::dirichlet,
+      homogeneity::inhomogeneous, homogeneity::inhomogeneous, {bc_func},
+      bc_time_func, {bc_func}, bc_time_func);
 
   inline static term<P> const term_0 =
       term<P>(true, // time-dependent
@@ -101,22 +99,22 @@ private:
     return penalty;
   }
   inline static const partial_term<P> partial_term_2 = partial_term<P>(
-      coefficient_type::div, g3, nullptr,
-      flux_type::downwind, boundary_condition::dirichlet,
-      boundary_condition::dirichlet, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, nullptr);
+      coefficient_type::div, g3, nullptr, flux_type::downwind,
+      boundary_condition::dirichlet, boundary_condition::dirichlet,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
+      nullptr);
 
   inline static term<P> const term_1 = term<P>(false, // time-dependent
                                                "",    // name
                                                {partial_term_2});
 
   inline static const partial_term<P> partial_term_3 = partial_term<P>(
-      coefficient_type::div, g4, nullptr,
-      flux_type::central, boundary_condition::dirichlet,
-      boundary_condition::dirichlet, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, nullptr);
+      coefficient_type::div, g4, nullptr, flux_type::central,
+      boundary_condition::dirichlet, boundary_condition::dirichlet,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
+      nullptr);
 
   inline static term<P> const term_2 = term<P>(false, // time-dependent
                                                "",    // name

--- a/src/pde/pde_diffusion1.hpp
+++ b/src/pde/pde_diffusion1.hpp
@@ -40,24 +40,16 @@ private:
     return fx;
   }
 
-  static P volume_jacobian_dV(P const x, P const time)
-  {
-    // suppress compiler warnings
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
   /* Define the dimension */
   inline static dimension<P> const dim_0 =
-      dimension<P>(0, 1, 3, 2, initial_condition_dim0, volume_jacobian_dV, "x");
+      dimension<P>(0, 1, 3, 2, initial_condition_dim0, nullptr, "x");
 
   inline static std::vector<dimension<P>> const dimensions_ = {dim_0};
 
   /* Define terms */
   inline static const partial_term<P> partial_term_0 =
-      partial_term<P>(coefficient_type::div, partial_term<P>::null_gfunc,
-                      partial_term<P>::null_gfunc, flux_type::downwind,
+      partial_term<P>(coefficient_type::div, nullptr,
+                      nullptr, flux_type::downwind,
                       boundary_condition::neumann, boundary_condition::neumann);
 
   static fk::vector<P> bc_func(fk::vector<P> const x, P const t)
@@ -81,11 +73,11 @@ private:
   // TODO: Add interior penalty terms?
   // TODO: update nu value, check initial conditions
   inline static const partial_term<P> partial_term_1 = partial_term<P>(
-      coefficient_type::grad, partial_term<P>::null_gfunc,
-      partial_term<P>::null_gfunc, flux_type::upwind,
-      boundary_condition::dirichlet, boundary_condition::dirichlet,
-      homogeneity::inhomogeneous, homogeneity::inhomogeneous, {bc_func},
-      bc_time_func, {bc_func}, bc_time_func);
+      coefficient_type::grad, nullptr, nullptr,
+      flux_type::upwind, boundary_condition::dirichlet,
+      boundary_condition::dirichlet, homogeneity::inhomogeneous,
+      homogeneity::inhomogeneous, {bc_func}, bc_time_func, {bc_func},
+      bc_time_func);
 
   inline static term<P> const term_0 =
       term<P>(true, // time-dependent
@@ -109,22 +101,22 @@ private:
     return penalty;
   }
   inline static const partial_term<P> partial_term_2 = partial_term<P>(
-      coefficient_type::div, g3, partial_term<P>::null_gfunc,
+      coefficient_type::div, g3, nullptr,
       flux_type::downwind, boundary_condition::dirichlet,
       boundary_condition::dirichlet, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, volume_jacobian_dV);
+      partial_term<P>::null_scalar_func, nullptr);
 
   inline static term<P> const term_1 = term<P>(false, // time-dependent
                                                "",    // name
                                                {partial_term_2});
 
   inline static const partial_term<P> partial_term_3 = partial_term<P>(
-      coefficient_type::div, g4, partial_term<P>::null_gfunc,
+      coefficient_type::div, g4, nullptr,
       flux_type::central, boundary_condition::dirichlet,
       boundary_condition::dirichlet, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, volume_jacobian_dV);
+      partial_term<P>::null_scalar_func, nullptr);
 
   inline static term<P> const term_2 = term<P>(false, // time-dependent
                                                "",    // name

--- a/src/pde/pde_diffusion2.hpp
+++ b/src/pde/pde_diffusion2.hpp
@@ -57,14 +57,12 @@ private:
 
   /* build the terms */
   inline static partial_term<P> const partial_term_I_ = partial_term<P>(
-      coefficient_type::mass, nullptr, nullptr,
-      flux_type::central, boundary_condition::periodic,
-      boundary_condition::periodic);
+      coefficient_type::mass, nullptr, nullptr, flux_type::central,
+      boundary_condition::periodic, boundary_condition::periodic);
 
-  inline static const partial_term<P> partial_term_0 =
-      partial_term<P>(coefficient_type::div, nullptr,
-                      nullptr, flux_type::upwind,
-                      boundary_condition::neumann, boundary_condition::neumann);
+  inline static const partial_term<P> partial_term_0 = partial_term<P>(
+      coefficient_type::div, nullptr, nullptr, flux_type::upwind,
+      boundary_condition::neumann, boundary_condition::neumann);
 
   static fk::vector<P> bc_func(fk::vector<P> const x, P const t)
   {
@@ -84,11 +82,10 @@ private:
   }
 
   inline static const partial_term<P> partial_term_1 = partial_term<P>(
-      coefficient_type::grad, nullptr, nullptr,
-      flux_type::downwind, boundary_condition::dirichlet,
-      boundary_condition::dirichlet, homogeneity::inhomogeneous,
-      homogeneity::inhomogeneous, {bc_func, bc_func}, bc_time_func,
-      {bc_func, bc_func}, bc_time_func);
+      coefficient_type::grad, nullptr, nullptr, flux_type::downwind,
+      boundary_condition::dirichlet, boundary_condition::dirichlet,
+      homogeneity::inhomogeneous, homogeneity::inhomogeneous,
+      {bc_func, bc_func}, bc_time_func, {bc_func, bc_func}, bc_time_func);
 
   inline static term<P> const term_0 =
       term<P>(false, // time-dependent

--- a/src/pde/pde_diffusion2.hpp
+++ b/src/pde/pde_diffusion2.hpp
@@ -44,40 +44,31 @@ private:
     return fx;
   }
 
-  static P volume_jacobian_dV(P const x, P const time)
-  {
-    // suppress compiler warnings
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
   /* Define the dimension */
   inline static dimension<P> const dim_0 =
       dimension<P>(domain_min, domain_max, default_level, default_degree,
-                   initial_condition_dim, volume_jacobian_dV, "x");
+                   initial_condition_dim, nullptr, "x");
 
   inline static dimension<P> const dim_1 =
       dimension<P>(domain_min, domain_max, default_level, default_degree,
-                   initial_condition_dim, volume_jacobian_dV, "y");
+                   initial_condition_dim, nullptr, "y");
 
   inline static std::vector<dimension<P>> const dimensions_ = {dim_0, dim_1};
 
   /* build the terms */
   inline static partial_term<P> const partial_term_I_ = partial_term<P>(
-      coefficient_type::mass, partial_term<P>::null_gfunc,
-      partial_term<P>::null_gfunc, flux_type::central,
-      boundary_condition::periodic, boundary_condition::periodic);
+      coefficient_type::mass, nullptr, nullptr,
+      flux_type::central, boundary_condition::periodic,
+      boundary_condition::periodic);
 
   inline static const partial_term<P> partial_term_0 =
-      partial_term<P>(coefficient_type::div, partial_term<P>::null_gfunc,
-                      partial_term<P>::null_gfunc, flux_type::upwind,
+      partial_term<P>(coefficient_type::div, nullptr,
+                      nullptr, flux_type::upwind,
                       boundary_condition::neumann, boundary_condition::neumann);
 
   static fk::vector<P> bc_func(fk::vector<P> const x, P const t)
   {
     ignore(t);
-
     fk::vector<P> fx(x.size());
     std::transform(x.begin(), x.end(), fx.begin(),
                    [](P const x_value) -> P { return std::cos(PI * x_value); });
@@ -93,12 +84,11 @@ private:
   }
 
   inline static const partial_term<P> partial_term_1 = partial_term<P>(
-      coefficient_type::grad, partial_term<P>::null_gfunc,
-      partial_term<P>::null_gfunc, flux_type::downwind,
-      boundary_condition::dirichlet, boundary_condition::dirichlet,
-      homogeneity::inhomogeneous, homogeneity::inhomogeneous,
-      {bc_func, bc_func}, bc_time_func, {bc_func, bc_func}, bc_time_func,
-      partial_term<P>::null_gfunc);
+      coefficient_type::grad, nullptr, nullptr,
+      flux_type::downwind, boundary_condition::dirichlet,
+      boundary_condition::dirichlet, homogeneity::inhomogeneous,
+      homogeneity::inhomogeneous, {bc_func, bc_func}, bc_time_func,
+      {bc_func, bc_func}, bc_time_func);
 
   inline static term<P> const term_0 =
       term<P>(false, // time-dependent

--- a/src/pde/pde_fokkerplanck1_4p3.hpp
+++ b/src/pde/pde_fokkerplanck1_4p3.hpp
@@ -91,14 +91,6 @@ private:
     return 1.0;
   }
 
-  static P volume_jacobian_dV(P const x, P const time)
-  {
-    // suppress compiler warnings
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
   // specify source functions...
 
   // N/A
@@ -122,7 +114,7 @@ private:
                    2,                      // levels
                    2,                      // degree
                    initial_condition_dim0, // initial condition
-                   volume_jacobian_dV,
+                   nullptr,
                    "x"); // name
 
   inline static std::vector<dimension<P>> const dimensions_ = {dim0_};
@@ -145,7 +137,7 @@ private:
   }
 
   inline static partial_term<P> const partial_term_0 = partial_term<P>(
-      coefficient_type::div, g_func_1, partial_term<P>::null_gfunc,
+      coefficient_type::div, g_func_1, nullptr,
       flux_type::downwind, boundary_condition::dirichlet,
       boundary_condition::dirichlet, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},

--- a/src/pde/pde_fokkerplanck1_4p3.hpp
+++ b/src/pde/pde_fokkerplanck1_4p3.hpp
@@ -137,11 +137,11 @@ private:
   }
 
   inline static partial_term<P> const partial_term_0 = partial_term<P>(
-      coefficient_type::div, g_func_1, nullptr,
-      flux_type::downwind, boundary_condition::dirichlet,
-      boundary_condition::dirichlet, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_func);
+      coefficient_type::div, g_func_1, nullptr, flux_type::downwind,
+      boundary_condition::dirichlet, boundary_condition::dirichlet,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
+      dV_func);
 
   inline static term<P> const term0_dim0_ = term<P>(false,  // time-dependent
                                                     "d_dx", // name

--- a/src/pde/pde_fokkerplanck1_4p4.hpp
+++ b/src/pde/pde_fokkerplanck1_4p4.hpp
@@ -104,14 +104,6 @@ private:
     return 1.0;
   }
 
-  static P volume_jacobian_dV(P const x, P const time)
-  {
-    // suppress compiler warnings
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
   // specify source functions...
 
   // N/A
@@ -165,7 +157,7 @@ private:
                    2,      // levels
                    2,      // degree
                    f0_vec, // initial condition
-                   volume_jacobian_dV,
+                   nullptr,
                    "x"); // name
 
   inline static std::vector<dimension<P>> const dimensions_ = {dim0_};
@@ -177,7 +169,7 @@ private:
   // -E d/dz((1-z^2) f)
 
   inline static partial_term<P> const partial_term_0 = partial_term<P>(
-      coefficient_type::div, g_func_t1_z, partial_term<P>::null_gfunc,
+      coefficient_type::div, g_func_t1_z, nullptr,
       flux_type::downwind, boundary_condition::dirichlet,
       boundary_condition::dirichlet, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
@@ -193,20 +185,18 @@ private:
   //
   // +C * d/dz( (1-z^2) df/dz )
   inline static partial_term<P> const partial_term_1 = partial_term<P>(
-      coefficient_type::div, partial_term<P>::null_gfunc,
-      partial_term<P>::null_gfunc, flux_type::downwind,
-      boundary_condition::dirichlet, boundary_condition::dirichlet,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
-      dV_z);
+      coefficient_type::div, nullptr, nullptr,
+      flux_type::downwind, boundary_condition::dirichlet,
+      boundary_condition::dirichlet, homogeneity::homogeneous,
+      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
+      partial_term<P>::null_scalar_func, dV_z);
 
-  inline static partial_term<P> const partial_term_2 =
-      partial_term<P>(coefficient_type::grad, partial_term<P>::null_gfunc,
-                      partial_term<P>::null_gfunc, flux_type::upwind,
-                      boundary_condition::neumann, boundary_condition::neumann,
-                      homogeneity::homogeneous, homogeneity::homogeneous, {},
-                      partial_term<P>::null_scalar_func, {},
-                      partial_term<P>::null_scalar_func, dV_z);
+  inline static partial_term<P> const partial_term_2 = partial_term<P>(
+      coefficient_type::grad, nullptr, nullptr,
+      flux_type::upwind, boundary_condition::neumann,
+      boundary_condition::neumann, homogeneity::homogeneous,
+      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
+      partial_term<P>::null_scalar_func, dV_z);
 
   inline static term<P> const termC_z =
       term<P>(false,  // time-dependent

--- a/src/pde/pde_fokkerplanck1_4p4.hpp
+++ b/src/pde/pde_fokkerplanck1_4p4.hpp
@@ -137,12 +137,6 @@ private:
     ignore(time);
     return 1 - std::pow(x, 2);
   }
-  static P g_func_t2_z2(P const x, P const time)
-  {
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
 
   static P dV_z(P const x, P const time)
   {
@@ -169,11 +163,11 @@ private:
   // -E d/dz((1-z^2) f)
 
   inline static partial_term<P> const partial_term_0 = partial_term<P>(
-      coefficient_type::div, g_func_t1_z, nullptr,
-      flux_type::downwind, boundary_condition::dirichlet,
-      boundary_condition::dirichlet, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_z);
+      coefficient_type::div, g_func_t1_z, nullptr, flux_type::downwind,
+      boundary_condition::dirichlet, boundary_condition::dirichlet,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
+      dV_z);
 
   inline static term<P> const termE_z = term<P>(false,  // time-dependent
                                                 "d_dx", // name
@@ -185,18 +179,18 @@ private:
   //
   // +C * d/dz( (1-z^2) df/dz )
   inline static partial_term<P> const partial_term_1 = partial_term<P>(
-      coefficient_type::div, nullptr, nullptr,
-      flux_type::downwind, boundary_condition::dirichlet,
-      boundary_condition::dirichlet, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_z);
+      coefficient_type::div, nullptr, nullptr, flux_type::downwind,
+      boundary_condition::dirichlet, boundary_condition::dirichlet,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
+      dV_z);
 
   inline static partial_term<P> const partial_term_2 = partial_term<P>(
-      coefficient_type::grad, nullptr, nullptr,
-      flux_type::upwind, boundary_condition::neumann,
-      boundary_condition::neumann, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_z);
+      coefficient_type::grad, nullptr, nullptr, flux_type::upwind,
+      boundary_condition::neumann, boundary_condition::neumann,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
+      dV_z);
 
   inline static term<P> const termC_z =
       term<P>(false,  // time-dependent

--- a/src/pde/pde_fokkerplanck1_4p5.hpp
+++ b/src/pde/pde_fokkerplanck1_4p5.hpp
@@ -107,14 +107,6 @@ private:
     return 1.0;
   }
 
-  static P volume_jacobian_dV(P const x, P const time)
-  {
-    // suppress compiler warnings
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
   // specify source functions...
 
   // N/A
@@ -138,7 +130,7 @@ private:
                    2,      // levels
                    2,      // degree
                    f0_vec, // initial condition
-                   volume_jacobian_dV,
+                   nullptr,
                    "x"); // name
 
   inline static std::vector<dimension<P>> const dimensions_ = {dim0_};
@@ -162,11 +154,11 @@ private:
   }
 
   inline static partial_term<P> const partial_term_0 = partial_term<P>(
-      coefficient_type::div, g_func_t1_z, partial_term<P>::null_gfunc,
-      flux_type::downwind, boundary_condition::dirichlet,
-      boundary_condition::dirichlet, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_z);
+      coefficient_type::div, g_func_t1_z, nullptr, flux_type::downwind,
+      boundary_condition::dirichlet, boundary_condition::dirichlet,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
+      dV_z);
 
   inline static term<P> const termE_z = term<P>(false,  // time-dependent
                                                 "d_dx", // name
@@ -197,14 +189,14 @@ private:
   }
 
   inline static partial_term<P> const partial_term_1 = partial_term<P>(
-      coefficient_type::div, g_func_t2_z2, partial_term<P>::null_gfunc,
+      coefficient_type::div, g_func_t2_z2, nullptr,
       flux_type::downwind, boundary_condition::dirichlet,
       boundary_condition::dirichlet, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
       partial_term<P>::null_scalar_func, dV_z);
 
   inline static partial_term<P> const partial_term_2 = partial_term<P>(
-      coefficient_type::grad, g_func_t2_z2, partial_term<P>::null_gfunc,
+      coefficient_type::grad, g_func_t2_z2, nullptr,
       flux_type::upwind, boundary_condition::neumann,
       boundary_condition::neumann, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
@@ -228,7 +220,7 @@ private:
   }
 
   inline static partial_term<P> const partial_term_3 = partial_term<P>(
-      coefficient_type::div, g_func_t3_z, partial_term<P>::null_gfunc,
+      coefficient_type::div, g_func_t3_z, nullptr,
       flux_type::downwind, boundary_condition::dirichlet,
       boundary_condition::dirichlet, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},

--- a/src/pde/pde_fokkerplanck1_4p5.hpp
+++ b/src/pde/pde_fokkerplanck1_4p5.hpp
@@ -181,26 +181,20 @@ private:
     ignore(time);
     return 1 - std::pow(x, 2);
   }
-  static P g_func_t2_z2(P const x, P const time)
-  {
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
 
   inline static partial_term<P> const partial_term_1 = partial_term<P>(
-      coefficient_type::div, g_func_t2_z2, nullptr,
-      flux_type::downwind, boundary_condition::dirichlet,
-      boundary_condition::dirichlet, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_z);
+      coefficient_type::div, nullptr, nullptr, flux_type::downwind,
+      boundary_condition::dirichlet, boundary_condition::dirichlet,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
+      dV_z);
 
   inline static partial_term<P> const partial_term_2 = partial_term<P>(
-      coefficient_type::grad, g_func_t2_z2, nullptr,
-      flux_type::upwind, boundary_condition::neumann,
-      boundary_condition::neumann, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_z);
+      coefficient_type::grad, nullptr, nullptr, flux_type::upwind,
+      boundary_condition::neumann, boundary_condition::neumann,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
+      dV_z);
 
   inline static term<P> const termC_z =
       term<P>(false,  // time-dependent
@@ -220,11 +214,11 @@ private:
   }
 
   inline static partial_term<P> const partial_term_3 = partial_term<P>(
-      coefficient_type::div, g_func_t3_z, nullptr,
-      flux_type::downwind, boundary_condition::dirichlet,
-      boundary_condition::dirichlet, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_z);
+      coefficient_type::div, g_func_t3_z, nullptr, flux_type::downwind,
+      boundary_condition::dirichlet, boundary_condition::dirichlet,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
+      dV_z);
 
   inline static term<P> const termR_z = term<P>(false,  // time-dependent
                                                 "d_dx", // name

--- a/src/pde/pde_fokkerplanck1_pitch_C.hpp
+++ b/src/pde/pde_fokkerplanck1_pitch_C.hpp
@@ -167,18 +167,18 @@ private:
   //    termC_z.BCR2 = 'N';
 
   inline static partial_term<P> const partial_term_0 = partial_term<P>(
-      coefficient_type::div, g_func_2, nullptr,
-      flux_type::downwind, boundary_condition::dirichlet,
-      boundary_condition::dirichlet, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_z);
+      coefficient_type::div, g_func_2, nullptr, flux_type::downwind,
+      boundary_condition::dirichlet, boundary_condition::dirichlet,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
+      dV_z);
 
   inline static partial_term<P> const partial_term_1 = partial_term<P>(
-      coefficient_type::grad, g_func_2, nullptr,
-      flux_type::upwind, boundary_condition::neumann,
-      boundary_condition::neumann, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_z);
+      coefficient_type::grad, g_func_2, nullptr, flux_type::upwind,
+      boundary_condition::neumann, boundary_condition::neumann,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
+      dV_z);
 
   inline static term<P> const term0_dim0_ =
       term<P>(false,  // time-dependent

--- a/src/pde/pde_fokkerplanck1_pitch_C.hpp
+++ b/src/pde/pde_fokkerplanck1_pitch_C.hpp
@@ -95,14 +95,6 @@ private:
     return 1.0;
   }
 
-  static P volume_jacobian_dV(P const x, P const time)
-  {
-    // suppress compiler warnings
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
   // specify source functions...
 
   // N/A
@@ -154,7 +146,7 @@ private:
                    2,                      // levels
                    2,                      // degree
                    initial_condition_dim0, // initial condition
-                   volume_jacobian_dV,
+                   nullptr,
                    "x"); // name
 
   inline static std::vector<dimension<P>> const dimensions_ = {dim0_};
@@ -175,14 +167,14 @@ private:
   //    termC_z.BCR2 = 'N';
 
   inline static partial_term<P> const partial_term_0 = partial_term<P>(
-      coefficient_type::div, g_func_2, partial_term<P>::null_gfunc,
+      coefficient_type::div, g_func_2, nullptr,
       flux_type::downwind, boundary_condition::dirichlet,
       boundary_condition::dirichlet, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
       partial_term<P>::null_scalar_func, dV_z);
 
   inline static partial_term<P> const partial_term_1 = partial_term<P>(
-      coefficient_type::grad, g_func_2, partial_term<P>::null_gfunc,
+      coefficient_type::grad, g_func_2, nullptr,
       flux_type::upwind, boundary_condition::neumann,
       boundary_condition::neumann, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},

--- a/src/pde/pde_fokkerplanck1_pitch_E.hpp
+++ b/src/pde/pde_fokkerplanck1_pitch_E.hpp
@@ -102,14 +102,6 @@ private:
     return 1.0;
   }
 
-  static P volume_jacobian_dV(P const x, P const time)
-  {
-    // suppress compiler warnings
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
   // specify source functions...
 
   // N/A
@@ -161,7 +153,7 @@ private:
                    2,                      // levels
                    2,                      // degree
                    initial_condition_dim0, // initial condition
-                   volume_jacobian_dV,
+                   nullptr,
                    "x"); // name
 
   inline static std::vector<dimension<P>> const dimensions_ = {dim0_};
@@ -175,7 +167,7 @@ private:
   // construction. term2_z.LF = -1; % Upwind term2_z.name = 'd_dz';
 
   inline static partial_term<P> const partial_term_0 = partial_term<P>(
-      coefficient_type::div, g_func_1, partial_term<P>::null_gfunc,
+      coefficient_type::div, g_func_1, nullptr,
       flux_type::downwind, boundary_condition::neumann,
       boundary_condition::neumann, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},

--- a/src/pde/pde_fokkerplanck1_pitch_E.hpp
+++ b/src/pde/pde_fokkerplanck1_pitch_E.hpp
@@ -167,11 +167,11 @@ private:
   // construction. term2_z.LF = -1; % Upwind term2_z.name = 'd_dz';
 
   inline static partial_term<P> const partial_term_0 = partial_term<P>(
-      coefficient_type::div, g_func_1, nullptr,
-      flux_type::downwind, boundary_condition::neumann,
-      boundary_condition::neumann, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_z);
+      coefficient_type::div, g_func_1, nullptr, flux_type::downwind,
+      boundary_condition::neumann, boundary_condition::neumann,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
+      dV_z);
 
   inline static term<P> const term0_dim0_ = term<P>(false,  // time-dependent
                                                     "d_dx", // name

--- a/src/pde/pde_fokkerplanck2_complete.hpp
+++ b/src/pde/pde_fokkerplanck2_complete.hpp
@@ -272,14 +272,6 @@ private:
     return std::pow(x, 2);
   }
 
-  static P volume_jacobian_dV_z(P const x, P const time)
-  {
-    // suppress compiler warnings
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
   // initial conditionn in z
   static fk::vector<P>
   initial_condition_z_case1(fk::vector<P> const x, P const t = 0)
@@ -377,7 +369,7 @@ private:
                    2,                   // levels
                    2,                   // degree
                    initial_condition_z, // initial condition
-                   volume_jacobian_dV_z,
+                   nullptr,
                    "z"); // name
 
   // assemble dimensions
@@ -412,13 +404,6 @@ private:
     return x;
   }
 
-  static P dV_z(P const x, P const time)
-  {
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
   static P dV_z3(P const x, P const time)
   {
     ignore(time);
@@ -450,23 +435,23 @@ private:
 
   // 1. create partial_terms
   inline static partial_term<P> const c1_pterm1 = partial_term<P>(
-      coefficient_type::div, c1_g1, partial_term<P>::null_gfunc,
+      coefficient_type::div, c1_g1, nullptr,
       flux_type::upwind, boundary_condition::dirichlet,
       boundary_condition::neumann, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
       partial_term<P>::null_scalar_func, dV_p);
   inline static partial_term<P> const c1_pterm2 = partial_term<P>(
-      coefficient_type::grad, c1_g1, partial_term<P>::null_gfunc,
+      coefficient_type::grad, c1_g1, nullptr,
       flux_type::downwind, boundary_condition::neumann,
       boundary_condition::dirichlet, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
       partial_term<P>::null_scalar_func, dV_p);
   inline static partial_term<P> const c1_pterm3 = partial_term<P>(
-      coefficient_type::mass, gI, partial_term<P>::null_gfunc,
+      coefficient_type::mass, gI, nullptr,
       flux_type::central, boundary_condition::neumann,
       boundary_condition::neumann, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_z);
+      partial_term<P>::null_scalar_func);
 
   // 2. combine partial terms into single dimension term
   inline static term<P> const c1_term_p = term<P>(false,  // time-dependent
@@ -494,17 +479,17 @@ private:
 
   // 1. create partial_terms
   inline static partial_term<P> const c2_pterm1 = partial_term<P>(
-      coefficient_type::div, c2_g1, partial_term<P>::null_gfunc,
+      coefficient_type::div, c2_g1, nullptr,
       flux_type::downwind, boundary_condition::neumann,
       boundary_condition::dirichlet, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
       partial_term<P>::null_scalar_func, dV_p);
   inline static partial_term<P> const c2_pterm2 = partial_term<P>(
-      coefficient_type::mass, gI, partial_term<P>::null_gfunc,
+      coefficient_type::mass, gI, nullptr,
       flux_type::central, boundary_condition::neumann,
       boundary_condition::neumann, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_z);
+      partial_term<P>::null_scalar_func);
 
   // 2. combine partial terms into single dimension term
   inline static term<P> const c2_term_p = term<P>(false,  // time-dependent
@@ -540,21 +525,21 @@ private:
 
   // 1. create partial_terms
   inline static partial_term<P> const c3_pterm1 = partial_term<P>(
-      coefficient_type::mass, c3_g1, partial_term<P>::null_gfunc,
+      coefficient_type::mass, c3_g1, nullptr,
       flux_type::central, boundary_condition::neumann,
       boundary_condition::neumann, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
       partial_term<P>::null_scalar_func, dV_p3);
 
   inline static partial_term<P> const c3_pterm2 = partial_term<P>(
-      coefficient_type::div, c3_g2, partial_term<P>::null_gfunc,
+      coefficient_type::div, c3_g2, nullptr,
       flux_type::upwind, boundary_condition::dirichlet,
       boundary_condition::dirichlet, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
       partial_term<P>::null_scalar_func, dV_z3);
 
   inline static partial_term<P> const c3_pterm3 = partial_term<P>(
-      coefficient_type::grad, c3_g2, partial_term<P>::null_gfunc,
+      coefficient_type::grad, c3_g2, nullptr,
       flux_type::downwind, boundary_condition::neumann,
       boundary_condition::neumann, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
@@ -597,17 +582,17 @@ private:
 
   // 1. create partial_terms
   inline static partial_term<P> const e1_pterm1 = partial_term<P>(
-      coefficient_type::div, e1_g1, partial_term<P>::null_gfunc,
+      coefficient_type::div, e1_g1, nullptr,
       flux_type::downwind, boundary_condition::dirichlet,
       boundary_condition::neumann, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
       partial_term<P>::null_scalar_func, dV_p);
   inline static partial_term<P> const e1_pterm2 = partial_term<P>(
-      coefficient_type::mass, e1_g2, partial_term<P>::null_gfunc,
+      coefficient_type::mass, e1_g2, nullptr,
       flux_type::central, boundary_condition::neumann,
       boundary_condition::neumann, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_z);
+      partial_term<P>::null_scalar_func);
 
   // 2. combine partial terms into single dimension term
   inline static term<P> const e1_term_p = term<P>(false,  // time-dependent
@@ -643,18 +628,18 @@ private:
 
   // 1. create partial_terms
   inline static partial_term<P> const e2_pterm1 = partial_term<P>(
-      coefficient_type::div, e2_g1, partial_term<P>::null_gfunc,
+      coefficient_type::div, e2_g1, nullptr,
       flux_type::upwind, boundary_condition::neumann,
       boundary_condition::dirichlet, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
       partial_term<P>::null_scalar_func, dV_p);
 
   inline static partial_term<P> const e2_pterm2 = partial_term<P>(
-      coefficient_type::mass, e2_g2, partial_term<P>::null_gfunc,
+      coefficient_type::mass, e2_g2, nullptr,
       flux_type::central, boundary_condition::neumann,
       boundary_condition::neumann, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_z);
+      partial_term<P>::null_scalar_func);
 
   // 2. combine partial terms into single dimension term
   inline static term<P> const e2_term_p = term<P>(false,  // time-dependent
@@ -682,13 +667,13 @@ private:
 
   // 1. create partial_terms
   inline static partial_term<P> const e3_pterm1 = partial_term<P>(
-      coefficient_type::mass, e3_g1, partial_term<P>::null_gfunc,
+      coefficient_type::mass, e3_g1, nullptr,
       flux_type::central, boundary_condition::neumann,
       boundary_condition::neumann, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
       partial_term<P>::null_scalar_func, dV_p3);
   inline static partial_term<P> const e3_pterm2 = partial_term<P>(
-      coefficient_type::div, e3_g2, partial_term<P>::null_gfunc,
+      coefficient_type::div, e3_g2, nullptr,
       flux_type::downwind, boundary_condition::neumann,
       boundary_condition::neumann, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
@@ -731,17 +716,17 @@ private:
 
   // 1. create partial_terms
   inline static partial_term<P> const r1_pterm1 = partial_term<P>(
-      coefficient_type::div, r1_g1, partial_term<P>::null_gfunc,
+      coefficient_type::div, r1_g1, nullptr,
       flux_type::downwind, boundary_condition::neumann,
       boundary_condition::dirichlet, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
       partial_term<P>::null_scalar_func, dV_p);
   inline static partial_term<P> const r1_pterm2 = partial_term<P>(
-      coefficient_type::mass, r1_g1, partial_term<P>::null_gfunc,
+      coefficient_type::mass, r1_g1, nullptr,
       flux_type::central, boundary_condition::neumann,
       boundary_condition::neumann, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_z);
+      partial_term<P>::null_scalar_func);
 
   // 2. combine partial terms into single dimension term
   inline static term<P> const r1_term_p =
@@ -780,13 +765,13 @@ private:
 
   // 1. create partial_terms
   inline static partial_term<P> const r2_pterm1 = partial_term<P>(
-      coefficient_type::mass, r2_g1, partial_term<P>::null_gfunc,
+      coefficient_type::mass, r2_g1, nullptr,
       flux_type::central, boundary_condition::neumann,
       boundary_condition::neumann, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
       partial_term<P>::null_scalar_func, dV_p3);
   inline static partial_term<P> const r2_pterm2 = partial_term<P>(
-      coefficient_type::div, r2_g2, partial_term<P>::null_gfunc,
+      coefficient_type::div, r2_g2, nullptr,
       flux_type::downwind, boundary_condition::neumann,
       boundary_condition::neumann, homogeneity::homogeneous,
       homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},

--- a/src/pde/pde_fokkerplanck2_complete.hpp
+++ b/src/pde/pde_fokkerplanck2_complete.hpp
@@ -435,23 +435,22 @@ private:
 
   // 1. create partial_terms
   inline static partial_term<P> const c1_pterm1 = partial_term<P>(
-      coefficient_type::div, c1_g1, nullptr,
-      flux_type::upwind, boundary_condition::dirichlet,
-      boundary_condition::neumann, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_p);
+      coefficient_type::div, c1_g1, nullptr, flux_type::upwind,
+      boundary_condition::dirichlet, boundary_condition::neumann,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
+      dV_p);
   inline static partial_term<P> const c1_pterm2 = partial_term<P>(
-      coefficient_type::grad, c1_g1, nullptr,
-      flux_type::downwind, boundary_condition::neumann,
-      boundary_condition::dirichlet, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_p);
+      coefficient_type::grad, c1_g1, nullptr, flux_type::downwind,
+      boundary_condition::neumann, boundary_condition::dirichlet,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
+      dV_p);
   inline static partial_term<P> const c1_pterm3 = partial_term<P>(
-      coefficient_type::mass, gI, nullptr,
-      flux_type::central, boundary_condition::neumann,
-      boundary_condition::neumann, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func);
+      coefficient_type::mass, gI, nullptr, flux_type::central,
+      boundary_condition::neumann, boundary_condition::neumann,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func);
 
   // 2. combine partial terms into single dimension term
   inline static term<P> const c1_term_p = term<P>(false,  // time-dependent
@@ -479,17 +478,16 @@ private:
 
   // 1. create partial_terms
   inline static partial_term<P> const c2_pterm1 = partial_term<P>(
-      coefficient_type::div, c2_g1, nullptr,
-      flux_type::downwind, boundary_condition::neumann,
-      boundary_condition::dirichlet, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_p);
+      coefficient_type::div, c2_g1, nullptr, flux_type::downwind,
+      boundary_condition::neumann, boundary_condition::dirichlet,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
+      dV_p);
   inline static partial_term<P> const c2_pterm2 = partial_term<P>(
-      coefficient_type::mass, gI, nullptr,
-      flux_type::central, boundary_condition::neumann,
-      boundary_condition::neumann, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func);
+      coefficient_type::mass, gI, nullptr, flux_type::central,
+      boundary_condition::neumann, boundary_condition::neumann,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func);
 
   // 2. combine partial terms into single dimension term
   inline static term<P> const c2_term_p = term<P>(false,  // time-dependent
@@ -525,25 +523,25 @@ private:
 
   // 1. create partial_terms
   inline static partial_term<P> const c3_pterm1 = partial_term<P>(
-      coefficient_type::mass, c3_g1, nullptr,
-      flux_type::central, boundary_condition::neumann,
-      boundary_condition::neumann, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_p3);
+      coefficient_type::mass, c3_g1, nullptr, flux_type::central,
+      boundary_condition::neumann, boundary_condition::neumann,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
+      dV_p3);
 
   inline static partial_term<P> const c3_pterm2 = partial_term<P>(
-      coefficient_type::div, c3_g2, nullptr,
-      flux_type::upwind, boundary_condition::dirichlet,
-      boundary_condition::dirichlet, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_z3);
+      coefficient_type::div, c3_g2, nullptr, flux_type::upwind,
+      boundary_condition::dirichlet, boundary_condition::dirichlet,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
+      dV_z3);
 
   inline static partial_term<P> const c3_pterm3 = partial_term<P>(
-      coefficient_type::grad, c3_g2, nullptr,
-      flux_type::downwind, boundary_condition::neumann,
-      boundary_condition::neumann, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_z3);
+      coefficient_type::grad, c3_g2, nullptr, flux_type::downwind,
+      boundary_condition::neumann, boundary_condition::neumann,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
+      dV_z3);
 
   // 2. combine partial terms into single dimension term
   inline static term<P> const c3_term_p = term<P>(false,  // time-dependent
@@ -582,17 +580,16 @@ private:
 
   // 1. create partial_terms
   inline static partial_term<P> const e1_pterm1 = partial_term<P>(
-      coefficient_type::div, e1_g1, nullptr,
-      flux_type::downwind, boundary_condition::dirichlet,
-      boundary_condition::neumann, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_p);
+      coefficient_type::div, e1_g1, nullptr, flux_type::downwind,
+      boundary_condition::dirichlet, boundary_condition::neumann,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
+      dV_p);
   inline static partial_term<P> const e1_pterm2 = partial_term<P>(
-      coefficient_type::mass, e1_g2, nullptr,
-      flux_type::central, boundary_condition::neumann,
-      boundary_condition::neumann, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func);
+      coefficient_type::mass, e1_g2, nullptr, flux_type::central,
+      boundary_condition::neumann, boundary_condition::neumann,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func);
 
   // 2. combine partial terms into single dimension term
   inline static term<P> const e1_term_p = term<P>(false,  // time-dependent
@@ -628,18 +625,17 @@ private:
 
   // 1. create partial_terms
   inline static partial_term<P> const e2_pterm1 = partial_term<P>(
-      coefficient_type::div, e2_g1, nullptr,
-      flux_type::upwind, boundary_condition::neumann,
-      boundary_condition::dirichlet, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_p);
+      coefficient_type::div, e2_g1, nullptr, flux_type::upwind,
+      boundary_condition::neumann, boundary_condition::dirichlet,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
+      dV_p);
 
   inline static partial_term<P> const e2_pterm2 = partial_term<P>(
-      coefficient_type::mass, e2_g2, nullptr,
-      flux_type::central, boundary_condition::neumann,
-      boundary_condition::neumann, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func);
+      coefficient_type::mass, e2_g2, nullptr, flux_type::central,
+      boundary_condition::neumann, boundary_condition::neumann,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func);
 
   // 2. combine partial terms into single dimension term
   inline static term<P> const e2_term_p = term<P>(false,  // time-dependent
@@ -667,17 +663,17 @@ private:
 
   // 1. create partial_terms
   inline static partial_term<P> const e3_pterm1 = partial_term<P>(
-      coefficient_type::mass, e3_g1, nullptr,
-      flux_type::central, boundary_condition::neumann,
-      boundary_condition::neumann, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_p3);
+      coefficient_type::mass, e3_g1, nullptr, flux_type::central,
+      boundary_condition::neumann, boundary_condition::neumann,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
+      dV_p3);
   inline static partial_term<P> const e3_pterm2 = partial_term<P>(
-      coefficient_type::div, e3_g2, nullptr,
-      flux_type::downwind, boundary_condition::neumann,
-      boundary_condition::neumann, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_z3);
+      coefficient_type::div, e3_g2, nullptr, flux_type::downwind,
+      boundary_condition::neumann, boundary_condition::neumann,
+      homogeneity::homogeneous, homogeneity::homogeneous, {},
+      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
+      dV_z3);
 
   // 2. combine partial terms into single dimension term
   inline static term<P> const e3_term_p = term<P>(false,  // time-dependent

--- a/src/pde/pde_two_stream.hpp
+++ b/src/pde/pde_two_stream.hpp
@@ -179,15 +179,13 @@ private:
     return (x > 0.0) ? x : 0.0;
   }
 
-  inline static const partial_term<P> e1_pterm_x =
-      partial_term<P>(coefficient_type::div, e1_g1, partial_term<P>::null_gfunc,
-                      flux_type::downwind, boundary_condition::periodic,
-                      boundary_condition::periodic);
+  inline static const partial_term<P> e1_pterm_x = partial_term<P>(
+      coefficient_type::div, e1_g1, nullptr, flux_type::downwind,
+      boundary_condition::periodic, boundary_condition::periodic);
 
   inline static const partial_term<P> e1_pterm_v = partial_term<P>(
-      coefficient_type::mass, e1_g2, partial_term<P>::null_gfunc,
-      flux_type::central, boundary_condition::periodic,
-      boundary_condition::periodic);
+      coefficient_type::mass, e1_g2, nullptr, flux_type::central,
+      boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const term_e1x =
       term<P>(false,  // time-dependent
@@ -217,15 +215,13 @@ private:
     return (x < 0.0) ? x : 0.0;
   }
 
-  inline static const partial_term<P> e2_pterm_x =
-      partial_term<P>(coefficient_type::div, e2_g1, partial_term<P>::null_gfunc,
-                      flux_type::upwind, boundary_condition::periodic,
-                      boundary_condition::periodic);
+  inline static const partial_term<P> e2_pterm_x = partial_term<P>(
+      coefficient_type::div, e2_g1, nullptr, flux_type::upwind,
+      boundary_condition::periodic, boundary_condition::periodic);
 
   inline static const partial_term<P> e2_pterm_v = partial_term<P>(
-      coefficient_type::mass, e2_g2, partial_term<P>::null_gfunc,
-      flux_type::central, boundary_condition::periodic,
-      boundary_condition::periodic);
+      coefficient_type::mass, e2_g2, nullptr, flux_type::central,
+      boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const term_e2x =
       term<P>(false,  // time-dependent
@@ -258,9 +254,8 @@ private:
   }
 
   inline static const partial_term<P> pterm_E_mass_x = partial_term<P>(
-      coefficient_type::mass, E_func, partial_term<P>::null_gfunc,
-      flux_type::central, boundary_condition::periodic,
-      boundary_condition::periodic);
+      coefficient_type::mass, E_func, nullptr, flux_type::central,
+      boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const E_mass_x =
       term<P>(true, // time-dependent
@@ -268,10 +263,9 @@ private:
               {pterm_E_mass_x}, imex_flag::imex_explicit);
 
   inline static const partial_term<P> pterm_div_v = partial_term<P>(
-      coefficient_type::div, negOne, partial_term<P>::null_gfunc,
-      flux_type::central, boundary_condition::dirichlet,
-      boundary_condition::dirichlet, homogeneity::homogeneous,
-      homogeneity::homogeneous);
+      coefficient_type::div, negOne, nullptr, flux_type::central,
+      boundary_condition::dirichlet, boundary_condition::dirichlet,
+      homogeneity::homogeneous, homogeneity::homogeneous);
 
   inline static term<P> const div_v =
       term<P>(false, // time-dependent
@@ -299,9 +293,8 @@ private:
   }
 
   inline static const partial_term<P> pterm_MaxAbsE_mass_x = partial_term<P>(
-      coefficient_type::mass, MaxAbsE_func, partial_term<P>::null_gfunc,
-      flux_type::central, boundary_condition::periodic,
-      boundary_condition::periodic);
+      coefficient_type::mass, MaxAbsE_func, nullptr, flux_type::central,
+      boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const MaxAbsE_mass_x_1 =
       term<P>(true, // time-dependent
@@ -314,10 +307,9 @@ private:
               {pterm_MaxAbsE_mass_x}, imex_flag::imex_explicit);
 
   inline static const partial_term<P> pterm_div_v_downwind = partial_term<P>(
-      coefficient_type::div, posOne, partial_term<P>::null_gfunc,
-      flux_type::downwind, boundary_condition::dirichlet,
-      boundary_condition::dirichlet, homogeneity::homogeneous,
-      homogeneity::homogeneous);
+      coefficient_type::div, posOne, nullptr, flux_type::downwind,
+      boundary_condition::dirichlet, boundary_condition::dirichlet,
+      homogeneity::homogeneous, homogeneity::homogeneous);
 
   inline static term<P> const div_v_downwind =
       term<P>(false, // time-dependent

--- a/src/pde/pde_vlasov_lb_full_f.hpp
+++ b/src/pde/pde_vlasov_lb_full_f.hpp
@@ -180,15 +180,13 @@ private:
     return (x > 0.0) ? x : 0.0;
   }
 
-  inline static const partial_term<P> e1_pterm_x =
-      partial_term<P>(coefficient_type::div, e1_g1, nullptr,
-                      flux_type::downwind, boundary_condition::periodic,
-                      boundary_condition::periodic);
+  inline static const partial_term<P> e1_pterm_x = partial_term<P>(
+      coefficient_type::div, e1_g1, nullptr, flux_type::downwind,
+      boundary_condition::periodic, boundary_condition::periodic);
 
   inline static const partial_term<P> e1_pterm_v = partial_term<P>(
-      coefficient_type::mass, e1_g2, nullptr,
-      flux_type::central, boundary_condition::periodic,
-      boundary_condition::periodic);
+      coefficient_type::mass, e1_g2, nullptr, flux_type::central,
+      boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const term_e1x =
       term<P>(false,  // time-dependent
@@ -218,15 +216,13 @@ private:
     return (x < 0.0) ? x : 0.0;
   }
 
-  inline static const partial_term<P> e2_pterm_x =
-      partial_term<P>(coefficient_type::div, e2_g1, nullptr,
-                      flux_type::upwind, boundary_condition::periodic,
-                      boundary_condition::periodic);
+  inline static const partial_term<P> e2_pterm_x = partial_term<P>(
+      coefficient_type::div, e2_g1, nullptr, flux_type::upwind,
+      boundary_condition::periodic, boundary_condition::periodic);
 
   inline static const partial_term<P> e2_pterm_v = partial_term<P>(
-      coefficient_type::mass, e2_g2, nullptr,
-      flux_type::central, boundary_condition::periodic,
-      boundary_condition::periodic);
+      coefficient_type::mass, e2_g2, nullptr, flux_type::central,
+      boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const term_e2x =
       term<P>(false,  // time-dependent
@@ -257,14 +253,12 @@ private:
   }
 
   inline static const partial_term<P> i1_pterm_x = partial_term<P>(
-      coefficient_type::mass, i1_g1, nullptr,
-      flux_type::central, boundary_condition::periodic,
-      boundary_condition::periodic);
+      coefficient_type::mass, i1_g1, nullptr, flux_type::central,
+      boundary_condition::periodic, boundary_condition::periodic);
 
-  inline static const partial_term<P> i1_pterm_v =
-      partial_term<P>(coefficient_type::div, i1_g2, nullptr,
-                      flux_type::downwind, boundary_condition::dirichlet,
-                      boundary_condition::dirichlet);
+  inline static const partial_term<P> i1_pterm_v = partial_term<P>(
+      coefficient_type::div, i1_g2, nullptr, flux_type::downwind,
+      boundary_condition::dirichlet, boundary_condition::dirichlet);
 
   inline static term<P> const term_i1x =
       term<P>(false,  // time-dependent
@@ -296,14 +290,12 @@ private:
   }
 
   inline static const partial_term<P> i2_pterm_x = partial_term<P>(
-      coefficient_type::mass, i2_g1, nullptr,
-      flux_type::central, boundary_condition::periodic,
-      boundary_condition::periodic);
+      coefficient_type::mass, i2_g1, nullptr, flux_type::central,
+      boundary_condition::periodic, boundary_condition::periodic);
 
-  inline static const partial_term<P> i2_pterm_v =
-      partial_term<P>(coefficient_type::div, i2_g2, nullptr,
-                      flux_type::central, boundary_condition::dirichlet,
-                      boundary_condition::dirichlet);
+  inline static const partial_term<P> i2_pterm_v = partial_term<P>(
+      coefficient_type::div, i2_g2, nullptr, flux_type::central,
+      boundary_condition::dirichlet, boundary_condition::dirichlet);
 
   inline static term<P> const term_i2x =
       term<P>(false,  // time-dependent
@@ -339,14 +331,12 @@ private:
   }
 
   inline static const partial_term<P> i3_pterm_x1 = partial_term<P>(
-      coefficient_type::mass, i3_g1, nullptr,
-      flux_type::central, boundary_condition::periodic,
-      boundary_condition::periodic);
+      coefficient_type::mass, i3_g1, nullptr, flux_type::central,
+      boundary_condition::periodic, boundary_condition::periodic);
 
   inline static const partial_term<P> i3_pterm_x2 = partial_term<P>(
-      coefficient_type::mass, i3_g2, nullptr,
-      flux_type::central, boundary_condition::periodic,
-      boundary_condition::periodic);
+      coefficient_type::mass, i3_g2, nullptr, flux_type::central,
+      boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const term_i3x =
       term<P>(false,  // time-dependent
@@ -367,15 +357,13 @@ private:
     return 1.0;
   }
 
-  inline static const partial_term<P> i3_pterm_v1 =
-      partial_term<P>(coefficient_type::div, i3_g3, nullptr,
-                      flux_type::central, boundary_condition::dirichlet,
-                      boundary_condition::dirichlet);
+  inline static const partial_term<P> i3_pterm_v1 = partial_term<P>(
+      coefficient_type::div, i3_g3, nullptr, flux_type::central,
+      boundary_condition::dirichlet, boundary_condition::dirichlet);
 
   inline static const partial_term<P> i3_pterm_v2 = partial_term<P>(
-      coefficient_type::grad, i3_g4, nullptr,
-      flux_type::central, boundary_condition::dirichlet,
-      boundary_condition::dirichlet);
+      coefficient_type::grad, i3_g4, nullptr, flux_type::central,
+      boundary_condition::dirichlet, boundary_condition::dirichlet);
 
   inline static term<P> const term_i3v =
       term<P>(false,  // time-dependent

--- a/src/pde/pde_vlasov_lb_full_f.hpp
+++ b/src/pde/pde_vlasov_lb_full_f.hpp
@@ -87,21 +87,14 @@ private:
     return fx;
   }
 
-  static P dV(P const x, P const time)
-  {
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
   /* Define the dimension */
   inline static dimension<P> const dim_0 = dimension<P>(
       -1.0, 1.0, 4, default_degree,
-      {initial_condition_dim_x_0, initial_condition_dim_x_1}, dV, "x");
+      {initial_condition_dim_x_0, initial_condition_dim_x_1}, nullptr, "x");
 
   inline static dimension<P> const dim_1 = dimension<P>(
       -6.0, 6.0, 3, default_degree,
-      {initial_condition_dim_v_0, initial_condition_dim_v_1}, dV, "v");
+      {initial_condition_dim_v_0, initial_condition_dim_v_1}, nullptr, "v");
 
   inline static std::vector<dimension<P>> const dimensions_ = {dim_0, dim_1};
 
@@ -188,12 +181,12 @@ private:
   }
 
   inline static const partial_term<P> e1_pterm_x =
-      partial_term<P>(coefficient_type::div, e1_g1, partial_term<P>::null_gfunc,
+      partial_term<P>(coefficient_type::div, e1_g1, nullptr,
                       flux_type::downwind, boundary_condition::periodic,
                       boundary_condition::periodic);
 
   inline static const partial_term<P> e1_pterm_v = partial_term<P>(
-      coefficient_type::mass, e1_g2, partial_term<P>::null_gfunc,
+      coefficient_type::mass, e1_g2, nullptr,
       flux_type::central, boundary_condition::periodic,
       boundary_condition::periodic);
 
@@ -226,12 +219,12 @@ private:
   }
 
   inline static const partial_term<P> e2_pterm_x =
-      partial_term<P>(coefficient_type::div, e2_g1, partial_term<P>::null_gfunc,
+      partial_term<P>(coefficient_type::div, e2_g1, nullptr,
                       flux_type::upwind, boundary_condition::periodic,
                       boundary_condition::periodic);
 
   inline static const partial_term<P> e2_pterm_v = partial_term<P>(
-      coefficient_type::mass, e2_g2, partial_term<P>::null_gfunc,
+      coefficient_type::mass, e2_g2, nullptr,
       flux_type::central, boundary_condition::periodic,
       boundary_condition::periodic);
 
@@ -264,12 +257,12 @@ private:
   }
 
   inline static const partial_term<P> i1_pterm_x = partial_term<P>(
-      coefficient_type::mass, i1_g1, partial_term<P>::null_gfunc,
+      coefficient_type::mass, i1_g1, nullptr,
       flux_type::central, boundary_condition::periodic,
       boundary_condition::periodic);
 
   inline static const partial_term<P> i1_pterm_v =
-      partial_term<P>(coefficient_type::div, i1_g2, partial_term<P>::null_gfunc,
+      partial_term<P>(coefficient_type::div, i1_g2, nullptr,
                       flux_type::downwind, boundary_condition::dirichlet,
                       boundary_condition::dirichlet);
 
@@ -303,12 +296,12 @@ private:
   }
 
   inline static const partial_term<P> i2_pterm_x = partial_term<P>(
-      coefficient_type::mass, i2_g1, partial_term<P>::null_gfunc,
+      coefficient_type::mass, i2_g1, nullptr,
       flux_type::central, boundary_condition::periodic,
       boundary_condition::periodic);
 
   inline static const partial_term<P> i2_pterm_v =
-      partial_term<P>(coefficient_type::div, i2_g2, partial_term<P>::null_gfunc,
+      partial_term<P>(coefficient_type::div, i2_g2, nullptr,
                       flux_type::central, boundary_condition::dirichlet,
                       boundary_condition::dirichlet);
 
@@ -346,12 +339,12 @@ private:
   }
 
   inline static const partial_term<P> i3_pterm_x1 = partial_term<P>(
-      coefficient_type::mass, i3_g1, partial_term<P>::null_gfunc,
+      coefficient_type::mass, i3_g1, nullptr,
       flux_type::central, boundary_condition::periodic,
       boundary_condition::periodic);
 
   inline static const partial_term<P> i3_pterm_x2 = partial_term<P>(
-      coefficient_type::mass, i3_g2, partial_term<P>::null_gfunc,
+      coefficient_type::mass, i3_g2, nullptr,
       flux_type::central, boundary_condition::periodic,
       boundary_condition::periodic);
 
@@ -375,12 +368,12 @@ private:
   }
 
   inline static const partial_term<P> i3_pterm_v1 =
-      partial_term<P>(coefficient_type::div, i3_g3, partial_term<P>::null_gfunc,
+      partial_term<P>(coefficient_type::div, i3_g3, nullptr,
                       flux_type::central, boundary_condition::dirichlet,
                       boundary_condition::dirichlet);
 
   inline static const partial_term<P> i3_pterm_v2 = partial_term<P>(
-      coefficient_type::grad, i3_g4, partial_term<P>::null_gfunc,
+      coefficient_type::grad, i3_g4, nullptr,
       flux_type::central, boundary_condition::dirichlet,
       boundary_condition::dirichlet);
 

--- a/src/pde_tests.cpp
+++ b/src/pde_tests.cpp
@@ -333,7 +333,9 @@ TEMPLATE_TEST_CASE("testing fokkerplanck2_complete_case4 implementations",
         for (auto k = 0; k < static_cast<int>(partial_terms.size()); ++k)
         {
           fk::vector<TestType> transformed(x);
-          g_func_type<TestType> g_func = partial_terms[k].g_func;
+          g_func_type<TestType> g_func =
+              partial_terms[k].g_func ? partial_terms[k].g_func
+                                      : partial_term<TestType>::null_gfunc;
           std::transform(x.begin(), x.end(), transformed.begin(),
                          [g_func, time](TestType const x_elem) -> TestType {
                            return g_func(x_elem, time);
@@ -344,7 +346,9 @@ TEMPLATE_TEST_CASE("testing fokkerplanck2_complete_case4 implementations",
           rmse_comparison(transformed, gold_pterm, tol_factor);
 
           fk::vector<TestType> dv(x);
-          g_func_type<TestType> dv_func = partial_terms[k].dv_func;
+          g_func_type<TestType> dv_func =
+              partial_terms[k].dv_func ? partial_terms[k].dv_func
+                                       : partial_term<TestType>::null_gfunc;
           std::transform(x.begin(), x.end(), dv.begin(),
                          [dv_func, time](TestType const x_elem) -> TestType {
                            return dv_func(x_elem, time);

--- a/src/transformations.hpp
+++ b/src/transformations.hpp
@@ -95,10 +95,6 @@ fk::vector<P> forward_transform(
   expect(degree > 0);
   expect(domain_max > domain_min);
 
-  if (!dv_func)
-    dv_func = partial_term<P>::null_gfunc;
-  expect(dv_func);
-
   // check to make sure the F function arg is a function type
   // that will accept a vector argument. we have a check for its
   // return below
@@ -145,11 +141,14 @@ fk::vector<P> forward_transform(
     fk::vector<P> f_here = function(mapped_roots, t);
 
     // apply dv to f(v)
-    std::transform(f_here.begin(), f_here.end(), mapped_roots.begin(),
-                   f_here.begin(),
-                   [dv_func, t](P &f_elem, P const &x_elem) -> P {
-                     return f_elem * dv_func(x_elem, t);
-                   });
+    if (dv_func)
+    {
+      std::transform(f_here.begin(), f_here.end(), mapped_roots.begin(),
+                     f_here.begin(),
+                     [dv_func, t](P &f_elem, P const &x_elem) -> P {
+                       return f_elem * dv_func(x_elem, t);
+                     });
+    }
 
     // ensuring function returns vector of appropriate size
     expect(f_here.size() == weights.size());

--- a/src/transformations.hpp
+++ b/src/transformations.hpp
@@ -81,7 +81,7 @@ void combine_dimensions(int const degree, elements::table const &table,
 
 template<typename P, typename F>
 fk::vector<P> forward_transform(
-    dimension<P> const &dim, F function, g_func_type<P> const dv_func,
+    dimension<P> const &dim, F function, g_func_type<P> dv_func,
     basis::wavelet_transform<P, resource::host> const &transformer,
     P const t = 0)
 {
@@ -94,6 +94,10 @@ fk::vector<P> forward_transform(
   expect(num_levels <= transformer.max_level);
   expect(degree > 0);
   expect(domain_max > domain_min);
+
+  if (!dv_func)
+    dv_func = partial_term<P>::null_gfunc;
+  expect(dv_func);
 
   // check to make sure the F function arg is a function type
   // that will accept a vector argument. we have a check for its


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

We need some way to differentiate `partial_term<precision>::null_gfunc` from another function. The easiest option is default construct it so that it holds a nullptr.

This fixes #493.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [ ] Bugfix
- [x] New feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
