### PR TITLE
Adjusts kronmult CUDA launch configuration

### DIFF
--- a/src/device/kronmult_cuda.cpp
+++ b/src/device/kronmult_cuda.cpp
@@ -309,33 +309,34 @@ void call_kronmult(int const n, P *x_ptrs[], P *output_ptrs[], P *work_ptrs[],
 #ifdef ASGARD_USE_CUDA
   {
     int constexpr warpsize    = 32;
-    int constexpr nwarps      = 1;
+    int constexpr nwarps      = 8;
     int constexpr num_threads = nwarps * warpsize;
+    int const num_blocks      = (num_krons / num_threads) + 1;
 
     switch (num_dims)
     {
     case 1:
-      kronmult1_xbatched<P><<<num_krons, num_threads>>>(
+      kronmult1_xbatched<P><<<num_blocks, num_threads>>>(
           n, operator_ptrs, lda, x_ptrs, output_ptrs, work_ptrs, num_krons);
       break;
     case 2:
-      kronmult2_xbatched<P><<<num_krons, num_threads>>>(
+      kronmult2_xbatched<P><<<num_blocks, num_threads>>>(
           n, operator_ptrs, lda, x_ptrs, output_ptrs, work_ptrs, num_krons);
       break;
     case 3:
-      kronmult3_xbatched<P><<<num_krons, num_threads>>>(
+      kronmult3_xbatched<P><<<num_blocks, num_threads>>>(
           n, operator_ptrs, lda, x_ptrs, output_ptrs, work_ptrs, num_krons);
       break;
     case 4:
-      kronmult4_xbatched<P><<<num_krons, num_threads>>>(
+      kronmult4_xbatched<P><<<num_blocks, num_threads>>>(
           n, operator_ptrs, lda, x_ptrs, output_ptrs, work_ptrs, num_krons);
       break;
     case 5:
-      kronmult5_xbatched<P><<<num_krons, num_threads>>>(
+      kronmult5_xbatched<P><<<num_blocks, num_threads>>>(
           n, operator_ptrs, lda, x_ptrs, output_ptrs, work_ptrs, num_krons);
       break;
     case 6:
-      kronmult6_xbatched<P><<<num_krons, num_threads>>>(
+      kronmult6_xbatched<P><<<num_blocks, num_threads>>>(
           n, operator_ptrs, lda, x_ptrs, output_ptrs, work_ptrs, num_krons);
       break;
     default:


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

This adjusts the kernel launch configurations when calling kronmult to better utilize the GPU.
Running the two-stream level 7 full grid saw the average kronmult time go from 379ms to 233ms. A full IMEX time step went from about 21 seconds to 13.8 seconds.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

Ubuntu 20.04, CUDA 11.5, RTX 3080Ti

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
