### PR TITLE
Fix tolerance option when using IMEX

### DIFF
--- a/src/program_options.cpp
+++ b/src/program_options.cpp
@@ -210,7 +210,13 @@ parser::parser(int argc, char const *const *argv)
     valid = false;
   }
 
-  if (use_implicit_stepping)
+  if (use_imex_stepping)
+  {
+    // imex only uses gmres
+    solver_str = "gmres";
+  }
+
+  if (use_implicit_stepping || use_imex_stepping)
   {
     if (solver_str == "none")
     {


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

The `--tol` option for setting the GMRES tolerance does not work when using the imex switch `-x`, giving the following:
```
gmres tolerance has no effect with solver = none
invalid cli string; exiting
```

This sets the solver string when using IMEX so that this no longer occurs.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

Ubuntu 20.04

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [ ] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
