### PR TITLE
Add collisional landau pde

### DIFF
--- a/src/coefficients.cpp
+++ b/src/coefficients.cpp
@@ -19,6 +19,7 @@ void generate_all_coefficients(
     PDE<P> &pde, basis::wavelet_transform<P, resource::host> const &transformer,
     P const time, bool const rotate)
 {
+  tools::timer.start("gen_coefficients");
   expect(time >= 0.0);
 
   for (auto i = 0; i < pde.num_dims; ++i)
@@ -65,6 +66,7 @@ void generate_all_coefficients(
     }
     pde.rechain_dimension(i);
   }
+  tools::timer.stop("gen_coefficients");
 }
 
 template<typename P>

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -82,6 +82,20 @@ void write_output(PDE<P> const &pde, fk::vector<P> const &vec, P const time,
   H5Easy::dump(file, "time", time);
   H5Easy::dump(file, "nodes", nodes.to_std());
   H5Easy::dump(file, "soln", vec.to_std(), opts);
+
+  // save E field
+  H5Easy::dump(file, "Efield", pde.E_field.to_std(), opts);
+
+  if (pde.moments.size() > 0)
+  {
+    // save realspace moments
+    H5Easy::dump(file, "nmoments", pde.moments.size());
+    for (size_t i = 0; i < pde.moments.size(); ++i)
+    {
+      H5Easy::dump(file, "moment" + std::to_string(i),
+                   pde.moments[i].get_realspace_moment().to_std(), opts);
+    }
+  }
 }
 
 } // namespace asgard

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -58,8 +58,8 @@ void update_output_file(HighFive::DataSet &dataset, fk::vector<P> const &vec,
 }
 
 template<typename P>
-void write_output(PDE<P> const &pde, fk::vector<P> const &vec, P const time,
-                  int const file_index,
+void write_output(PDE<P> const &pde, parser const &cli_input,
+                  fk::vector<P> const &vec, P const time, int const file_index,
                   std::string const output_dataset_name = "asgard")
 {
   std::string const output_file_name =
@@ -73,8 +73,12 @@ void write_output(PDE<P> const &pde, fk::vector<P> const &vec, P const time,
   H5Easy::DumpOptions opts;
   opts.setChunkSize(std::vector<hsize_t>{2});
 
+  H5Easy::dump(file, "pde", cli_input.get_pde_string());
+  H5Easy::dump(file, "degree", cli_input.get_degree());
+  H5Easy::dump(file, "dt", cli_input.get_dt());
   H5Easy::dump(file, "time", time);
-
+  H5Easy::dump(file, "ndims", pde.num_dims);
+  H5Easy::dump(file, "max_level", pde.max_level);
   auto const dims = pde.get_dimensions();
   for (size_t dim = 0; dim < dims.size(); ++dim)
   {
@@ -82,6 +86,12 @@ void write_output(PDE<P> const &pde, fk::vector<P> const &vec, P const time,
         gen_realspace_nodes(dims[dim].get_degree(), dims[dim].get_level(),
                             dims[dim].domain_min, dims[dim].domain_max);
     H5Easy::dump(file, "nodes" + std::to_string(dim), nodes.to_std());
+    H5Easy::dump(file, "dim" + std::to_string(dim) + "_level",
+                 dims[dim].get_level());
+    H5Easy::dump(file, "dim" + std::to_string(dim) + "_min",
+                 dims[dim].domain_min);
+    H5Easy::dump(file, "dim" + std::to_string(dim) + "_max",
+                 dims[dim].domain_max);
   }
 
   H5Easy::dump(file, "soln", vec.to_std(), opts);

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -109,6 +109,17 @@ void write_output(PDE<P> const &pde, parser const &cli_input,
                    pde.moments[i].get_realspace_moment().to_std(), opts);
     }
   }
+
+  // save gmres error and iteration counts
+  for (size_t i = 0; i < pde.gmres_outputs.size(); ++i)
+  {
+    H5Easy::dump(file, "gmres" + std::to_string(i) + "_err",
+                 pde.gmres_outputs[i].error, opts);
+    H5Easy::dump(file, "gmres" + std::to_string(i) + "_num_outer",
+                 pde.gmres_outputs[i].outer_iter, opts);
+    H5Easy::dump(file, "gmres" + std::to_string(i) + "_num_inner",
+                 pde.gmres_outputs[i].inner_iter, opts);
+  }
 }
 
 } // namespace asgard

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -321,11 +321,13 @@ int main(int argc, char **argv)
 #ifdef ASGARD_IO_HIGHFIVE
     if (opts.should_output_wavelet(i))
     {
-      asgard::write_output(*pde, f_val, time, i + 1, "asgard_wavelet");
+      asgard::write_output(*pde, cli_input, f_val, time, i + 1,
+                           "asgard_wavelet");
     }
     if (opts.should_output_realspace(i))
     {
-      asgard::write_output(*pde, real_space, time, i + 1, "asgard_real");
+      asgard::write_output(*pde, cli_input, real_space, time, i + 1,
+                           "asgard_real");
     }
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -213,12 +213,12 @@ int main(int argc, char **argv)
 #ifdef ASGARD_IO_HIGHFIVE
   if (cli_input.get_wavelet_output_freq() > 0)
   {
-    asgard::write_output(*pde, initial_condition, static_cast<prec>(0.0), 0,
-                         "asgard_wavelet");
+    asgard::write_output(*pde, cli_input, initial_condition,
+                         static_cast<prec>(0.0), 0, "asgard_wavelet");
   }
   if (cli_input.get_realspace_output_freq() > 0)
   {
-    asgard::write_output(*pde, real_space, static_cast<prec>(0.0), 0,
+    asgard::write_output(*pde, cli_input, real_space, static_cast<prec>(0.0), 0,
                          "asgard_real");
   }
 #endif

--- a/src/matlab_utilities.cpp
+++ b/src/matlab_utilities.cpp
@@ -475,6 +475,7 @@ template<typename P>
 fk::vector<P> interp1(fk::vector<P> const &sample, fk::vector<P> const &values,
                       fk::vector<P> const &coords)
 {
+  tools::timer.start("interp1");
   // nearest neighbor 1D interpolation with extrapolation
   // equivalent to matlab's interp1(sample, values, coords, 'nearest', 'extrap')
   expect(sample.size() == values.size());
@@ -508,6 +509,7 @@ fk::vector<P> interp1(fk::vector<P> const &sample, fk::vector<P> const &values,
     interpolated(i) = values[min_ind];
   }
 
+  tools::timer.stop("interp1");
   return interpolated;
 }
 

--- a/src/moment.cpp
+++ b/src/moment.cpp
@@ -203,7 +203,7 @@ void moment<P>::createMomentReducedMatrix_nd(PDE<P> const &pde,
 }
 
 template<typename P>
-fk::vector<P> const &moment<P>::create_realspace_moment(
+fk::vector<P> &moment<P>::create_realspace_moment(
     PDE<P> const &pde_1d, fk::vector<P> &wave, elements::table const &table,
     basis::wavelet_transform<P, resource::host> const &transformer,
     std::array<fk::vector<P, mem_type::view, resource::host>, 2> &workspace)

--- a/src/moment.cpp
+++ b/src/moment.cpp
@@ -1,4 +1,5 @@
 #include "moment.hpp"
+#include "basis.hpp"
 #include "elements.hpp"
 #include "transformations.hpp"
 
@@ -199,6 +200,18 @@ void moment<P>::createMomentReducedMatrix_nd(PDE<P> const &pde,
       }
     }
   }
+}
+
+template<typename P>
+fk::vector<P> const &moment<P>::create_realspace_moment(
+    PDE<P> const &pde_1d, fk::vector<P> &wave, elements::table const &table,
+    basis::wavelet_transform<P, resource::host> const &transformer,
+    std::array<fk::vector<P, mem_type::view, resource::host>, 2> &workspace)
+{
+  this->realspace.resize(wave.size());
+  wavelet_to_realspace<P>(pde_1d, wave, table, transformer, workspace,
+                          this->realspace);
+  return this->realspace;
 }
 
 template class moment<float>;

--- a/src/moment.hpp
+++ b/src/moment.hpp
@@ -48,7 +48,7 @@ public:
 
   fk::vector<P> const &get_realspace_moment() const { return realspace; }
 
-  fk::vector<P> const &create_realspace_moment(
+  fk::vector<P> &create_realspace_moment(
       PDE<P> const &pde_1d, fk::vector<P> &wave, elements::table const &table,
       asgard::basis::wavelet_transform<P, resource::host> const &transformer,
       std::array<fk::vector<P, mem_type::view, resource::host>, 2> &workspace);

--- a/src/moment.hpp
+++ b/src/moment.hpp
@@ -6,6 +6,7 @@ template<typename P>
 class PDE;
 }
 
