### PR TITLE
Replace null_scalar_func with nullptr

### DIFF
--- a/src/boundary_conditions.cpp
+++ b/src/boundary_conditions.cpp
@@ -136,13 +136,14 @@ fk::vector<P> generate_scaled_bc(unscaled_bc_parts<P> const &left_bc_parts,
         if (p_term.left_homo == homogeneity::inhomogeneous)
         {
           fm::axpy(left_bc_parts[term_num][dim_num][left_index++], bc,
-                   p_term.left_bc_time_func(time));
+                   p_term.left_bc_time_func ? p_term.left_bc_time_func(time)
+                                            : time);
         }
-
         if (p_term.right_homo == homogeneity::inhomogeneous)
         {
           fm::axpy(right_bc_parts[term_num][dim_num][right_index++], bc,
-                   p_term.right_bc_time_func(time));
+                   p_term.right_bc_time_func ? p_term.right_bc_time_func(time)
+                                             : time);
         }
       }
     }

--- a/src/coefficients.cpp
+++ b/src/coefficients.cpp
@@ -37,8 +37,8 @@ void generate_all_coefficients(
             coefficient_type::mass, partial_terms[k].lhs_mass_func, nullptr,
             flux_type::central, boundary_condition::periodic,
             boundary_condition::periodic, homogeneity::homogeneous,
-            homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-            partial_term<P>::null_scalar_func, dim.volume_jacobian_dV);
+            homogeneity::homogeneous, {}, nullptr, {}, nullptr,
+            dim.volume_jacobian_dV);
 
         auto mass_coeff = generate_coefficients<P>(
             dim, lhs_mass_pterm, transformer, pde.max_level, time, rotate);
@@ -78,9 +78,8 @@ void generate_dimension_mass_mat(
     partial_term<P> const lhs_mass_pterm = partial_term<P>(
         coefficient_type::mass, nullptr, nullptr, flux_type::central,
         boundary_condition::periodic, boundary_condition::periodic,
-        homogeneity::homogeneous, homogeneity::homogeneous, {},
-        partial_term<P>::null_scalar_func, {},
-        partial_term<P>::null_scalar_func, dim.volume_jacobian_dV);
+        homogeneity::homogeneous, homogeneity::homogeneous, {}, nullptr, {},
+        nullptr, dim.volume_jacobian_dV);
     auto mass_mat = generate_coefficients<P>(dim, lhs_mass_pterm, transformer,
                                              pde.max_level, 0.0, true);
 

--- a/src/pde/pde_advection1.hpp
+++ b/src/pde/pde_advection1.hpp
@@ -152,8 +152,8 @@ private:
       {bc_func},                     // left boundary condition function list
       bc_time_func,                  // left boundary time function
       {},                            // right boundary condition function list
-      partial_term<P>::null_scalar_func, // right boundary time function
-      nullptr                            // surface jacobian
+      nullptr,                       // right boundary time function
+      nullptr                        // surface jacobian
   );
 
   inline static term<P> term0_dim0_ =

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -106,8 +106,6 @@ template<typename P>
 class partial_term
 {
 public:
-  static P null_scalar_func(P const p) { return p; }
-
   static fk::vector<P> null_vector_func(fk::vector<P> x, P const t = 0)
   {
     ignore(t);
@@ -124,11 +122,11 @@ public:
                boundary_condition const right_in = boundary_condition::neumann,
                homogeneity const left_homo_in    = homogeneity::homogeneous,
                homogeneity const right_homo_in   = homogeneity::homogeneous,
-               std::vector<vector_func<P>> const left_bc_funcs_in = {},
-               scalar_func<P> const left_bc_time_func_in = null_scalar_func,
+               std::vector<vector_func<P>> const left_bc_funcs_in  = {},
+               scalar_func<P> const left_bc_time_func_in           = nullptr,
                std::vector<vector_func<P>> const right_bc_funcs_in = {},
-               scalar_func<P> const right_bc_time_func_in = null_scalar_func,
-               g_func_type<P> const dv_func_in            = nullptr)
+               scalar_func<P> const right_bc_time_func_in          = nullptr,
+               g_func_type<P> const dv_func_in                     = nullptr)
 
       : coeff_type(coeff_type_in), g_func(g_func_in),
         lhs_mass_func(lhs_mass_func_in), flux(set_flux(flux_in)), left(left_in),

