### PR TITLE
generate_all_coefficients: use move semantics, avoid null_gfunc

### DIFF
--- a/src/asgard_field_tests.cpp
+++ b/src/asgard_field_tests.cpp
@@ -5,12 +5,6 @@
 using namespace asgard;
 
 template<typename precision>
-struct volume
-{
-  static precision jacobi(precision const, precision const) { return 1.0; }
-};
-
-template<typename precision>
 struct initial
 {
   static fk::vector<precision>

--- a/src/coefficients.cpp
+++ b/src/coefficients.cpp
@@ -24,7 +24,7 @@ void generate_all_coefficients(
   for (auto i = 0; i < pde.num_dims; ++i)
   {
     auto const &dim = pde.get_dimensions()[i];
-
+    std::vector<int> ipiv(dim.get_degree() * fm::two_raised_to(pde.max_level));
     for (auto j = 0; j < pde.num_terms; ++j)
     {
       auto const &term_1D       = pde.get_terms()[j][i];
@@ -45,8 +45,7 @@ void generate_all_coefficients(
 
         // precompute inv(mass) * coeff for each level up to max level
         std::vector<fk::matrix<P>> pterm_coeffs;
-        std::vector<int> ipiv(dim.get_degree() *
-                              fm::two_raised_to(pde.max_level));
+
         for (int level = 0; level <= pde.max_level; ++level)
         {
           auto result = generate_coefficients<P>(
@@ -60,8 +59,8 @@ void generate_all_coefficients(
           pterm_coeffs.emplace_back(std::move(result));
         }
 
-        pde.set_lhs_mass(j, i, k, mass_coeff);
-        pde.set_partial_coefficients(j, i, k, pterm_coeffs);
+        pde.set_lhs_mass(j, i, k, std::move(mass_coeff));
+        pde.set_partial_coefficients(j, i, k, std::move(pterm_coeffs));
       }
     }
     pde.rechain_dimension(i);

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -199,10 +199,18 @@ public:
     coefficients_ = new_coefficients;
   }
 
+  void set_coefficients(std::vector<fk::matrix<P>> &&new_coefficients)
+  {
+    expect(new_coefficients.size() > 0);
+    coefficients_ = std::move(new_coefficients);
+  }
+
   void set_mass(fk::matrix<P> const &new_mass)
   {
     this->mass_.clear_and_resize(new_mass.nrows(), new_mass.ncols()) = new_mass;
   }
+
+  void set_mass(fk::matrix<P> &&new_mass) { this->mass_ = std::move(new_mass); }
 
   boundary_condition set_bilinear_boundary(boundary_condition const bc)
   {
@@ -275,11 +283,26 @@ public:
     partial_terms_[pterm].set_coefficients(coeffs);
   }
 
+  void
+  set_partial_coefficients(std::vector<fk::matrix<P>> &&coeffs, int const pterm)
+  {
+    expect(pterm >= 0);
+    expect(pterm < static_cast<int>(partial_terms_.size()));
+    partial_terms_[pterm].set_coefficients(std::move(coeffs));
+  }
+
   void set_lhs_mass(fk::matrix<P> const &mass, int const pterm)
   {
     expect(pterm >= 0);
     expect(pterm < static_cast<int>(partial_terms_.size()));
     partial_terms_[pterm].set_mass(mass);
+  }
+
+  void set_lhs_mass(fk::matrix<P> &&mass, int const pterm)
+  {
+    expect(pterm >= 0);
+    expect(pterm < static_cast<int>(partial_terms_.size()));
+    partial_terms_[pterm].set_mass(std::move(mass));
   }
 
   fk::matrix<P, mem_type::owner, resource::device> const &
@@ -693,6 +716,16 @@ public:
     expect(dim >= 0);
     expect(dim < num_dims);
     terms_[term][dim].set_lhs_mass(mass, pterm);
+  }
+
+  void set_lhs_mass(int const term, int const dim, int const pterm,
+                    fk::matrix<P> &&mass)
+  {
+    expect(term >= 0);
+    expect(term < num_terms);
+    expect(dim >= 0);
+    expect(dim < num_dims);
+    terms_[term][dim].set_lhs_mass(mass, std::move(pterm));
   }
 
   void update_dimension(int const dim_index, int const new_level)

--- a/src/pde/pde_fokkerplanck1_pitch_C.hpp
+++ b/src/pde/pde_fokkerplanck1_pitch_C.hpp
@@ -125,13 +125,6 @@ private:
     ignore(time);
     return 1 - std::pow(x, 2);
   }
-  static P g_func_2(P const x, P const time)
-  {
-    // suppress compiler warnings
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
 
   static P dV_z(P const x, P const time)
   {
@@ -167,14 +160,14 @@ private:
   //    termC_z.BCR2 = 'N';
 
   inline static partial_term<P> const partial_term_0 = partial_term<P>(
-      coefficient_type::div, g_func_2, nullptr, flux_type::downwind,
+      coefficient_type::div, nullptr, nullptr, flux_type::downwind,
       boundary_condition::dirichlet, boundary_condition::dirichlet,
       homogeneity::homogeneous, homogeneity::homogeneous, {},
       partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
       dV_z);
 
   inline static partial_term<P> const partial_term_1 = partial_term<P>(
-      coefficient_type::grad, g_func_2, nullptr, flux_type::upwind,
+      coefficient_type::grad, nullptr, nullptr, flux_type::upwind,
       boundary_condition::neumann, boundary_condition::neumann,
       homogeneity::homogeneous, homogeneity::homogeneous, {},
       partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,

--- a/src/pde/pde_fokkerplanck1_pitch_E.hpp
+++ b/src/pde/pde_fokkerplanck1_pitch_E.hpp
@@ -132,13 +132,6 @@ private:
     ignore(time);
     return -sqrt(1 - std::pow(x, 2));
   }
-  static P g_func_2(P const x, P const time)
-  {
-    // suppress compiler warnings
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
 
   static P dV_z(P const x, P const time)
   {

--- a/src/pde/pde_fokkerplanck2_complete.hpp
+++ b/src/pde/pde_fokkerplanck2_complete.hpp
@@ -384,14 +384,6 @@ private:
   //
   // ----------------------------------------
 
-  // create a default mass matrix
-  static P gI(P const x, P const time = 0)
-  {
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
   static P dV_p(P const x, P const time)
   {
     ignore(time);
@@ -411,7 +403,7 @@ private:
   }
 
   inline static partial_term<P> const pterm_I =
-      partial_term<P>(coefficient_type::mass, gI);
+      partial_term<P>(coefficient_type::mass, nullptr);
   inline static term<P> const I_ =
       term<P>(false,           // time-dependent
               fk::vector<P>(), // additional data vector
@@ -447,7 +439,7 @@ private:
       partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
       dV_p);
   inline static partial_term<P> const c1_pterm3 = partial_term<P>(
-      coefficient_type::mass, gI, nullptr, flux_type::central,
+      coefficient_type::mass, nullptr, nullptr, flux_type::central,
       boundary_condition::neumann, boundary_condition::neumann,
       homogeneity::homogeneous, homogeneity::homogeneous, {},
       partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func);
@@ -484,7 +476,7 @@ private:
       partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
       dV_p);
   inline static partial_term<P> const c2_pterm2 = partial_term<P>(
-      coefficient_type::mass, gI, nullptr, flux_type::central,
+      coefficient_type::mass, nullptr, nullptr, flux_type::central,
       boundary_condition::neumann, boundary_condition::neumann,
       homogeneity::homogeneous, homogeneity::homogeneous, {},
       partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func);
@@ -514,12 +506,6 @@ private:
     ignore(time);
     return sqrt(Cb(x));
   }
-  static P c3_g2(P const x, P const time = 0)
-  {
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
 
   // 1. create partial_terms
   inline static partial_term<P> const c3_pterm1 = partial_term<P>(
@@ -530,14 +516,14 @@ private:
       dV_p3);
 
   inline static partial_term<P> const c3_pterm2 = partial_term<P>(
-      coefficient_type::div, c3_g2, nullptr, flux_type::upwind,
+      coefficient_type::div, nullptr, nullptr, flux_type::upwind,
       boundary_condition::dirichlet, boundary_condition::dirichlet,
       homogeneity::homogeneous, homogeneity::homogeneous, {},
       partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
       dV_z3);
 
   inline static partial_term<P> const c3_pterm3 = partial_term<P>(
-      coefficient_type::grad, c3_g2, nullptr, flux_type::downwind,
+      coefficient_type::grad, nullptr, nullptr, flux_type::downwind,
       boundary_condition::neumann, boundary_condition::neumann,
       homogeneity::homogeneous, homogeneity::homogeneous, {},
       partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
@@ -648,13 +634,6 @@ private:
   // 3. combine single dimension terms into multi dimension term
   inline static std::vector<term<P>> const termE2 = {e2_term_p, e2_term_z};
 
-  // TODO: add comments about this term
-  static P e3_g1(P const x, P const time = 0)
-  {
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
   static P e3_g2(P const x, P const time = 0)
   {
     ignore(time);
@@ -663,7 +642,7 @@ private:
 
   // 1. create partial_terms
   inline static partial_term<P> const e3_pterm1 = partial_term<P>(
-      coefficient_type::mass, e3_g1, nullptr, flux_type::central,
+      coefficient_type::mass, nullptr, nullptr, flux_type::central,
       boundary_condition::neumann, boundary_condition::neumann,
       homogeneity::homogeneous, homogeneity::homogeneous, {},
       partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,

--- a/src/pde/pde_two_stream.hpp
+++ b/src/pde/pde_two_stream.hpp
@@ -64,21 +64,14 @@ private:
     return fx;
   }
 
-  static P dV(P const x, P const time)
-  {
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
   /* Define the dimension */
   inline static dimension<P> const dim_0 =
       dimension<P>(-2.0 * PI, 2.0 * PI, 4, default_degree,
-                   initial_condition_dim_x_0, dV, "x");
+                   initial_condition_dim_x_0, nullptr, "x");
 
   inline static dimension<P> const dim_1 =
       dimension<P>(-2.0 * PI, 2.0 * PI, 3, default_degree,
-                   initial_condition_dim_v_0, dV, "v");
+                   initial_condition_dim_v_0, nullptr, "v");
 
   inline static std::vector<dimension<P>> const dimensions_ = {dim_0, dim_1};
 
@@ -176,7 +169,7 @@ private:
   static P e1_g2(P const x, P const time = 0)
   {
     ignore(time);
-    return (x > 0.0) ? x : 0.0;
+    return std::max(P{0.0}, x);
   }
 
   inline static const partial_term<P> e1_pterm_x = partial_term<P>(
@@ -212,7 +205,7 @@ private:
   static P e2_g2(P const x, P const time = 0)
   {
     ignore(time);
-    return (x < 0.0) ? x : 0.0;
+    return std::min(P{0.0}, x);
   }
 
   inline static const partial_term<P> e2_pterm_x = partial_term<P>(
@@ -285,13 +278,6 @@ private:
     return param->value(x, time);
   }
 
-  static P posOne(P const x, P const time = 0)
-  {
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
   inline static const partial_term<P> pterm_MaxAbsE_mass_x = partial_term<P>(
       coefficient_type::mass, MaxAbsE_func, nullptr, flux_type::central,
       boundary_condition::periodic, boundary_condition::periodic);
@@ -307,7 +293,7 @@ private:
               {pterm_MaxAbsE_mass_x}, imex_flag::imex_explicit);
 
   inline static const partial_term<P> pterm_div_v_downwind = partial_term<P>(
-      coefficient_type::div, posOne, nullptr, flux_type::downwind,
+      coefficient_type::div, nullptr, nullptr, flux_type::downwind,
       boundary_condition::dirichlet, boundary_condition::dirichlet,
       homogeneity::homogeneous, homogeneity::homogeneous);
 

--- a/src/pde/pde_vlasov_lb_full_f.hpp
+++ b/src/pde/pde_vlasov_lb_full_f.hpp
@@ -316,12 +316,6 @@ private:
   //
   // div_v(th q)
   // q = \grad_v f
-  static P i3_g1(P const x, P const time = 0)
-  {
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
 
   static P i3_g2(P const x, P const time = 0)
   {
@@ -331,7 +325,7 @@ private:
   }
 
   inline static const partial_term<P> i3_pterm_x1 = partial_term<P>(
-      coefficient_type::mass, i3_g1, nullptr, flux_type::central,
+      coefficient_type::mass, nullptr, nullptr, flux_type::central,
       boundary_condition::periodic, boundary_condition::periodic);
 
   inline static const partial_term<P> i3_pterm_x2 = partial_term<P>(
@@ -343,26 +337,12 @@ private:
               "I3_x", // name
               {i3_pterm_x1, i3_pterm_x2}, imex_flag::imex_implicit);
 
-  static P i3_g3(P const x, P const time = 0)
-  {
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
-  static P i3_g4(P const x, P const time = 0)
-  {
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
   inline static const partial_term<P> i3_pterm_v1 = partial_term<P>(
-      coefficient_type::div, i3_g3, nullptr, flux_type::central,
+      coefficient_type::div, nullptr, nullptr, flux_type::central,
       boundary_condition::dirichlet, boundary_condition::dirichlet);
 
   inline static const partial_term<P> i3_pterm_v2 = partial_term<P>(
-      coefficient_type::grad, i3_g4, nullptr, flux_type::central,
+      coefficient_type::grad, nullptr, nullptr, flux_type::central,
       boundary_condition::dirichlet, boundary_condition::dirichlet);
 
   inline static term<P> const term_i3v =


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Removed some functions that look like `null_gfunc` and prevent the optimizations in #504 from occurring. Also saw a couple places where move semantics could eliminate memory allocations and copies.

This fixes #493.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [ ] Bugfix
- [x] New feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

ubuntu 20.04

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