+#include "basis.hpp"
 #include "elements.hpp"
 #include "pde/pde_base.hpp"
 #include "program_options.hpp"
@@ -17,6 +18,12 @@ namespace asgard
 namespace elements
 {
 class table;
+}
+
+namespace basis
+{
+template<typename P, resource resrc>
+class wavelet_transform;
 }
 
 template<typename P>
@@ -39,6 +46,13 @@ public:
   void createMomentReducedMatrix(PDE<P> const &pde,
                                  elements::table const &hash_table);
 
+  fk::vector<P> const &get_realspace_moment() const { return realspace; }
+
+  fk::vector<P> const &create_realspace_moment(
+      PDE<P> const &pde_1d, fk::vector<P> &wave, elements::table const &table,
+      asgard::basis::wavelet_transform<P, resource::host> const &transformer,
+      std::array<fk::vector<P, mem_type::view, resource::host>, 2> &workspace);
+
 private:
   template<int nvdim>
   void createMomentReducedMatrix_nd(PDE<P> const &pde,
@@ -48,6 +62,7 @@ private:
   std::vector<std::vector<fk::vector<P>>> fList;
   fk::vector<P> vector;
   fk::matrix<P> moment_matrix;
+  fk::vector<P> realspace;
   // moment_fval_integral;
   // moment_analytic_integral;
 };

--- a/src/pde.hpp
+++ b/src/pde.hpp
@@ -15,6 +15,7 @@
 #include "pde/pde_base.hpp"
 
 #include "pde/pde_advection1.hpp"
+#include "pde/pde_collisional_landau.hpp"
 #include "pde/pde_continuity1.hpp"
 #include "pde/pde_continuity2.hpp"
 #include "pde/pde_continuity3.hpp"
@@ -96,6 +97,8 @@ std::unique_ptr<PDE<P>> make_PDE(parser const &cli_input)
     return std::make_unique<PDE_vlasov_lb<P>>(cli_input);
   case PDE_opts::vlasov_two_stream:
     return std::make_unique<PDE_vlasov_two_stream<P>>(cli_input);
+  case PDE_opts::collisional_landau:
+    return std::make_unique<PDE_collisional_landau<P>>(cli_input);
   default:
     std::cout << "Invalid pde choice" << std::endl;
     exit(-1);
@@ -184,6 +187,9 @@ make_PDE(PDE_opts const pde_choice, int const level = parser::NO_USER_VALUE,
       return fk::vector<int>(std::vector<int>(2, level));
 
     case PDE_opts::vlasov_two_stream:
+      return fk::vector<int>(std::vector<int>(2, level));
+
+    case PDE_opts::collisional_landau:
       return fk::vector<int>(std::vector<int>(2, level));
 
     default:

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -91,6 +91,14 @@ enum class imex_flag
   imex_implicit,
 };
 
+template<typename P>
+struct gmres_info
+{
+  P error;
+  int outer_iter;
+  int inner_iter;
+};
+
 // ---------------------------------------------------------------------------
 //
 // Term: describes a single term in the pde for operator matrix
@@ -635,6 +643,8 @@ public:
           "Invalid PDE choice for IMEX time advance. PDE must have "
           "moments defined to use -x\n");
     }
+
+    gmres_outputs.resize(cli_input.using_imex() ? 2 : 1);
   }
 
   constexpr static int extract_dim0 = 1;
@@ -672,6 +682,8 @@ public:
   fk::vector<P> poisson_off_diag;
 
   fk::vector<P> E_field;
+  // holds gmres error and iteration counts for writing to output file
+  std::vector<gmres_info<P>> gmres_outputs;
 
   virtual ~PDE() {}
 

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -671,6 +671,8 @@ public:
   fk::vector<P> poisson_diag;
   fk::vector<P> poisson_off_diag;
 
+  fk::vector<P> E_field;
+
   virtual ~PDE() {}
 
   std::vector<dimension<P>> const &get_dimensions() const

--- a/src/pde/pde_collisional_landau.hpp
+++ b/src/pde/pde_collisional_landau.hpp
@@ -37,7 +37,9 @@ private:
   static bool constexpr has_analytic_soln_     = false;
   static int constexpr default_degree          = 3;
 
-  static P constexpr nu = 1.0; // collision frequency
+  static P constexpr nu       = 1.0;    // collision frequency
+  static P constexpr A        = 1.0e-4; // amplitude
+  static P constexpr theta_in = 1.0;
 
   static fk::vector<P>
   initial_condition_dim_x_0(fk::vector<P> const &x, P const t = 0)
@@ -45,7 +47,7 @@ private:
     ignore(t);
     fk::vector<P> fx(x.size());
     std::transform(x.begin(), x.end(), fx.begin(), [](P const x_v) -> P {
-      return 1.0 + 1.0e-4 * std::cos(0.5 * x_v);
+      return 1.0 + A * std::cos(0.5 * x_v);
     });
     return fx;
   }
@@ -55,13 +57,14 @@ private:
   {
     ignore(t);
 
-    P const coefficient = 1.0 / std::sqrt(2.0 * PI);
+    P const coefficient = 1.0 / std::sqrt(2.0 * PI * theta_in);
 
     fk::vector<P> fx(x.size());
-    std::transform(x.begin(), x.end(), fx.begin(),
-                   [coefficient](P const x_v) -> P {
-                     return coefficient * std::exp(-0.5 * std::pow(x_v, 2));
-                   });
+    std::transform(
+        x.begin(), x.end(), fx.begin(), [coefficient](P const x_v) -> P {
+          return coefficient *
+                 std::exp(-0.5 * (1.0 / theta_in) * std::pow(x_v, 2));
+        });
     return fx;
   }
 
@@ -126,7 +129,7 @@ private:
   {
     ignore(t);
 
-    return (1.0 + 1.0e-4 * std::cos(0.5 * x));
+    return (1.0 + A * std::cos(0.5 * x));
   }
 
   static P u(P const &x, P const t = 0)
@@ -478,7 +481,7 @@ private:
   inline static term<P> const term_i3v =
       term<P>(false,  // time-dependent
               "I3_v", // name
-              {i3_pterm_v1, i3_pterm_v2}, imex_flag::imex_explicit);
+              {i3_pterm_v1, i3_pterm_v2}, imex_flag::imex_implicit);
 
   inline static std::vector<term<P>> const terms_8 = {term_i3x, term_i3v};
 

--- a/src/pde/pde_collisional_landau.hpp
+++ b/src/pde/pde_collisional_landau.hpp
@@ -188,15 +188,13 @@ private:
     return (x > 0.0) ? x : 0.0;
   }
 
-  inline static const partial_term<P> e1_pterm_x =
-      partial_term<P>(coefficient_type::div, e1_g1, partial_term<P>::null_gfunc,
-                      flux_type::downwind, boundary_condition::periodic,
-                      boundary_condition::periodic);
+  inline static const partial_term<P> e1_pterm_x = partial_term<P>(
+      coefficient_type::div, e1_g1, nullptr, flux_type::downwind,
+      boundary_condition::periodic, boundary_condition::periodic);
 
   inline static const partial_term<P> e1_pterm_v = partial_term<P>(
-      coefficient_type::mass, e1_g2, partial_term<P>::null_gfunc,
-      flux_type::central, boundary_condition::periodic,
-      boundary_condition::periodic);
+      coefficient_type::mass, e1_g2, nullptr, flux_type::central,
+      boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const term_e1x =
       term<P>(false,  // time-dependent
@@ -226,15 +224,13 @@ private:
     return (x < 0.0) ? x : 0.0;
   }
 