--- a/src/pde/pde_diffusion1.hpp
+++ b/src/pde/pde_diffusion1.hpp
@@ -101,9 +101,8 @@ private:
   inline static const partial_term<P> partial_term_2 = partial_term<P>(
       coefficient_type::div, g3, nullptr, flux_type::downwind,
       boundary_condition::dirichlet, boundary_condition::dirichlet,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
-      nullptr);
+      homogeneity::homogeneous, homogeneity::homogeneous, {}, nullptr, {},
+      nullptr, nullptr);
 
   inline static term<P> const term_1 = term<P>(false, // time-dependent
                                                "",    // name
@@ -112,9 +111,8 @@ private:
   inline static const partial_term<P> partial_term_3 = partial_term<P>(
       coefficient_type::div, g4, nullptr, flux_type::central,
       boundary_condition::dirichlet, boundary_condition::dirichlet,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
-      nullptr);
+      homogeneity::homogeneous, homogeneity::homogeneous, {}, nullptr, {},
+      nullptr, nullptr);
 
   inline static term<P> const term_2 = term<P>(false, // time-dependent
                                                "",    // name

--- a/src/pde/pde_fokkerplanck1_4p3.hpp
+++ b/src/pde/pde_fokkerplanck1_4p3.hpp
@@ -139,9 +139,8 @@ private:
   inline static partial_term<P> const partial_term_0 = partial_term<P>(
       coefficient_type::div, g_func_1, nullptr, flux_type::downwind,
       boundary_condition::dirichlet, boundary_condition::dirichlet,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
-      dV_func);
+      homogeneity::homogeneous, homogeneity::homogeneous, {}, nullptr, {},
+      nullptr, dV_func);
 
   inline static term<P> const term0_dim0_ = term<P>(false,  // time-dependent
                                                     "d_dx", // name

--- a/src/pde/pde_fokkerplanck1_4p4.hpp
+++ b/src/pde/pde_fokkerplanck1_4p4.hpp
@@ -162,12 +162,11 @@ private:
   //
   // -E d/dz((1-z^2) f)
 
-  inline static partial_term<P> const partial_term_0 = partial_term<P>(
-      coefficient_type::div, g_func_t1_z, nullptr, flux_type::downwind,
-      boundary_condition::dirichlet, boundary_condition::dirichlet,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
-      dV_z);
+  inline static partial_term<P> const partial_term_0 =
+      partial_term<P>(coefficient_type::div, g_func_t1_z, nullptr,
+                      flux_type::downwind, boundary_condition::dirichlet,
+                      boundary_condition::dirichlet, homogeneity::homogeneous,
+                      homogeneity::homogeneous, {}, nullptr, {}, nullptr, dV_z);
 
   inline static term<P> const termE_z = term<P>(false,  // time-dependent
                                                 "d_dx", // name
@@ -178,19 +177,17 @@ private:
   // term 2
   //
   // +C * d/dz( (1-z^2) df/dz )
-  inline static partial_term<P> const partial_term_1 = partial_term<P>(
-      coefficient_type::div, nullptr, nullptr, flux_type::downwind,
-      boundary_condition::dirichlet, boundary_condition::dirichlet,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
-      dV_z);
+  inline static partial_term<P> const partial_term_1 =
+      partial_term<P>(coefficient_type::div, nullptr, nullptr,
+                      flux_type::downwind, boundary_condition::dirichlet,
+                      boundary_condition::dirichlet, homogeneity::homogeneous,
+                      homogeneity::homogeneous, {}, nullptr, {}, nullptr, dV_z);
 
-  inline static partial_term<P> const partial_term_2 = partial_term<P>(
-      coefficient_type::grad, nullptr, nullptr, flux_type::upwind,
-      boundary_condition::neumann, boundary_condition::neumann,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
-      dV_z);
+  inline static partial_term<P> const partial_term_2 =
+      partial_term<P>(coefficient_type::grad, nullptr, nullptr,
+                      flux_type::upwind, boundary_condition::neumann,
+                      boundary_condition::neumann, homogeneity::homogeneous,
+                      homogeneity::homogeneous, {}, nullptr, {}, nullptr, dV_z);
 
   inline static term<P> const termC_z =
       term<P>(false,  // time-dependent

--- a/src/pde/pde_fokkerplanck1_4p5.hpp
+++ b/src/pde/pde_fokkerplanck1_4p5.hpp
@@ -153,12 +153,11 @@ private:
     return sqrt(1.0 - std::pow(x, 2));
   }
 
-  inline static partial_term<P> const partial_term_0 = partial_term<P>(
-      coefficient_type::div, g_func_t1_z, nullptr, flux_type::downwind,
-      boundary_condition::dirichlet, boundary_condition::dirichlet,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
-      dV_z);
+  inline static partial_term<P> const partial_term_0 =
+      partial_term<P>(coefficient_type::div, g_func_t1_z, nullptr,
+                      flux_type::downwind, boundary_condition::dirichlet,
+                      boundary_condition::dirichlet, homogeneity::homogeneous,
+                      homogeneity::homogeneous, {}, nullptr, {}, nullptr, dV_z);
 
   inline static term<P> const termE_z = term<P>(false,  // time-dependent
                                                 "d_dx", // name
@@ -182,19 +181,17 @@ private:
     return 1 - std::pow(x, 2);
   }
 
-  inline static partial_term<P> const partial_term_1 = partial_term<P>(
-      coefficient_type::div, nullptr, nullptr, flux_type::downwind,
-      boundary_condition::dirichlet, boundary_condition::dirichlet,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
-      dV_z);
+  inline static partial_term<P> const partial_term_1 =
+      partial_term<P>(coefficient_type::div, nullptr, nullptr,
+                      flux_type::downwind, boundary_condition::dirichlet,
+                      boundary_condition::dirichlet, homogeneity::homogeneous,
+                      homogeneity::homogeneous, {}, nullptr, {}, nullptr, dV_z);
 
-  inline static partial_term<P> const partial_term_2 = partial_term<P>(
-      coefficient_type::grad, nullptr, nullptr, flux_type::upwind,
-      boundary_condition::neumann, boundary_condition::neumann,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
-      dV_z);
+  inline static partial_term<P> const partial_term_2 =
+      partial_term<P>(coefficient_type::grad, nullptr, nullptr,
+                      flux_type::upwind, boundary_condition::neumann,
+                      boundary_condition::neumann, homogeneity::homogeneous,
+                      homogeneity::homogeneous, {}, nullptr, {}, nullptr, dV_z);
 
   inline static term<P> const termC_z =
       term<P>(false,  // time-dependent
@@ -213,12 +210,11 @@ private:
     return -R * x * sqrt(1 - std::pow(x, 2));
   }
 
-  inline static partial_term<P> const partial_term_3 = partial_term<P>(
-      coefficient_type::div, g_func_t3_z, nullptr, flux_type::downwind,
-      boundary_condition::dirichlet, boundary_condition::dirichlet,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
-      dV_z);
+  inline static partial_term<P> const partial_term_3 =
+      partial_term<P>(coefficient_type::div, g_func_t3_z, nullptr,
+                      flux_type::downwind, boundary_condition::dirichlet,
+                      boundary_condition::dirichlet, homogeneity::homogeneous,
+                      homogeneity::homogeneous, {}, nullptr, {}, nullptr, dV_z);
 
   inline static term<P> const termR_z = term<P>(false,  // time-dependent
                                                 "d_dx", // name

--- a/src/pde/pde_fokkerplanck1_pitch_C.hpp
+++ b/src/pde/pde_fokkerplanck1_pitch_C.hpp
@@ -159,19 +159,17 @@ private:
   //    termC_z.BCL2 = 'N';
   //    termC_z.BCR2 = 'N';
 
-  inline static partial_term<P> const partial_term_0 = partial_term<P>(
-      coefficient_type::div, nullptr, nullptr, flux_type::downwind,
-      boundary_condition::dirichlet, boundary_condition::dirichlet,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
-      dV_z);
+  inline static partial_term<P> const partial_term_0 =
+      partial_term<P>(coefficient_type::div, nullptr, nullptr,
+                      flux_type::downwind, boundary_condition::dirichlet,
+                      boundary_condition::dirichlet, homogeneity::homogeneous,
+                      homogeneity::homogeneous, {}, nullptr, {}, nullptr, dV_z);
 
-  inline static partial_term<P> const partial_term_1 = partial_term<P>(
-      coefficient_type::grad, nullptr, nullptr, flux_type::upwind,
-      boundary_condition::neumann, boundary_condition::neumann,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
-      dV_z);
+  inline static partial_term<P> const partial_term_1 =
+      partial_term<P>(coefficient_type::grad, nullptr, nullptr,
+                      flux_type::upwind, boundary_condition::neumann,
+                      boundary_condition::neumann, homogeneity::homogeneous,
+                      homogeneity::homogeneous, {}, nullptr, {}, nullptr, dV_z);
 
   inline static term<P> const term0_dim0_ =
       term<P>(false,  // time-dependent

--- a/src/pde/pde_fokkerplanck1_pitch_E.hpp
+++ b/src/pde/pde_fokkerplanck1_pitch_E.hpp
@@ -159,12 +159,11 @@ private:
   // term2_z.G = @(z,p,t,dat) -1.*(1-z.^2); % G function for use in coeff_matrix
   // construction. term2_z.LF = -1; % Upwind term2_z.name = 'd_dz';
 
-  inline static partial_term<P> const partial_term_0 = partial_term<P>(
-      coefficient_type::div, g_func_1, nullptr, flux_type::downwind,
-      boundary_condition::neumann, boundary_condition::neumann,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
-      dV_z);
+  inline static partial_term<P> const partial_term_0 =
+      partial_term<P>(coefficient_type::div, g_func_1, nullptr,
+                      flux_type::downwind, boundary_condition::neumann,
+                      boundary_condition::neumann, homogeneity::homogeneous,
+                      homogeneity::homogeneous, {}, nullptr, {}, nullptr, dV_z);
 
   inline static term<P> const term0_dim0_ = term<P>(false,  // time-dependent
                                                     "d_dx", // name

--- a/src/pde/pde_fokkerplanck2_complete.hpp
+++ b/src/pde/pde_fokkerplanck2_complete.hpp
@@ -426,23 +426,21 @@ private:
   }
 
   // 1. create partial_terms
-  inline static partial_term<P> const c1_pterm1 = partial_term<P>(
-      coefficient_type::div, c1_g1, nullptr, flux_type::upwind,
-      boundary_condition::dirichlet, boundary_condition::neumann,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
-      dV_p);
-  inline static partial_term<P> const c1_pterm2 = partial_term<P>(
-      coefficient_type::grad, c1_g1, nullptr, flux_type::downwind,
-      boundary_condition::neumann, boundary_condition::dirichlet,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
-      dV_p);
-  inline static partial_term<P> const c1_pterm3 = partial_term<P>(
-      coefficient_type::mass, nullptr, nullptr, flux_type::central,
-      boundary_condition::neumann, boundary_condition::neumann,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func);
+  inline static partial_term<P> const c1_pterm1 =
+      partial_term<P>(coefficient_type::div, c1_g1, nullptr, flux_type::upwind,
+                      boundary_condition::dirichlet,
+                      boundary_condition::neumann, homogeneity::homogeneous,
+                      homogeneity::homogeneous, {}, nullptr, {}, nullptr, dV_p);
+  inline static partial_term<P> const c1_pterm2 =
+      partial_term<P>(coefficient_type::grad, c1_g1, nullptr,
+                      flux_type::downwind, boundary_condition::neumann,
+                      boundary_condition::dirichlet, homogeneity::homogeneous,
+                      homogeneity::homogeneous, {}, nullptr, {}, nullptr, dV_p);
+  inline static partial_term<P> const c1_pterm3 =
+      partial_term<P>(coefficient_type::mass, nullptr, nullptr,
+                      flux_type::central, boundary_condition::neumann,
+                      boundary_condition::neumann, homogeneity::homogeneous,
+                      homogeneity::homogeneous, {}, nullptr, {}, nullptr);
 
   // 2. combine partial terms into single dimension term
   inline static term<P> const c1_term_p = term<P>(false,  // time-dependent
@@ -469,17 +467,16 @@ private:
   }
 
   // 1. create partial_terms
-  inline static partial_term<P> const c2_pterm1 = partial_term<P>(
-      coefficient_type::div, c2_g1, nullptr, flux_type::downwind,
-      boundary_condition::neumann, boundary_condition::dirichlet,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
-      dV_p);
-  inline static partial_term<P> const c2_pterm2 = partial_term<P>(
-      coefficient_type::mass, nullptr, nullptr, flux_type::central,
-      boundary_condition::neumann, boundary_condition::neumann,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func);
+  inline static partial_term<P> const c2_pterm1 =
+      partial_term<P>(coefficient_type::div, c2_g1, nullptr,
+                      flux_type::downwind, boundary_condition::neumann,
+                      boundary_condition::dirichlet, homogeneity::homogeneous,
+                      homogeneity::homogeneous, {}, nullptr, {}, nullptr, dV_p);
+  inline static partial_term<P> const c2_pterm2 =
+      partial_term<P>(coefficient_type::mass, nullptr, nullptr,
+                      flux_type::central, boundary_condition::neumann,
+                      boundary_condition::neumann, homogeneity::homogeneous,
+                      homogeneity::homogeneous, {}, nullptr, {}, nullptr);
 
   // 2. combine partial terms into single dimension term
   inline static term<P> const c2_term_p = term<P>(false,  // time-dependent
@@ -511,23 +508,20 @@ private:
   inline static partial_term<P> const c3_pterm1 = partial_term<P>(
       coefficient_type::mass, c3_g1, nullptr, flux_type::central,
       boundary_condition::neumann, boundary_condition::neumann,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
-      dV_p3);
+      homogeneity::homogeneous, homogeneity::homogeneous, {}, nullptr, {},
+      nullptr, dV_p3);
 
   inline static partial_term<P> const c3_pterm2 = partial_term<P>(
       coefficient_type::div, nullptr, nullptr, flux_type::upwind,
       boundary_condition::dirichlet, boundary_condition::dirichlet,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
-      dV_z3);
+      homogeneity::homogeneous, homogeneity::homogeneous, {}, nullptr, {},
+      nullptr, dV_z3);
 
   inline static partial_term<P> const c3_pterm3 = partial_term<P>(
       coefficient_type::grad, nullptr, nullptr, flux_type::downwind,
       boundary_condition::neumann, boundary_condition::neumann,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
-      dV_z3);
+      homogeneity::homogeneous, homogeneity::homogeneous, {}, nullptr, {},
+      nullptr, dV_z3);
 
   // 2. combine partial terms into single dimension term
   inline static term<P> const c3_term_p = term<P>(false,  // time-dependent
@@ -565,17 +559,16 @@ private:
   }
 
   // 1. create partial_terms
-  inline static partial_term<P> const e1_pterm1 = partial_term<P>(
-      coefficient_type::div, e1_g1, nullptr, flux_type::downwind,
-      boundary_condition::dirichlet, boundary_condition::neumann,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
-      dV_p);
-  inline static partial_term<P> const e1_pterm2 = partial_term<P>(
-      coefficient_type::mass, e1_g2, nullptr, flux_type::central,
-      boundary_condition::neumann, boundary_condition::neumann,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func);
+  inline static partial_term<P> const e1_pterm1 =
+      partial_term<P>(coefficient_type::div, e1_g1, nullptr,
+                      flux_type::downwind, boundary_condition::dirichlet,
+                      boundary_condition::neumann, homogeneity::homogeneous,
+                      homogeneity::homogeneous, {}, nullptr, {}, nullptr, dV_p);
+  inline static partial_term<P> const e1_pterm2 =
+      partial_term<P>(coefficient_type::mass, e1_g2, nullptr,
+                      flux_type::central, boundary_condition::neumann,
+                      boundary_condition::neumann, homogeneity::homogeneous,
+                      homogeneity::homogeneous, {}, nullptr, {}, nullptr);
 
   // 2. combine partial terms into single dimension term
   inline static term<P> const e1_term_p = term<P>(false,  // time-dependent
@@ -610,18 +603,17 @@ private:
   }
 
   // 1. create partial_terms
-  inline static partial_term<P> const e2_pterm1 = partial_term<P>(
-      coefficient_type::div, e2_g1, nullptr, flux_type::upwind,
-      boundary_condition::neumann, boundary_condition::dirichlet,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
-      dV_p);
+  inline static partial_term<P> const e2_pterm1 =
+      partial_term<P>(coefficient_type::div, e2_g1, nullptr, flux_type::upwind,
+                      boundary_condition::neumann,
+                      boundary_condition::dirichlet, homogeneity::homogeneous,
+                      homogeneity::homogeneous, {}, nullptr, {}, nullptr, dV_p);
 
-  inline static partial_term<P> const e2_pterm2 = partial_term<P>(
-      coefficient_type::mass, e2_g2, nullptr, flux_type::central,
-      boundary_condition::neumann, boundary_condition::neumann,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func);
+  inline static partial_term<P> const e2_pterm2 =
+      partial_term<P>(coefficient_type::mass, e2_g2, nullptr,
+                      flux_type::central, boundary_condition::neumann,
+                      boundary_condition::neumann, homogeneity::homogeneous,
+                      homogeneity::homogeneous, {}, nullptr, {}, nullptr);
 
   // 2. combine partial terms into single dimension term
   inline static term<P> const e2_term_p = term<P>(false,  // time-dependent
@@ -644,15 +636,13 @@ private:
   inline static partial_term<P> const e3_pterm1 = partial_term<P>(
       coefficient_type::mass, nullptr, nullptr, flux_type::central,
       boundary_condition::neumann, boundary_condition::neumann,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
-      dV_p3);
+      homogeneity::homogeneous, homogeneity::homogeneous, {}, nullptr, {},
+      nullptr, dV_p3);
   inline static partial_term<P> const e3_pterm2 = partial_term<P>(
       coefficient_type::div, e3_g2, nullptr, flux_type::downwind,
       boundary_condition::neumann, boundary_condition::neumann,
-      homogeneity::homogeneous, homogeneity::homogeneous, {},
-      partial_term<P>::null_scalar_func, {}, partial_term<P>::null_scalar_func,
-      dV_z3);
+      homogeneity::homogeneous, homogeneity::homogeneous, {}, nullptr, {},
+      nullptr, dV_z3);
 
   // 2. combine partial terms into single dimension term
   inline static term<P> const e3_term_p = term<P>(false,  // time-dependent
@@ -694,14 +684,14 @@ private:
       coefficient_type::div, r1_g1, nullptr,
       flux_type::downwind, boundary_condition::neumann,
       boundary_condition::dirichlet, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_p);
+      homogeneity::homogeneous, {}, nullptr, {},
+      nullptr, dV_p);
   inline static partial_term<P> const r1_pterm2 = partial_term<P>(
       coefficient_type::mass, r1_g1, nullptr,
       flux_type::central, boundary_condition::neumann,
       boundary_condition::neumann, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func);
+      homogeneity::homogeneous, {}, nullptr, {},
+      nullptr);
 
   // 2. combine partial terms into single dimension term
   inline static term<P> const r1_term_p =
@@ -743,14 +733,14 @@ private:
       coefficient_type::mass, r2_g1, nullptr,
       flux_type::central, boundary_condition::neumann,
       boundary_condition::neumann, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_p3);
+      homogeneity::homogeneous, {}, nullptr, {},
+      nullptr, dV_p3);
   inline static partial_term<P> const r2_pterm2 = partial_term<P>(
       coefficient_type::div, r2_g2, nullptr,
       flux_type::downwind, boundary_condition::neumann,
       boundary_condition::neumann, homogeneity::homogeneous,
-      homogeneity::homogeneous, {}, partial_term<P>::null_scalar_func, {},
-      partial_term<P>::null_scalar_func, dV_z3);
+      homogeneity::homogeneous, {}, nullptr, {},
+      nullptr, dV_z3);
 
   // 2. combine partial terms into single dimension term
   inline static term<P> const r2_term_p =


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Doing the same for `null_scalar_func` as I did with `null_gfunc` in #504. This adds consistency and something shorter to type. 

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [ ] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

ubuntu 20.04

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
