### PR TITLE
Add penalty term to the two_stream PDE

### DIFF
--- a/src/coefficients.cpp
+++ b/src/coefficients.cpp
@@ -355,11 +355,13 @@ fk::matrix<P> generate_coefficients(
                 (-1);
           }
           trace_value_3 =
-              (legendre_poly_R_t * legendre_poly_R) * (+1 * flux_right / 2) +
+              (legendre_poly_R_t * legendre_poly_R) * (+1 * flux_right / 2) *
+                  central_coeff +
               (legendre_poly_R_t * legendre_poly_R) *
                   (+1 * pterm.get_flux_scale() * std::abs(flux_right) / 2 * +1);
           trace_value_4 =
-              (legendre_poly_R_t * legendre_poly_L) * (+1 * flux_right / 2) +
+              (legendre_poly_R_t * legendre_poly_L) * (+1 * flux_right / 2) *
+                  central_coeff +
               (legendre_poly_R_t * legendre_poly_L) *
                   (-1 * pterm.get_flux_scale() * std::abs(flux_right) / 2 * +1);
         }
@@ -370,11 +372,13 @@ fk::matrix<P> generate_coefficients(
         if (i == num_cells - 1)
         {
           trace_value_1 =
-              (legendre_poly_L_t * legendre_poly_R) * (-1 * flux_left / 2) +
+              (legendre_poly_L_t * legendre_poly_R) * (-1 * flux_left / 2) *
+                  central_coeff +
               (legendre_poly_L_t * legendre_poly_R) *
                   (+1 * pterm.get_flux_scale() * std::abs(flux_left) / 2 * -1);
           trace_value_2 =
-              (legendre_poly_L_t * legendre_poly_L) * (-1 * flux_left / 2) +
+              (legendre_poly_L_t * legendre_poly_L) * (-1 * flux_left / 2) *
+                  central_coeff +
               (legendre_poly_L_t * legendre_poly_L) *
                   (-1 * pterm.get_flux_scale() * std::abs(flux_left) / 2 * -1);
           if (pterm.coeff_type == coefficient_type::penalty)
@@ -423,11 +427,13 @@ fk::matrix<P> generate_coefficients(
                 (legendre_poly_L_t * legendre_poly_L) * (-1 * flux_left);
           }
           trace_value_3 =
-              (legendre_poly_R_t * legendre_poly_R) * (+1 * flux_right / 2) +
+              (legendre_poly_R_t * legendre_poly_R) * (+1 * flux_right / 2) *
+                  central_coeff +
               (legendre_poly_R_t * legendre_poly_R) *
                   (+1 * pterm.get_flux_scale() * std::abs(flux_right) / 2 * +1);
           trace_value_4 =
-              (legendre_poly_R_t * legendre_poly_L) * (+1 * flux_right / 2) +
+              (legendre_poly_R_t * legendre_poly_L) * (+1 * flux_right / 2) *
+                  central_coeff +
               (legendre_poly_R_t * legendre_poly_L) *
                   (-1 * pterm.get_flux_scale() * std::abs(flux_right) / 2 * +1);
         }
@@ -438,11 +444,13 @@ fk::matrix<P> generate_coefficients(
         if (i == num_cells - 1)
         {
           trace_value_1 =
-              (legendre_poly_L_t * legendre_poly_R) * (-1 * flux_left / 2) +
+              (legendre_poly_L_t * legendre_poly_R) * (-1 * flux_left / 2) *
+                  central_coeff +
               (legendre_poly_L_t * legendre_poly_R) *
                   (+1 * pterm.get_flux_scale() * std::abs(flux_left) / 2 * -1);
           trace_value_2 =
-              (legendre_poly_L_t * legendre_poly_L) * (-1 * flux_left / 2) +
+              (legendre_poly_L_t * legendre_poly_L) * (-1 * flux_left / 2) *
+                  central_coeff +
               (legendre_poly_L_t * legendre_poly_L) *
                   (-1 * pterm.get_flux_scale() * std::abs(flux_left) / 2 * -1);
           if (pterm.coeff_type == coefficient_type::penalty)

--- a/src/pde/pde_collisional_landau.hpp
+++ b/src/pde/pde_collisional_landau.hpp
@@ -185,7 +185,7 @@ private:
   static P e1_g2(P const x, P const time = 0)
   {
     ignore(time);
-    return (x > 0.0) ? x : 0.0;
+    return std::max(P{0.0}, x);
   }
 
   inline static const partial_term<P> e1_pterm_x = partial_term<P>(
@@ -221,7 +221,7 @@ private:
   static P e2_g2(P const x, P const time = 0)
   {
     ignore(time);
-    return (x < 0.0) ? x : 0.0;
+    return std::min(P{0.0}, x);
   }
 
   inline static const partial_term<P> e2_pterm_x = partial_term<P>(
@@ -294,13 +294,6 @@ private:
     return param->value(x, time);
   }
 
-  static P posOne(P const x, P const time = 0)
-  {
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
   inline static const partial_term<P> pterm_MaxAbsE_mass_x = partial_term<P>(
       coefficient_type::mass, MaxAbsE_func, nullptr, flux_type::central,
       boundary_condition::periodic, boundary_condition::periodic);
@@ -316,7 +309,7 @@ private:
               {pterm_MaxAbsE_mass_x}, imex_flag::imex_explicit);
 
   inline static const partial_term<P> pterm_div_v_downwind = partial_term<P>(
-      coefficient_type::div, posOne, nullptr, flux_type::downwind,
+      coefficient_type::div, nullptr, nullptr, flux_type::downwind,
       boundary_condition::dirichlet, boundary_condition::dirichlet,
       homogeneity::homogeneous, homogeneity::homogeneous);
 
@@ -413,13 +406,6 @@ private:
   //
   // div_v(th q)
   // q = \grad_v f
-  static P i3_g1(P const x, P const time = 0)
-  {
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
   static P i3_g2(P const x, P const time = 0)
   {
     auto param = param_manager.get_parameter("theta");
@@ -428,7 +414,7 @@ private:
   }
 
   inline static const partial_term<P> i3_pterm_x1 = partial_term<P>(
-      coefficient_type::mass, i3_g1, nullptr, flux_type::central,
+      coefficient_type::mass, nullptr, nullptr, flux_type::central,
       boundary_condition::periodic, boundary_condition::periodic);
 
   inline static const partial_term<P> i3_pterm_x2 = partial_term<P>(
@@ -440,26 +426,12 @@ private:
               "I3_x", // name
               {i3_pterm_x1, i3_pterm_x2}, imex_flag::imex_implicit);
 
-  static P i3_g3(P const x, P const time = 0)
-  {
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
-  static P i3_g4(P const x, P const time = 0)
-  {
-    ignore(x);
-    ignore(time);
-    return 1.0;
-  }
-
   inline static const partial_term<P> i3_pterm_v1 = partial_term<P>(
-      coefficient_type::div, i3_g3, nullptr, flux_type::central,
+      coefficient_type::div, nullptr, nullptr, flux_type::central,
       boundary_condition::dirichlet, boundary_condition::dirichlet);
 
   inline static const partial_term<P> i3_pterm_v2 = partial_term<P>(
-      coefficient_type::grad, i3_g4, nullptr, flux_type::central,
+      coefficient_type::grad, nullptr, nullptr, flux_type::central,
       boundary_condition::dirichlet, boundary_condition::dirichlet);
 
   inline static term<P> const term_i3v =
@@ -479,9 +451,6 @@ private:
   static P get_dt_(dimension<P> const &dim)
   {
     ignore(dim);
-    /* return dx; this will be scaled by CFL from command line */
-    // return std::pow(0.25, dim.get_level());
-
     // TODO: these are constants since we want dt always based on dim 2,
     //  but there is no way to force a different dim for this function!
     // (Lmax - Lmin) / 2 ^ LevX * CFL, where 2 ^ LevX = 8 (LevX = 3)

--- a/src/pde/pde_two_stream.hpp
+++ b/src/pde/pde_two_stream.hpp
@@ -31,7 +31,7 @@ public:
 private:
   static int constexpr num_dims_          = 2;
   static int constexpr num_sources_       = 0;
-  static int constexpr num_terms_         = 5;
+  static int constexpr num_terms_         = 4;
   static bool constexpr do_poisson_solve_ = true;
   // disable implicit steps in IMEX
   static bool constexpr do_collision_operator_ = false;
@@ -267,7 +267,7 @@ private:
 
   inline static std::vector<term<P>> const terms_3 = {E_mass_x, div_v};
 
-  // Term 4 + 5
+  // Term 4
   // Penalty Part of E\cdot\grad_v f
   //
 
@@ -282,35 +282,27 @@ private:
       coefficient_type::mass, MaxAbsE_func, nullptr, flux_type::central,
       boundary_condition::periodic, boundary_condition::periodic);
 
-  inline static term<P> const MaxAbsE_mass_x_1 =
+  inline static term<P> const MaxAbsE_mass_x =
       term<P>(true, // time-dependent
               "",   // name
               {pterm_MaxAbsE_mass_x}, imex_flag::imex_explicit);
 
-  inline static term<P> const MaxAbsE_mass_x_2 =
-      term<P>(true, // time-dependent
-              "",   // name
-              {pterm_MaxAbsE_mass_x}, imex_flag::imex_explicit);
-
-  inline static const partial_term<P> pterm_div_v_downwind = partial_term<P>(
-      coefficient_type::div, nullptr, nullptr, flux_type::downwind,
-      boundary_condition::dirichlet, boundary_condition::dirichlet,
+  inline static const partial_term<P> e_penalty_pterm = partial_term<P>(
+      coefficient_type::penalty, nullptr, nullptr, flux_type::downwind,
+      boundary_condition::neumann, boundary_condition::neumann,
       homogeneity::homogeneous, homogeneity::homogeneous);
 
-  inline static term<P> const div_v_downwind =
+  inline static term<P> const e_penalty =
       term<P>(false, // time-dependent
               "",    // name
-              {pterm_div_v_downwind}, imex_flag::imex_explicit);
+              {e_penalty_pterm}, imex_flag::imex_explicit);
 
   // Central Part Defined Above (div_v; can do this due to time independence)
 
-  inline static std::vector<term<P>> const terms_4 = {MaxAbsE_mass_x_1,
-                                                      div_v_downwind};
+  inline static std::vector<term<P>> const terms_4 = {MaxAbsE_mass_x,
+                                                      e_penalty};
 
-  inline static std::vector<term<P>> const terms_5 = {MaxAbsE_mass_x_2, div_v};
-
-  inline static term_set<P> const terms_ = {terms_1, terms_2, terms_3, terms_4,
-                                            terms_5};
+  inline static term_set<P> const terms_ = {terms_1, terms_2, terms_3, terms_4};
 
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {};
   inline static scalar_func<P> const exact_scalar_func_               = {};

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -31,14 +31,14 @@ simple_gmres(PDE<P> const &pde, elements::table const &elem_table,
              options const &program_options, element_subgrid const &my_subgrid,
              fk::vector<P> &x, fk::vector<P> const &b, fk::matrix<P> const &M,
              int const restart, int const max_iter, P const tolerance,
-             imex_flag const imex, P const alpha_in)
+             imex_flag const imex, P const dt_factor)
 {
   auto euler_operator = [&pde, &elem_table, &program_options, &my_subgrid, imex,
-                         alpha_in](fk::vector<P> const &x_in, fk::vector<P> &y,
-                                   P const alpha = 1.0, P const beta = 0.0) {
+                         dt_factor](fk::vector<P> const &x_in, fk::vector<P> &y,
+                                    P const alpha = 1.0, P const beta = 0.0) {
     auto tmp = kronmult::execute(pde, elem_table, program_options, my_subgrid,
                                  x_in, imex);
-    tmp      = x_in - tmp * pde.get_dt() * alpha_in;
+    tmp      = x_in - tmp * pde.get_dt() * dt_factor;
     y        = tmp * alpha + y * beta;
   };
   return simple_gmres(euler_operator, x, b, M, restart, max_iter, tolerance);
@@ -372,7 +372,8 @@ simple_gmres(PDE<float> const &pde, elements::table const &elem_table,
              options const &program_options, element_subgrid const &my_subgrid,
              fk::vector<float> &x, fk::vector<float> const &b,
              fk::matrix<float> const &M, int const restart, int const max_iter,
-             float const tolerance, imex_flag const imex, const float alpha_in);
+             float const tolerance, imex_flag const imex,
+             const float dt_factor);
 
 template gmres_info<double>
 simple_gmres(PDE<double> const &pde, elements::table const &elem_table,
@@ -380,7 +381,7 @@ simple_gmres(PDE<double> const &pde, elements::table const &elem_table,
              fk::vector<double> &x, fk::vector<double> const &b,
              fk::matrix<double> const &M, int const restart, int const max_iter,
              double const tolerance, imex_flag const imex,
-             const double alpha_in);
+             const double dt_factor);
 
 template void setup_poisson(const int N_elements, float const x_min,
                             float const x_max, fk::vector<float> &diag,

--- a/src/solver.hpp
+++ b/src/solver.hpp
@@ -26,7 +26,7 @@ simple_gmres(PDE<P> const &pde, elements::table const &elem_table,
              fk::vector<P> &x, fk::vector<P> const &b, fk::matrix<P> const &M,
              int const restart, int const max_iter, P const tolerance,
              imex_flag const imex = imex_flag::unspecified,
-             const P alpha_in     = 1.0);
+             const P dt_factor    = 1.0);
 
 template<typename P>
 void setup_poisson(const int N_nodes, P const x_min, P const x_max,

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -506,10 +506,10 @@ imex_advance(PDE<P> &pde, adapt::distributed_grid<P> const &adaptive_grid,
 
     pde.E_field = poisson_E;
 
-    P const max_E = *std::max_element(poisson_E.begin(), poisson_E.end(),
-                                      [](const P &x_v, const P &y_v) {
-                                        return std::abs(x_v) < std::abs(y_v);
-                                      });
+    P const max_E = std::abs(*std::max_element(
+        poisson_E.begin(), poisson_E.end(), [](const P &x_v, const P &y_v) {
+          return std::abs(x_v) < std::abs(y_v);
+        }));
 
     param_manager.get_parameter("MaxAbsE")->value =
         [max_E](P const x_v, P const t = 0) -> P {


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Adds the penalty term to the `two_stream` PDE. This also fixes an issue with the coefficients for the penalty term and an issue in the IMEX time advance where the maximum energy returned was not returning the absolute value.


## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [x] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

Ubuntu 20.04

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