-  inline static const partial_term<P> e2_pterm_x =
-      partial_term<P>(coefficient_type::div, e2_g1, partial_term<P>::null_gfunc,
-                      flux_type::upwind, boundary_condition::periodic,
-                      boundary_condition::periodic);
+  inline static const partial_term<P> e2_pterm_x = partial_term<P>(
+      coefficient_type::div, e2_g1, nullptr, flux_type::upwind,
+      boundary_condition::periodic, boundary_condition::periodic);
 
   inline static const partial_term<P> e2_pterm_v = partial_term<P>(
-      coefficient_type::mass, e2_g2, partial_term<P>::null_gfunc,
-      flux_type::central, boundary_condition::periodic,
-      boundary_condition::periodic);
+      coefficient_type::mass, e2_g2, nullptr, flux_type::central,
+      boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const term_e2x =
       term<P>(false,  // time-dependent
@@ -267,9 +263,8 @@ private:
   }
 
   inline static const partial_term<P> pterm_E_mass_x = partial_term<P>(
-      coefficient_type::mass, E_func, partial_term<P>::null_gfunc,
-      flux_type::central, boundary_condition::periodic,
-      boundary_condition::periodic);
+      coefficient_type::mass, E_func, nullptr, flux_type::central,
+      boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const E_mass_x =
       term<P>(true, // time-dependent
@@ -277,10 +272,9 @@ private:
               {pterm_E_mass_x}, imex_flag::imex_explicit);
 
   inline static const partial_term<P> pterm_div_v = partial_term<P>(
-      coefficient_type::div, negOne, partial_term<P>::null_gfunc,
-      flux_type::central, boundary_condition::dirichlet,
-      boundary_condition::dirichlet, homogeneity::homogeneous,
-      homogeneity::homogeneous);
+      coefficient_type::div, negOne, nullptr, flux_type::central,
+      boundary_condition::dirichlet, boundary_condition::dirichlet,
+      homogeneity::homogeneous, homogeneity::homogeneous);
 
   inline static term<P> const div_v =
       term<P>(false, // time-dependent
@@ -308,9 +302,8 @@ private:
   }
 
   inline static const partial_term<P> pterm_MaxAbsE_mass_x = partial_term<P>(
-      coefficient_type::mass, MaxAbsE_func, partial_term<P>::null_gfunc,
-      flux_type::central, boundary_condition::periodic,
-      boundary_condition::periodic);
+      coefficient_type::mass, MaxAbsE_func, nullptr, flux_type::central,
+      boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const MaxAbsE_mass_x_1 =
       term<P>(true, // time-dependent
@@ -323,10 +316,9 @@ private:
               {pterm_MaxAbsE_mass_x}, imex_flag::imex_explicit);
 
   inline static const partial_term<P> pterm_div_v_downwind = partial_term<P>(
-      coefficient_type::div, posOne, partial_term<P>::null_gfunc,
-      flux_type::downwind, boundary_condition::dirichlet,
-      boundary_condition::dirichlet, homogeneity::homogeneous,
-      homogeneity::homogeneous);
+      coefficient_type::div, posOne, nullptr, flux_type::downwind,
+      boundary_condition::dirichlet, boundary_condition::dirichlet,
+      homogeneity::homogeneous, homogeneity::homogeneous);
 
   inline static term<P> const div_v_downwind =
       term<P>(false, // time-dependent
@@ -358,14 +350,12 @@ private:
     return x;
   }
   inline static const partial_term<P> i1_pterm_x = partial_term<P>(
-      coefficient_type::mass, i1_g1, partial_term<P>::null_gfunc,
-      flux_type::central, boundary_condition::periodic,
-      boundary_condition::periodic);
+      coefficient_type::mass, i1_g1, nullptr, flux_type::central,
+      boundary_condition::periodic, boundary_condition::periodic);
 
-  inline static const partial_term<P> i1_pterm_v =
-      partial_term<P>(coefficient_type::div, i1_g2, partial_term<P>::null_gfunc,
-                      flux_type::downwind, boundary_condition::dirichlet,
-                      boundary_condition::dirichlet);
+  inline static const partial_term<P> i1_pterm_v = partial_term<P>(
+      coefficient_type::div, i1_g2, nullptr, flux_type::downwind,
+      boundary_condition::dirichlet, boundary_condition::dirichlet);
 
   inline static term<P> const term_i1x =
       term<P>(false,  // time-dependent
@@ -397,14 +387,12 @@ private:
   }
 
   inline static const partial_term<P> i2_pterm_x = partial_term<P>(
-      coefficient_type::mass, i2_g1, partial_term<P>::null_gfunc,
-      flux_type::central, boundary_condition::periodic,
-      boundary_condition::periodic);
+      coefficient_type::mass, i2_g1, nullptr, flux_type::central,
+      boundary_condition::periodic, boundary_condition::periodic);
 
-  inline static const partial_term<P> i2_pterm_v =
-      partial_term<P>(coefficient_type::div, i2_g2, partial_term<P>::null_gfunc,
-                      flux_type::central, boundary_condition::dirichlet,
-                      boundary_condition::dirichlet);
+  inline static const partial_term<P> i2_pterm_v = partial_term<P>(
+      coefficient_type::div, i2_g2, nullptr, flux_type::central,
+      boundary_condition::dirichlet, boundary_condition::dirichlet);
 
   inline static term<P> const term_i2x =
       term<P>(false,  // time-dependent
@@ -440,14 +428,12 @@ private:
   }
 
   inline static const partial_term<P> i3_pterm_x1 = partial_term<P>(
-      coefficient_type::mass, i3_g1, partial_term<P>::null_gfunc,
-      flux_type::central, boundary_condition::periodic,
-      boundary_condition::periodic);
+      coefficient_type::mass, i3_g1, nullptr, flux_type::central,
+      boundary_condition::periodic, boundary_condition::periodic);
 
   inline static const partial_term<P> i3_pterm_x2 = partial_term<P>(
-      coefficient_type::mass, i3_g2, partial_term<P>::null_gfunc,
-      flux_type::central, boundary_condition::periodic,
-      boundary_condition::periodic);
+      coefficient_type::mass, i3_g2, nullptr, flux_type::central,
+      boundary_condition::periodic, boundary_condition::periodic);
 
   inline static term<P> const term_i3x =
       term<P>(false,  // time-dependent
@@ -468,15 +454,13 @@ private:
     return 1.0;
   }
 
-  inline static const partial_term<P> i3_pterm_v1 =
-      partial_term<P>(coefficient_type::div, i3_g3, partial_term<P>::null_gfunc,
-                      flux_type::central, boundary_condition::dirichlet,
-                      boundary_condition::dirichlet);
+  inline static const partial_term<P> i3_pterm_v1 = partial_term<P>(
+      coefficient_type::div, i3_g3, nullptr, flux_type::central,
+      boundary_condition::dirichlet, boundary_condition::dirichlet);
 
   inline static const partial_term<P> i3_pterm_v2 = partial_term<P>(
-      coefficient_type::grad, i3_g4, partial_term<P>::null_gfunc,
-      flux_type::central, boundary_condition::dirichlet,
-      boundary_condition::dirichlet);
+      coefficient_type::grad, i3_g4, nullptr, flux_type::central,
+      boundary_condition::dirichlet, boundary_condition::dirichlet);
 
   inline static term<P> const term_i3v =
       term<P>(false,  // time-dependent

--- a/src/pde/pde_collisional_landau.hpp
+++ b/src/pde/pde_collisional_landau.hpp
@@ -1,0 +1,508 @@
+#pragma once
+#include "pde_base.hpp"
+
+namespace asgard
+{
+// 2D collisional landau, i.e.,
+//
+//  df/dt == -v*\grad_x f -E\grad_v f + div_v( (v-u)f + theta\grad_v f)
+//
+//  BC is peridoic in x
+//  BC in v is all inflow in advection for v and Neumann for diffusion in v
+
+template<typename P>
+class PDE_collisional_landau : public PDE<P>
+{
+public:
+  PDE_collisional_landau(parser const &cli_input)
+      : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
+               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               get_dt_, do_poisson_solve_, has_analytic_soln_, moments_,
+               do_collision_operator_)
+  {
+    param_manager.add_parameter(parameter<P>{"n", n});
+    param_manager.add_parameter(parameter<P>{"u", u});
+    param_manager.add_parameter(parameter<P>{"theta", theta});
+    param_manager.add_parameter(parameter<P>{"E", E});
+    param_manager.add_parameter(parameter<P>{"S", S});
+    param_manager.add_parameter(parameter<P>{"MaxAbsE", MaxAbsE});
+  }
+
+private:
+  static int constexpr num_dims_               = 2;
+  static int constexpr num_sources_            = 0;
+  static int constexpr num_terms_              = 6;
+  static bool constexpr do_poisson_solve_      = true;
+  static bool constexpr do_collision_operator_ = true;
+  static bool constexpr has_analytic_soln_     = false;
+  static int constexpr default_degree          = 3;
+
+  static P constexpr nu = 1.0; // collision frequency
+
+  static fk::vector<P>
+  initial_condition_dim_x_0(fk::vector<P> const &x, P const t = 0)
+  {
+    ignore(t);
+    fk::vector<P> fx(x.size());
+    std::transform(x.begin(), x.end(), fx.begin(), [](P const x_v) -> P {
+      return 1.0 + 1.0e-4 * std::cos(0.5 * x_v);
+    });
+    return fx;
+  }
+
+  static fk::vector<P>
+  initial_condition_dim_v_0(fk::vector<P> const &x, P const t = 0)
+  {
+    ignore(t);
+
+    P const coefficient = 1.0 / std::sqrt(2.0 * PI);
+
+    fk::vector<P> fx(x.size());
+    std::transform(x.begin(), x.end(), fx.begin(),
+                   [coefficient](P const x_v) -> P {
+                     return coefficient * std::exp(-0.5 * std::pow(x_v, 2));
+                   });
+    return fx;
+  }
+
+  static P dV(P const x, P const time)
+  {
+    ignore(x);
+    ignore(time);
+    return 1.0;
+  }
+
+  /* Define the dimension */
+  inline static dimension<P> const dim_0 =
+      dimension<P>(-2.0 * PI, 2.0 * PI, 4, default_degree,
+                   initial_condition_dim_x_0, dV, "x");
+
+  inline static dimension<P> const dim_1 = dimension<P>(
+      -6.0, 6.0, 3, default_degree, initial_condition_dim_v_0, dV, "v");
+
+  inline static std::vector<dimension<P>> const dimensions_ = {dim_0, dim_1};
+
+  /* Define the moments */
+  static fk::vector<P> moment0_f1(fk::vector<P> const &x, P const t = 0)
+  {
+    ignore(t);
+
+    fk::vector<P> f(x.size());
+    std::fill(f.begin(), f.end(), 1.0);
+    return f;
+  }
+
+  static fk::vector<P> moment1_f1(fk::vector<P> const &x, P const t = 0)
+  {
+    ignore(t);
+    return fk::vector<P>(x);
+  }
+
+  static fk::vector<P> moment2_f1(fk::vector<P> const &x, P const t = 0)
+  {
+    ignore(t);
+
+    fk::vector<P> f(x.size());
+    std::transform(x.begin(), x.end(), f.begin(),
+                   [](P const &x_v) -> P { return std::pow(x_v, 2); });
+    return f;
+  }
+
+  inline static moment<P> const moment0 = moment<P>(
+      std::vector<md_func_type<P>>({{moment0_f1, moment0_f1, moment0_f1}}));
+  inline static moment<P> const moment1 = moment<P>(
+      std::vector<md_func_type<P>>({{moment0_f1, moment1_f1, moment0_f1}}));
+  inline static moment<P> const moment2 = moment<P>(
+      std::vector<md_func_type<P>>({{moment0_f1, moment2_f1, moment0_f1}}));
+
+  inline static std::vector<moment<P>> const moments_ = {moment0, moment1,
+                                                         moment2};
+
+  /* Construct (n, u, theta) */
+  // n = density
+  // u = bulk velocity
+  // theta = temperature
+  static P n(P const &x, P const t = 0)
+  {
+    ignore(t);
+
+    return (1.0 + 1.0e-4 * std::cos(0.5 * x));
+  }
+
+  static P u(P const &x, P const t = 0)
+  {
+    ignore(t);
+    ignore(x);
+    return 0.0;
+  }
+
+  static P theta(P const &x, P const t = 0)
+  {
+    ignore(t);
+    ignore(x);
+    return 1.0;
+  }
+
+  // E = -d_x phi
+  static P E(P const &x, P const t = 0)
+  {
+    ignore(t);
+    ignore(x);
+    return 0.0;
+  }
+
+  // source for poisson problem is -d_xx phi = n - 1 = S(n)
+  static P S(P const &y, P const t = 0)
+  {
+    ignore(t);
+    // subtracts quadrature values by one
+    return y - 1.0;
+  }
+
+  // holds the maximum absolute value of E
+  static P MaxAbsE(P const &x, P const t = 0)
+  {
+    ignore(t);
+    ignore(x);
+    return 0.0;
+  }
+
+  /* build the terms */
+
+  // Term 1
+  // -v\cdot\grad_x f for v > 0
+  //
+  static P e1_g1(P const x, P const time = 0)
+  {
+    ignore(x);
+    ignore(time);
+    return -1.0;
+  }
+
+  static P e1_g2(P const x, P const time = 0)
+  {
+    ignore(time);
+    return (x > 0.0) ? x : 0.0;
+  }
+
+  inline static const partial_term<P> e1_pterm_x =
+      partial_term<P>(coefficient_type::div, e1_g1, partial_term<P>::null_gfunc,
+                      flux_type::downwind, boundary_condition::periodic,
+                      boundary_condition::periodic);
+
+  inline static const partial_term<P> e1_pterm_v = partial_term<P>(
+      coefficient_type::mass, e1_g2, partial_term<P>::null_gfunc,
+      flux_type::central, boundary_condition::periodic,
+      boundary_condition::periodic);
+
+  inline static term<P> const term_e1x =
+      term<P>(false,  // time-dependent
+              "E1_x", // name
+              {e1_pterm_x}, imex_flag::imex_explicit);
+
+  inline static term<P> const term_e1v =
+      term<P>(false,  // time-dependent
+              "E1_v", // name
+              {e1_pterm_v}, imex_flag::imex_explicit);
+
+  inline static std::vector<term<P>> const terms_1 = {term_e1x, term_e1v};
+
+  // Term 2
+  // -v\cdot\grad_x f for v < 0
+  //
+  static P e2_g1(P const x, P const time = 0)
+  {
+    ignore(x);
+    ignore(time);
+    return -1.0;
+  }
+
+  static P e2_g2(P const x, P const time = 0)
+  {
+    ignore(time);
+    return (x < 0.0) ? x : 0.0;
+  }
+
+  inline static const partial_term<P> e2_pterm_x =
+      partial_term<P>(coefficient_type::div, e2_g1, partial_term<P>::null_gfunc,
+                      flux_type::upwind, boundary_condition::periodic,
+                      boundary_condition::periodic);
+
+  inline static const partial_term<P> e2_pterm_v = partial_term<P>(
+      coefficient_type::mass, e2_g2, partial_term<P>::null_gfunc,
+      flux_type::central, boundary_condition::periodic,
+      boundary_condition::periodic);
+
+  inline static term<P> const term_e2x =
+      term<P>(false,  // time-dependent
+              "E2_x", // name
+              {e2_pterm_x}, imex_flag::imex_explicit);
+
+  inline static term<P> const term_e2v =
+      term<P>(false,  // time-dependent
+              "E2_v", // name
+              {e2_pterm_v}, imex_flag::imex_explicit);
+
+  inline static std::vector<term<P>> const terms_2 = {term_e2x, term_e2v};
+
+  // Term 3
+  // Central Part of E\cdot\grad_v f
+  //
+
+  static P E_func(P const x, P const time = 0)
+  {
+    auto param = param_manager.get_parameter("E");
+    expect(param != nullptr);
+    return param->value(x, time);
+  }
+
+  static P negOne(P const x, P const time = 0)
+  {
+    ignore(x);
+    ignore(time);
+    return -1.0;
+  }
+
+  inline static const partial_term<P> pterm_E_mass_x = partial_term<P>(
+      coefficient_type::mass, E_func, partial_term<P>::null_gfunc,
+      flux_type::central, boundary_condition::periodic,
+      boundary_condition::periodic);
+
+  inline static term<P> const E_mass_x =
+      term<P>(true, // time-dependent
+              "",   // name
+              {pterm_E_mass_x}, imex_flag::imex_explicit);
+
+  inline static const partial_term<P> pterm_div_v = partial_term<P>(
+      coefficient_type::div, negOne, partial_term<P>::null_gfunc,
+      flux_type::central, boundary_condition::dirichlet,
+      boundary_condition::dirichlet, homogeneity::homogeneous,
+      homogeneity::homogeneous);
+
+  inline static term<P> const div_v =
+      term<P>(false, // time-dependent
+              "",    // name
+              {pterm_div_v}, imex_flag::imex_explicit);
+
+  inline static std::vector<term<P>> const terms_3 = {E_mass_x, div_v};
+
+  // Term 4 + 5
+  // Penalty Part of E\cdot\grad_v f
+  //
+
+  static P MaxAbsE_func(P const x, P const time = 0)
+  {
+    auto param = param_manager.get_parameter("MaxAbsE");
+    expect(param != nullptr);
+    return param->value(x, time);
+  }
+
+  static P posOne(P const x, P const time = 0)
+  {
+    ignore(x);
+    ignore(time);
+    return 1.0;
+  }
+
+  inline static const partial_term<P> pterm_MaxAbsE_mass_x = partial_term<P>(
+      coefficient_type::mass, MaxAbsE_func, partial_term<P>::null_gfunc,
+      flux_type::central, boundary_condition::periodic,
+      boundary_condition::periodic);
+
+  inline static term<P> const MaxAbsE_mass_x_1 =
+      term<P>(true, // time-dependent
+              "",   // name
+              {pterm_MaxAbsE_mass_x}, imex_flag::imex_explicit);
+
+  inline static term<P> const MaxAbsE_mass_x_2 =
+      term<P>(true, // time-dependent
+              "",   // name
+              {pterm_MaxAbsE_mass_x}, imex_flag::imex_explicit);
+
+  inline static const partial_term<P> pterm_div_v_downwind = partial_term<P>(
+      coefficient_type::div, posOne, partial_term<P>::null_gfunc,
+      flux_type::downwind, boundary_condition::dirichlet,
+      boundary_condition::dirichlet, homogeneity::homogeneous,
+      homogeneity::homogeneous);
+
+  inline static term<P> const div_v_downwind =
+      term<P>(false, // time-dependent
+              "",    // name
+              {pterm_div_v_downwind}, imex_flag::imex_explicit);
+
+  // Central Part Defined Above (div_v; can do this due to time independence)
+
+  inline static std::vector<term<P>> const terms_4 = {MaxAbsE_mass_x_1,
+                                                      div_v_downwind};
+
+  inline static std::vector<term<P>> const terms_5 = {MaxAbsE_mass_x_2, div_v};
+
+  // Terms 3 - 5 from vlasov_lb_full_f PDE:
+
+  // Term 3
+  // v\cdot\grad_v f
+  //
+  static P i1_g1(P const x, P const time = 0)
+  {
+    ignore(x);
+    ignore(time);
+    return nu;
+  }
+
+  static P i1_g2(P const x, P const time = 0)
+  {
+    ignore(time);
+    return x;
+  }
+  inline static const partial_term<P> i1_pterm_x = partial_term<P>(
+      coefficient_type::mass, i1_g1, partial_term<P>::null_gfunc,
+      flux_type::central, boundary_condition::periodic,
+      boundary_condition::periodic);
+
+  inline static const partial_term<P> i1_pterm_v =
+      partial_term<P>(coefficient_type::div, i1_g2, partial_term<P>::null_gfunc,
+                      flux_type::downwind, boundary_condition::dirichlet,
+                      boundary_condition::dirichlet);
+
+  inline static term<P> const term_i1x =
+      term<P>(false,  // time-dependent
+              "I1_x", // name
+              {i1_pterm_x}, imex_flag::imex_implicit);
+
+  inline static term<P> const term_i1v =
+      term<P>(false,  // time-dependent
+              "I1_v", // name
+              {i1_pterm_v}, imex_flag::imex_implicit);
+
+  inline static std::vector<term<P>> const terms_6 = {term_i1x, term_i1v};
+
+  // Term 4
+  // -u\cdot\grad_v f
+  //
+  static P i2_g1(P const x, P const time = 0)
+  {
+    auto param = param_manager.get_parameter("u");
+    expect(param != nullptr);
+    return -param->value(x, time);
+  }
+
+  static P i2_g2(P const x, P const time = 0)
+  {
+    ignore(x);
+    ignore(time);
+    return nu;
+  }
+
+  inline static const partial_term<P> i2_pterm_x = partial_term<P>(
+      coefficient_type::mass, i2_g1, partial_term<P>::null_gfunc,
+      flux_type::central, boundary_condition::periodic,
+      boundary_condition::periodic);
+
+  inline static const partial_term<P> i2_pterm_v =
+      partial_term<P>(coefficient_type::div, i2_g2, partial_term<P>::null_gfunc,
+                      flux_type::central, boundary_condition::dirichlet,
+                      boundary_condition::dirichlet);
+
+  inline static term<P> const term_i2x =
+      term<P>(false,  // time-dependent
+              "I2_x", // name
+              {i2_pterm_x}, imex_flag::imex_implicit);
+
+  inline static term<P> const term_i2v =
+      term<P>(false,  // time-dependent
+              "I2_v", // name
+              {i2_pterm_v}, imex_flag::imex_implicit);
+
+  inline static std::vector<term<P>> const terms_7 = {term_i2x, term_i2v};
+
+  // Term 5
+  // div_v(th\grad_v f)
+  //
+  // Split by LDG
+  //
+  // div_v(th q)
+  // q = \grad_v f
+  static P i3_g1(P const x, P const time = 0)
+  {
+    ignore(x);
+    ignore(time);
+    return 1.0;
+  }
+
+  static P i3_g2(P const x, P const time = 0)
+  {
+    auto param = param_manager.get_parameter("theta");
+    expect(param != nullptr);
+    return param->value(x, time) * nu;
+  }
+
+  inline static const partial_term<P> i3_pterm_x1 = partial_term<P>(
+      coefficient_type::mass, i3_g1, partial_term<P>::null_gfunc,
+      flux_type::central, boundary_condition::periodic,
+      boundary_condition::periodic);
+
+  inline static const partial_term<P> i3_pterm_x2 = partial_term<P>(
+      coefficient_type::mass, i3_g2, partial_term<P>::null_gfunc,
+      flux_type::central, boundary_condition::periodic,
+      boundary_condition::periodic);
+
+  inline static term<P> const term_i3x =
+      term<P>(false,  // time-dependent
+              "I3_x", // name
+              {i3_pterm_x1, i3_pterm_x2}, imex_flag::imex_implicit);
+
+  static P i3_g3(P const x, P const time = 0)
+  {
+    ignore(x);
+    ignore(time);
+    return 1.0;
+  }
+
+  static P i3_g4(P const x, P const time = 0)
+  {
+    ignore(x);
+    ignore(time);
+    return 1.0;
+  }
+
+  inline static const partial_term<P> i3_pterm_v1 =
+      partial_term<P>(coefficient_type::div, i3_g3, partial_term<P>::null_gfunc,
+                      flux_type::central, boundary_condition::dirichlet,
+                      boundary_condition::dirichlet);
+
+  inline static const partial_term<P> i3_pterm_v2 = partial_term<P>(
+      coefficient_type::grad, i3_g4, partial_term<P>::null_gfunc,
+      flux_type::central, boundary_condition::dirichlet,
+      boundary_condition::dirichlet);
+
+  inline static term<P> const term_i3v =
+      term<P>(false,  // time-dependent
+              "I3_v", // name
+              {i3_pterm_v1, i3_pterm_v2}, imex_flag::imex_explicit);
+
+  inline static std::vector<term<P>> const terms_8 = {term_i3x, term_i3v};
+
+  // terms 6, 7, 8 are terms 3,4,5 from vlasov_lb_full_f
+  inline static term_set<P> const terms_ = {terms_1, terms_2, terms_3,
+                                            terms_6, terms_7, terms_8};
+
+  inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {};
+  inline static scalar_func<P> const exact_scalar_func_               = {};
+
+  static P get_dt_(dimension<P> const &dim)
+  {
+    ignore(dim);
+    /* return dx; this will be scaled by CFL from command line */
+    // return std::pow(0.25, dim.get_level());
+
+    // TODO: these are constants since we want dt always based on dim 2,
+    //  but there is no way to force a different dim for this function!
+    // (Lmax - Lmin) / 2 ^ LevX * CFL
+    return (6.0 - (-6.0)) / std::pow(2, 3);
+  }
+
+  /* problem contains no sources */
+  inline static std::vector<source<P>> const sources_ = {};
+};
+
+} // namespace asgard

--- a/src/pde/pde_collisional_landau.hpp
+++ b/src/pde/pde_collisional_landau.hpp
@@ -484,8 +484,8 @@ private:
 
     // TODO: these are constants since we want dt always based on dim 2,
     //  but there is no way to force a different dim for this function!
-    // (Lmax - Lmin) / 2 ^ LevX * CFL
-    return (6.0 - (-6.0)) / std::pow(2, 3);
+    // (Lmax - Lmin) / 2 ^ LevX * CFL, where 2 ^ LevX = 8 (LevX = 3)
+    return static_cast<P>((6.0 - (-6.0)) / 8.0);
   }
 
   /* problem contains no sources */

--- a/src/pde/pde_vlasov_lb_full_f.hpp
+++ b/src/pde/pde_vlasov_lb_full_f.hpp
@@ -348,7 +348,7 @@ private:
   inline static term<P> const term_i3v =
       term<P>(false,  // time-dependent
               "I3_v", // name
-              {i3_pterm_v1, i3_pterm_v2}, imex_flag::imex_explicit);
+              {i3_pterm_v1, i3_pterm_v2}, imex_flag::imex_implicit);
 
   inline static std::vector<term<P>> const terms_5 = {term_i3x, term_i3v};
 

--- a/src/program_options.hpp
+++ b/src/program_options.hpp
@@ -49,7 +49,8 @@ enum class PDE_opts
   diffusion_1,
   diffusion_2,
   vlasov_lb_full_f,
-  vlasov_two_stream
+  vlasov_two_stream,
+  collisional_landau
   // FIXME will need to add the user supplied PDE choice
 };
 
@@ -152,7 +153,10 @@ static pde_map_t const pde_mapping = {
                               PDE_opts::vlasov_lb_full_f)},
     {"two_stream",
      PDE_descriptor("Vlasov two-stream. df/dt == -v*grad_x f -E*grad_v f",
-                    PDE_opts::vlasov_two_stream)}};
+                    PDE_opts::vlasov_two_stream)},
+    {"landau", PDE_descriptor("Collisional Landau. df/dt == -v*grad_x f "
+                              "-E*grad_v f + div_v((v-u)f + theta*grad_v f)",
+                              PDE_opts::collisional_landau)}};
 
 // class to parse command line input
 class parser

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -11,9 +11,10 @@ namespace asgard::solver
 {
 // simple, node-local test version
 template<typename P>
-P simple_gmres(fk::matrix<P> const &A, fk::vector<P> &x, fk::vector<P> const &b,
-               fk::matrix<P> const &M, int const restart, int const max_iter,
-               P const tolerance)
+gmres_info<P>
+simple_gmres(fk::matrix<P> const &A, fk::vector<P> &x, fk::vector<P> const &b,
+             fk::matrix<P> const &M, int const restart, int const max_iter,
+             P const tolerance)
 {
   auto dense_matrix_wrapper = [&A](fk::vector<P> const &x_in, fk::vector<P> &y,
                                    P const alpha = 1.0, P const beta = 0.0) {
@@ -25,12 +26,12 @@ P simple_gmres(fk::matrix<P> const &A, fk::vector<P> &x, fk::vector<P> const &b,
 }
 
 template<typename P>
-P simple_gmres(PDE<P> const &pde, elements::table const &elem_table,
-               options const &program_options,
-               element_subgrid const &my_subgrid, fk::vector<P> &x,
-               fk::vector<P> const &b, fk::matrix<P> const &M,
-               int const restart, int const max_iter, P const tolerance,
-               imex_flag const imex, P const alpha_in)
+gmres_info<P>
+simple_gmres(PDE<P> const &pde, elements::table const &elem_table,
+             options const &program_options, element_subgrid const &my_subgrid,
+             fk::vector<P> &x, fk::vector<P> const &b, fk::matrix<P> const &M,
+             int const restart, int const max_iter, P const tolerance,
+             imex_flag const imex, P const alpha_in)
 {
   auto euler_operator = [&pde, &elem_table, &program_options, &my_subgrid, imex,
                          alpha_in](fk::vector<P> const &x_in, fk::vector<P> &y,
@@ -61,8 +62,9 @@ static int default_gmres_restarts(int num_cols)
 
 // simple, node-local test version
 template<typename P, typename matrix_replacement>
-P simple_gmres(matrix_replacement mat, fk::vector<P> &x, fk::vector<P> const &b,
-               fk::matrix<P> const &M, int restart, int max_iter, P tolerance)
+gmres_info<P>
+simple_gmres(matrix_replacement mat, fk::vector<P> &x, fk::vector<P> const &b,
+             fk::matrix<P> const &M, int restart, int max_iter, P tolerance)
 {
   if (tolerance == parser::NO_USER_VALUE_FP)
     tolerance = std::is_same_v<float, P> ? 1e-6 : 1e-12;
@@ -127,17 +129,17 @@ P simple_gmres(matrix_replacement mat, fk::vector<P> &x, fk::vector<P> const &b,
   };
 
   auto const done = [](P const error, int const outer_iters,
-                       int const inner_iters) {
+                       int const inner_iters) -> gmres_info<P> {
     std::cout << "GMRES complete with error: " << error << '\n';
     std::cout << outer_iters << " outer iterations, " << inner_iters
               << " inner iterations\n";
+    return gmres_info<P>{error, outer_iters, inner_iters};
   };
 
   P error = compute_residual() / norm_b;
   if (error < tolerance)
   {
-    done(error, 0, 0);
-    return error;
+    return done(error, 0, 0);
   }
 
   fk::matrix<P> basis(n, restart + 1);
@@ -212,8 +214,7 @@ P simple_gmres(matrix_replacement mat, fk::vector<P> &x, fk::vector<P> const &b,
 
     if (error <= tolerance)
     {
-      done(error, it, i);
-      return error; // all done!
+      return done(error, it, i); // all done!
     }
     auto proj   = fk::matrix<P, mem_type::view>(krylov_proj, 0, restart - 1, 0,
                                               restart - 1);
@@ -229,13 +230,11 @@ P simple_gmres(matrix_replacement mat, fk::vector<P> &x, fk::vector<P> const &b,
 
     if (error <= tolerance)
     {
-      done(error, it, i);
-      return error;
+      return done(error, it, i);
     }
   } // end outer iteration
 
-  done(error, it, i);
-  return error;
+  return done(error, it, i);
 }
 
 template<typename P>
@@ -358,24 +357,24 @@ void poisson_solver(fk::vector<P> const &source, fk::vector<P> const &A_D,
   tools::timer.stop("poisson_solver");
 }
 
-template float simple_gmres(fk::matrix<float> const &A, fk::vector<float> &x,
-                            fk::vector<float> const &b,
-                            fk::matrix<float> const &M, int const restart,
-                            int const max_iter, float const tolerance);
+template gmres_info<float>
+simple_gmres(fk::matrix<float> const &A, fk::vector<float> &x,
+             fk::vector<float> const &b, fk::matrix<float> const &M,
+             int const restart, int const max_iter, float const tolerance);
 
-template double simple_gmres(fk::matrix<double> const &A, fk::vector<double> &x,
-                             fk::vector<double> const &b,
-                             fk::matrix<double> const &M, int const restart,
-                             int const max_iter, double const tolerance);
+template gmres_info<double>
+simple_gmres(fk::matrix<double> const &A, fk::vector<double> &x,
+             fk::vector<double> const &b, fk::matrix<double> const &M,
+             int const restart, int const max_iter, double const tolerance);
 
-template float
+template gmres_info<float>
 simple_gmres(PDE<float> const &pde, elements::table const &elem_table,
              options const &program_options, element_subgrid const &my_subgrid,
              fk::vector<float> &x, fk::vector<float> const &b,
              fk::matrix<float> const &M, int const restart, int const max_iter,
              float const tolerance, imex_flag const imex, const float alpha_in);
 
-template double
+template gmres_info<double>
 simple_gmres(PDE<double> const &pde, elements::table const &elem_table,
              options const &program_options, element_subgrid const &my_subgrid,
              fk::vector<double> &x, fk::vector<double> const &b,

--- a/src/solver.hpp
+++ b/src/solver.hpp
@@ -12,20 +12,29 @@ enum class poisson_bc
   periodic
 };
 
+template<typename P>
+struct gmres_info
+{
+  P error;
+  int outer_iter;
+  int inner_iter;
+};
+
 // simple, node-local test version of gmres
 template<typename P>
-P simple_gmres(fk::matrix<P> const &A, fk::vector<P> &x, fk::vector<P> const &b,
-               fk::matrix<P> const &M, int const restart, int const max_iter,
-               P const tolerance);
+gmres_info<P>
+simple_gmres(fk::matrix<P> const &A, fk::vector<P> &x, fk::vector<P> const &b,
+             fk::matrix<P> const &M, int const restart, int const max_iter,
+             P const tolerance);
 
 template<typename P>
-P simple_gmres(PDE<P> const &pde, elements::table const &elem_table,
-               options const &program_options,
-               element_subgrid const &my_subgrid, fk::vector<P> &x,
-               fk::vector<P> const &b, fk::matrix<P> const &M,
-               int const restart, int const max_iter, P const tolerance,
-               imex_flag const imex = imex_flag::unspecified,
-               const P alpha_in     = 1.0);
+gmres_info<P>
+simple_gmres(PDE<P> const &pde, elements::table const &elem_table,
+             options const &program_options, element_subgrid const &my_subgrid,
+             fk::vector<P> &x, fk::vector<P> const &b, fk::matrix<P> const &M,
+             int const restart, int const max_iter, P const tolerance,
+             imex_flag const imex = imex_flag::unspecified,
+             const P alpha_in     = 1.0);
 
 template<typename P>
 void setup_poisson(const int N_nodes, P const x_min, P const x_max,

--- a/src/solver.hpp
+++ b/src/solver.hpp
@@ -12,14 +12,6 @@ enum class poisson_bc
   periodic
 };
 
-template<typename P>
-struct gmres_info
-{
-  P error;
-  int outer_iter;
-  int inner_iter;
-};
-
 // simple, node-local test version of gmres
 template<typename P>
 gmres_info<P>

--- a/src/solver.hpp
+++ b/src/solver.hpp
@@ -24,7 +24,8 @@ P simple_gmres(PDE<P> const &pde, elements::table const &elem_table,
                element_subgrid const &my_subgrid, fk::vector<P> &x,
                fk::vector<P> const &b, fk::matrix<P> const &M,
                int const restart, int const max_iter, P const tolerance,
-               imex_flag const imex = imex_flag::unspecified);
+               imex_flag const imex = imex_flag::unspecified,
+               const P alpha_in     = 1.0);
 
 template<typename P>
 void setup_poisson(const int N_nodes, P const x_min, P const x_max,

--- a/src/solver_tests.cpp
+++ b/src/solver_tests.cpp
@@ -134,11 +134,11 @@ TEMPLATE_TEST_CASE("simple GMRES", "[solver]", float, double)
     fk::vector<TestType> test(x_gold.size());
 
     std::cout.setstate(std::ios_base::failbit);
-    TestType const error = solver::simple_gmres(
+    gmres_info<TestType> const gmres_output = solver::simple_gmres(
         A_gold, test, b_gold, fk::matrix<TestType>(), A_gold.ncols(),
         A_gold.ncols(), std::numeric_limits<TestType>::epsilon());
     std::cout.clear();
-    REQUIRE(error < std::numeric_limits<TestType>::epsilon());
+    REQUIRE(gmres_output.error < std::numeric_limits<TestType>::epsilon());
     REQUIRE(test == x_gold);
   }
 
@@ -147,11 +147,11 @@ TEMPLATE_TEST_CASE("simple GMRES", "[solver]", float, double)
     fk::vector<TestType> test(x_gold.size());
 
     std::cout.setstate(std::ios_base::failbit);
-    TestType const error = solver::simple_gmres(
+    gmres_info<TestType> const gmres_output = solver::simple_gmres(
         A_gold, test, b_gold, precond, A_gold.ncols(), A_gold.ncols(),
         std::numeric_limits<TestType>::epsilon());
     std::cout.clear();
-    REQUIRE(error < std::numeric_limits<TestType>::epsilon());
+    REQUIRE(gmres_output.error < std::numeric_limits<TestType>::epsilon());
     REQUIRE(test == x_gold);
   }
 
@@ -160,11 +160,11 @@ TEMPLATE_TEST_CASE("simple GMRES", "[solver]", float, double)
     fk::vector<TestType> test(x_gold_2.size());
 
     std::cout.setstate(std::ios_base::failbit);
-    TestType const error = solver::simple_gmres(
+    gmres_info<TestType> const gmres_output = solver::simple_gmres(
         A_gold, test, b_gold_2, fk::matrix<TestType>(), A_gold.ncols(),
         A_gold.ncols(), std::numeric_limits<TestType>::epsilon());
     std::cout.clear();
-    REQUIRE(error < std::numeric_limits<TestType>::epsilon());
+    REQUIRE(gmres_output.error < std::numeric_limits<TestType>::epsilon());
     REQUIRE(test == x_gold_2);
   }
 
@@ -172,11 +172,11 @@ TEMPLATE_TEST_CASE("simple GMRES", "[solver]", float, double)
   {
     fk::vector<TestType> test(x_gold_2.size());
     std::cout.setstate(std::ios_base::failbit);
-    TestType const error = solver::simple_gmres(
+    gmres_info<TestType> const gmres_output = solver::simple_gmres(
         A_gold, test, b_gold_2, precond, A_gold.ncols(), A_gold.ncols(),
         std::numeric_limits<TestType>::epsilon());
     std::cout.clear();
-    REQUIRE(error < std::numeric_limits<TestType>::epsilon());
+    REQUIRE(gmres_output.error < std::numeric_limits<TestType>::epsilon());
     REQUIRE(test == x_gold_2);
   }
 }

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -629,7 +629,7 @@ imex_advance(PDE<P> &pde, adapt::distributed_grid<P> const &adaptive_grid,
 
   // Create rho_3s
   // TODO: refactor into more generic function
-  fm::gemv(pde.moments[0].get_moment_matrix(), f_2, mom0);
+  fm::gemv(pde.moments[0].get_moment_matrix(), x, mom0);
   wavelet_to_realspace<P>(pde_1d, mom0, adaptive_grid_1d.get_table(),
                           transformer, tmp_workspace, mom0_real);
   param_manager.get_parameter("n")->value = [mom0_real](P const x_v,
@@ -638,7 +638,7 @@ imex_advance(PDE<P> &pde, adapt::distributed_grid<P> const &adaptive_grid,
     return interp1(nodes, mom0_real, {x_v})[0];
   };
 
-  fm::gemv(pde.moments[1].get_moment_matrix(), f_2, mom1);
+  fm::gemv(pde.moments[1].get_moment_matrix(), x, mom1);
   wavelet_to_realspace<P>(pde_1d, mom1, adaptive_grid_1d.get_table(),
                           transformer, tmp_workspace, mom1_real);
   param_manager.get_parameter("u")->value = [mom1_real](P const x_v,
@@ -647,7 +647,7 @@ imex_advance(PDE<P> &pde, adapt::distributed_grid<P> const &adaptive_grid,
            param_manager.get_parameter("n")->value(x_v, t);
   };
 
-  fm::gemv(pde.moments[2].get_moment_matrix(), f_2, mom2);
+  fm::gemv(pde.moments[2].get_moment_matrix(), x, mom2);
   wavelet_to_realspace<P>(pde_1d, mom2, adaptive_grid_1d.get_table(),
                           transformer, tmp_workspace, mom2_real);
   param_manager.get_parameter("theta")->value =

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -476,10 +476,10 @@ imex_advance(PDE<P> &pde, adapt::distributed_grid<P> const &adaptive_grid,
     // Get 0th moment
     fk::vector<P> mom0(dense_size);
     fm::gemv(pde.moments[0].get_moment_matrix(), f_in, mom0);
-    auto mom0_real = pde.moments[0].create_realspace_moment(
+    fk::vector<P> &mom0_real = pde.moments[0].create_realspace_moment(
         pde_1d, mom0, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
-    param_manager.get_parameter("n")->value = [mom0_real](P const x_v,
-                                                          P const t = 0) -> P {
+    param_manager.get_parameter("n")->value =
+        [&mom0_real = mom0_real](P const x_v, P const t = 0) -> P {
       ignore(t);
       return interp1(nodes, mom0_real, {x_v})[0];
     };
@@ -557,10 +557,10 @@ imex_advance(PDE<P> &pde, adapt::distributed_grid<P> const &adaptive_grid,
   // Create rho_2s
   fk::vector<P> mom0(dense_size);
   fm::gemv(pde.moments[0].get_moment_matrix(), x, mom0);
-  auto mom0_real = pde.moments[0].create_realspace_moment(
+  fk::vector<P> &mom0_real = pde.moments[0].create_realspace_moment(
       pde_1d, mom0, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
-  param_manager.get_parameter("n")->value = [mom0_real](P const x_v,
-                                                        P const t = 0) -> P {
+  param_manager.get_parameter("n")->value =
+      [&mom0_real = mom0_real](P const x_v, P const t = 0) -> P {
     ignore(t);
     return interp1(nodes, mom0_real, {x_v})[0];
   };
@@ -568,20 +568,20 @@ imex_advance(PDE<P> &pde, adapt::distributed_grid<P> const &adaptive_grid,
   // TODO: refactor into more generic function
   fk::vector<P> mom1(dense_size);
   fm::gemv(pde.moments[1].get_moment_matrix(), x, mom1);
-  auto mom1_real = pde.moments[1].create_realspace_moment(
+  fk::vector<P> &mom1_real = pde.moments[1].create_realspace_moment(
       pde_1d, mom1, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
-  param_manager.get_parameter("u")->value = [mom1_real](P const x_v,
-                                                        P const t = 0) -> P {
+  param_manager.get_parameter("u")->value =
+      [&mom1_real = mom1_real](P const x_v, P const t = 0) -> P {
     return interp1(nodes, mom1_real, {x_v})[0] /
            param_manager.get_parameter("n")->value(x_v, t);
   };
 
   fk::vector<P> mom2(dense_size);
   fm::gemv(pde.moments[2].get_moment_matrix(), x, mom2);
-  auto mom2_real = pde.moments[2].create_realspace_moment(
+  fk::vector<P> &mom2_real = pde.moments[2].create_realspace_moment(
       pde_1d, mom2, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
   param_manager.get_parameter("theta")->value =
-      [mom2_real](P const x_v, P const t = 0) -> P {
+      [&mom2_real = mom2_real](P const x_v, P const t = 0) -> P {
     P const u = param_manager.get_parameter("u")->value(x_v, t);
     return (interp1(nodes, mom2_real, {x_v})[0] /
             param_manager.get_parameter("n")->value(x_v, t)) -
@@ -643,8 +643,8 @@ imex_advance(PDE<P> &pde, adapt::distributed_grid<P> const &adaptive_grid,
   fm::gemv(pde.moments[0].get_moment_matrix(), x, mom0);
   mom0_real = pde.moments[0].create_realspace_moment(
       pde_1d, mom0, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
-  param_manager.get_parameter("n")->value = [mom0_real](P const x_v,
-                                                        P const t = 0) -> P {
+  param_manager.get_parameter("n")->value =
+      [&mom0_real = mom0_real](P const x_v, P const t = 0) -> P {
     ignore(t);
     return interp1(nodes, mom0_real, {x_v})[0];
   };
@@ -652,8 +652,8 @@ imex_advance(PDE<P> &pde, adapt::distributed_grid<P> const &adaptive_grid,
   fm::gemv(pde.moments[1].get_moment_matrix(), x, mom1);
   mom1_real = pde.moments[1].create_realspace_moment(
       pde_1d, mom1, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
-  param_manager.get_parameter("u")->value = [mom1_real](P const x_v,
-                                                        P const t = 0) -> P {
+  param_manager.get_parameter("u")->value =
+      [&mom1_real = mom1_real](P const x_v, P const t = 0) -> P {
     return interp1(nodes, mom1_real, {x_v})[0] /
            param_manager.get_parameter("n")->value(x_v, t);
   };
@@ -662,7 +662,7 @@ imex_advance(PDE<P> &pde, adapt::distributed_grid<P> const &adaptive_grid,
   mom2_real = pde.moments[2].create_realspace_moment(
       pde_1d, mom2, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
   param_manager.get_parameter("theta")->value =
-      [mom2_real](P const x_v, P const t = 0) -> P {
+      [&mom2_real = mom2_real](P const x_v, P const t = 0) -> P {
     P const u = param_manager.get_parameter("u")->value(x_v, t);
     return (interp1(nodes, mom2_real, {x_v})[0] /
             param_manager.get_parameter("n")->value(x_v, t)) -

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -478,8 +478,8 @@ imex_advance(PDE<P> &pde, adapt::distributed_grid<P> const &adaptive_grid,
     fm::gemv(pde.moments[0].get_moment_matrix(), f_in, mom0);
     fk::vector<P> &mom0_real = pde.moments[0].create_realspace_moment(
         pde_1d, mom0, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
-    param_manager.get_parameter("n")->value =
-        [&mom0_real = mom0_real](P const x_v, P const t = 0) -> P {
+    param_manager.get_parameter("n")->value = [&](P const x_v,
+                                                  P const t = 0) -> P {
       ignore(t);
       return interp1(nodes, mom0_real, {x_v})[0];
     };
@@ -559,8 +559,8 @@ imex_advance(PDE<P> &pde, adapt::distributed_grid<P> const &adaptive_grid,
   fm::gemv(pde.moments[0].get_moment_matrix(), x, mom0);
   fk::vector<P> &mom0_real = pde.moments[0].create_realspace_moment(
       pde_1d, mom0, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
-  param_manager.get_parameter("n")->value =
-      [&mom0_real = mom0_real](P const x_v, P const t = 0) -> P {
+  param_manager.get_parameter("n")->value = [&](P const x_v,
+                                                P const t = 0) -> P {
     ignore(t);
     return interp1(nodes, mom0_real, {x_v})[0];
   };
@@ -570,8 +570,8 @@ imex_advance(PDE<P> &pde, adapt::distributed_grid<P> const &adaptive_grid,
   fm::gemv(pde.moments[1].get_moment_matrix(), x, mom1);
   fk::vector<P> &mom1_real = pde.moments[1].create_realspace_moment(
       pde_1d, mom1, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
-  param_manager.get_parameter("u")->value =
-      [&mom1_real = mom1_real](P const x_v, P const t = 0) -> P {
+  param_manager.get_parameter("u")->value = [&](P const x_v,
+                                                P const t = 0) -> P {
     return interp1(nodes, mom1_real, {x_v})[0] /
            param_manager.get_parameter("n")->value(x_v, t);
   };
@@ -580,8 +580,8 @@ imex_advance(PDE<P> &pde, adapt::distributed_grid<P> const &adaptive_grid,
   fm::gemv(pde.moments[2].get_moment_matrix(), x, mom2);
   fk::vector<P> &mom2_real = pde.moments[2].create_realspace_moment(
       pde_1d, mom2, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
-  param_manager.get_parameter("theta")->value =
-      [&mom2_real = mom2_real](P const x_v, P const t = 0) -> P {
+  param_manager.get_parameter("theta")->value = [&](P const x_v,
+                                                    P const t = 0) -> P {
     P const u = param_manager.get_parameter("u")->value(x_v, t);
     return (interp1(nodes, mom2_real, {x_v})[0] /
             param_manager.get_parameter("n")->value(x_v, t)) -
@@ -643,8 +643,8 @@ imex_advance(PDE<P> &pde, adapt::distributed_grid<P> const &adaptive_grid,
   fm::gemv(pde.moments[0].get_moment_matrix(), x, mom0);
   mom0_real = pde.moments[0].create_realspace_moment(
       pde_1d, mom0, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
-  param_manager.get_parameter("n")->value =
-      [&mom0_real = mom0_real](P const x_v, P const t = 0) -> P {
+  param_manager.get_parameter("n")->value = [&](P const x_v,
+                                                P const t = 0) -> P {
     ignore(t);
     return interp1(nodes, mom0_real, {x_v})[0];
   };
@@ -652,8 +652,8 @@ imex_advance(PDE<P> &pde, adapt::distributed_grid<P> const &adaptive_grid,
   fm::gemv(pde.moments[1].get_moment_matrix(), x, mom1);
   mom1_real = pde.moments[1].create_realspace_moment(
       pde_1d, mom1, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
-  param_manager.get_parameter("u")->value =
-      [&mom1_real = mom1_real](P const x_v, P const t = 0) -> P {
+  param_manager.get_parameter("u")->value = [&](P const x_v,
+                                                P const t = 0) -> P {
     return interp1(nodes, mom1_real, {x_v})[0] /
            param_manager.get_parameter("n")->value(x_v, t);
   };
@@ -661,8 +661,8 @@ imex_advance(PDE<P> &pde, adapt::distributed_grid<P> const &adaptive_grid,
   fm::gemv(pde.moments[2].get_moment_matrix(), x, mom2);
   mom2_real = pde.moments[2].create_realspace_moment(
       pde_1d, mom2, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
-  param_manager.get_parameter("theta")->value =
-      [&mom2_real = mom2_real](P const x_v, P const t = 0) -> P {
+  param_manager.get_parameter("theta")->value = [&](P const x_v,
+                                                    P const t = 0) -> P {
     P const u = param_manager.get_parameter("u")->value(x_v, t);
     return (interp1(nodes, mom2_real, {x_v})[0] /
             param_manager.get_parameter("n")->value(x_v, t)) -

--- a/src/time_advance.hpp
+++ b/src/time_advance.hpp
@@ -39,8 +39,7 @@ explicit_advance(PDE<P> const &pde,
 
 template<typename P>
 fk::vector<P>
-implicit_advance(PDE<P> const &pde,
-                 adapt::distributed_grid<P> const &adaptive_grid,
+implicit_advance(PDE<P> &pde, adapt::distributed_grid<P> const &adaptive_grid,
                  basis::wavelet_transform<P, resource::host> const &transformer,
                  options const &program_opts,
                  std::array<boundary_conditions::unscaled_bc_parts<P>, 2> const

--- a/src/transformations.cpp
+++ b/src/transformations.cpp
@@ -208,8 +208,10 @@ void wavelet_to_realspace(
     std::array<fk::vector<P, mem_type::view, resource::host>, 2> &workspace,
     fk::vector<P> &real_space)
 {
+  tools::timer.start("wavelet_to_realspace");
   wavelet_to_realspace(pde.get_dimensions(), wave_space, table, transformer,
                        workspace, real_space);
+  tools::timer.stop("wavelet_to_realspace");
 }
 
 template<typename P>


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

- Adds the collisional landau damping PDE
- Expands on adding additional data (E field, moments) and metadata (nodes for each dimension, levels, degree, pde info) to the HDF5 output files. The electric field is now stored as a member variable in the PDE class as a result.
- Saves GMRES iteration counts (inner, outer) and error to HDF5 files.
- Adds more performance timers to the IMEX advance and across the code. These are mainly meant to be temporary to show areas for optimization later.
- Fixes a bug in the `vlasov_lb_full_f` pde where the wrong imex flag was used.

This should be merged after #496. 

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [x] New feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

Ubuntu 20.04

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
