### PR TITLE
Coefficient generation fixes for IMEX adaptivity

### DIFF
--- a/src/asgard_dimension.hpp
+++ b/src/asgard_dimension.hpp
@@ -350,7 +350,7 @@ struct dimension
     degree_ = degree;
   }
 
-  void set_mass_matrix(fk::matrix<P> const &new_mass, int level)
+  void set_mass_matrix(fk::matrix<P> &&new_mass, int level)
   {
     expect(level >= 0);
 
@@ -358,8 +358,6 @@ struct dimension
     {
       this->mass_.resize(level + 1);
     }
-    this->mass_[level].clear_and_resize(new_mass.nrows(), new_mass.ncols());
-    expect(this->mass_[level].nrows() == new_mass.nrows());
     this->mass_[level] = std::move(new_mass);
   }
 

--- a/src/coefficients.cpp
+++ b/src/coefficients.cpp
@@ -25,11 +25,18 @@ void generate_all_coefficients(
   for (auto i = 0; i < pde.num_dims; ++i)
   {
     auto const &dim = pde.get_dimensions()[i];
-    std::vector<int> ipiv(dim.get_degree() * fm::two_raised_to(pde.max_level));
+    std::vector<int> ipiv(dim.get_degree() *
+                          fm::two_raised_to(dim.get_level()));
     for (auto j = 0; j < pde.num_terms; ++j)
     {
       auto const &term_1D       = pde.get_terms()[j][i];
       auto const &partial_terms = term_1D.get_partial_terms();
+
+      // skip regenerating coefficients that are constant in time
+      if (!term_1D.time_dependent && time > 0.0)
+      {
+        continue;
+      }
 
       for (auto k = 0; k < static_cast<int>(partial_terms.size()); ++k)
       {
@@ -42,26 +49,29 @@ void generate_all_coefficients(
             dim.volume_jacobian_dV);
 
         auto mass_coeff = generate_coefficients<P>(
-            dim, lhs_mass_pterm, transformer, pde.max_level, time, rotate);
+            dim, lhs_mass_pterm, transformer, dim.get_level(), time, rotate);
 
         // precompute inv(mass) * coeff for each level up to max level
-        std::vector<fk::matrix<P>> pterm_coeffs;
+        // std::vector<fk::matrix<P>> pterm_coeffs;
 
-        for (int level = 0; level <= pde.max_level; ++level)
+        auto result = generate_coefficients<P>(
+            dim, partial_terms[k], transformer, dim.get_level(), time, rotate);
+
+        // for (int level = 0; level <= dim.get_level(); ++level)
+        //{
+        auto const dof  = dim.get_degree() * fm::two_raised_to(dim.get_level());
+        auto result_tmp = result.extract_submatrix(0, 0, dof, dof);
+        if (partial_terms[k].dv_func || partial_terms[k].g_func)
         {
-          auto result = generate_coefficients<P>(
-              dim, partial_terms[k], transformer, level, time, rotate);
-          if (partial_terms[k].dv_func || partial_terms[k].g_func)
-          {
-            auto const dof = dim.get_degree() * fm::two_raised_to(level);
-            auto mass_tmp  = mass_coeff.extract_submatrix(0, 0, dof, dof);
-            fm::gesv(mass_tmp, result, ipiv);
-          }
-          pterm_coeffs.emplace_back(std::move(result));
+          auto mass_tmp = mass_coeff.extract_submatrix(0, 0, dof, dof);
+          fm::gesv(mass_tmp, result_tmp, ipiv);
         }
+        // pterm_coeffs.emplace_back(std::move(result_tmp));
+        //}
 
         pde.set_lhs_mass(j, i, k, std::move(mass_coeff));
-        pde.set_partial_coefficients(j, i, k, std::move(pterm_coeffs));
+        // pde.set_partial_coefficients(j, i, k, std::move(pterm_coeffs));
+        pde.set_partial_coefficients(j, i, k, std::move(result_tmp));
       }
     }
     pde.rechain_dimension(i);

--- a/src/coefficients.cpp
+++ b/src/coefficients.cpp
@@ -80,6 +80,61 @@ void generate_all_coefficients(
 }
 
 template<typename P>
+void generate_all_coefficients_max_level(
+    PDE<P> &pde, basis::wavelet_transform<P, resource::host> const &transformer,
+    P const time, bool const rotate)
+{
+  tools::timer.start("gen_coefficients");
+  expect(time >= 0.0);
+
+  for (auto i = 0; i < pde.num_dims; ++i)
+  {
+    auto const &dim = pde.get_dimensions()[i];
+    std::vector<int> ipiv(dim.get_degree() * fm::two_raised_to(pde.max_level));
+    for (auto j = 0; j < pde.num_terms; ++j)
+    {
+      auto const &term_1D       = pde.get_terms()[j][i];
+      auto const &partial_terms = term_1D.get_partial_terms();
+
+      for (auto k = 0; k < static_cast<int>(partial_terms.size()); ++k)
+      {
+        // TODO: refactor these changes, this is slow!
+        partial_term<P> const lhs_mass_pterm = partial_term<P>(
+            coefficient_type::mass, partial_terms[k].lhs_mass_func, nullptr,
+            flux_type::central, boundary_condition::periodic,
+            boundary_condition::periodic, homogeneity::homogeneous,
+            homogeneity::homogeneous, {}, nullptr, {}, nullptr,
+            dim.volume_jacobian_dV);
+
+        auto mass_coeff = generate_coefficients<P>(
+            dim, lhs_mass_pterm, transformer, pde.max_level, time, rotate);
+
+        // precompute inv(mass) * coeff for each level up to max level
+        std::vector<fk::matrix<P>> pterm_coeffs;
+
+        for (int level = 0; level <= pde.max_level; ++level)
+        {
+          auto result = generate_coefficients<P>(
+              dim, partial_terms[k], transformer, level, time, rotate);
+          if (partial_terms[k].dv_func || partial_terms[k].g_func)
+          {
+            auto const dof = dim.get_degree() * fm::two_raised_to(level);
+            auto mass_tmp  = mass_coeff.extract_submatrix(0, 0, dof, dof);
+            fm::gesv(mass_tmp, result, ipiv);
+          }
+          pterm_coeffs.emplace_back(std::move(result));
+        }
+
+        pde.set_lhs_mass(j, i, k, std::move(mass_coeff));
+        pde.set_partial_coefficients(j, i, k, std::move(pterm_coeffs));
+      }
+    }
+    pde.rechain_dimension(i);
+  }
+  tools::timer.stop("gen_coefficients");
+}
+
+template<typename P>
 void generate_dimension_mass_mat(
     PDE<P> &pde, basis::wavelet_transform<P, resource::host> const &transformer)
 {
@@ -87,15 +142,18 @@ void generate_dimension_mass_mat(
   {
     auto &dim = pde.get_dimensions()[i];
 
-    partial_term<P> const lhs_mass_pterm = partial_term<P>(
-        coefficient_type::mass, nullptr, nullptr, flux_type::central,
-        boundary_condition::periodic, boundary_condition::periodic,
-        homogeneity::homogeneous, homogeneity::homogeneous, {}, nullptr, {},
-        nullptr, dim.volume_jacobian_dV);
-    auto mass_mat = generate_coefficients<P>(dim, lhs_mass_pterm, transformer,
-                                             pde.max_level, 0.0, true);
+    for (int level = 0; level <= pde.max_level; ++level)
+    {
+      partial_term<P> const lhs_mass_pterm = partial_term<P>(
+          coefficient_type::mass, nullptr, nullptr, flux_type::central,
+          boundary_condition::periodic, boundary_condition::periodic,
+          homogeneity::homogeneous, homogeneity::homogeneous, {}, nullptr, {},
+          nullptr, dim.volume_jacobian_dV);
+      auto mass_mat = generate_coefficients<P>(dim, lhs_mass_pterm, transformer,
+                                               level, 0.0, true);
 
-    pde.update_dimension_mass_mat(i, mass_mat);
+      pde.update_dimension_mass_mat(i, std::move(mass_mat), level);
+    }
   }
 }
 
@@ -575,6 +633,11 @@ template void generate_all_coefficients<double>(
     basis::wavelet_transform<double, resource::host> const &transformer,
     double const time, bool const rotate);
 
+template void generate_all_coefficients_max_level<double>(
+    PDE<double> &pde,
+    basis::wavelet_transform<double, resource::host> const &transformer,
+    double const time, bool const rotate);
+
 template void generate_dimension_mass_mat<double>(
     PDE<double> &pde,
     basis::wavelet_transform<double, resource::host> const &transformer);
@@ -587,6 +650,11 @@ template fk::matrix<float> generate_coefficients<float>(
     int const level, float const time, bool const rotate);
 
 template void generate_all_coefficients<float>(
+    PDE<float> &pde,
+    basis::wavelet_transform<float, resource::host> const &transformer,
+    float const time, bool const rotate);
+
+template void generate_all_coefficients_max_level<float>(
     PDE<float> &pde,
     basis::wavelet_transform<float, resource::host> const &transformer,
     float const time, bool const rotate);

--- a/src/coefficients.hpp
+++ b/src/coefficients.hpp
@@ -11,6 +11,11 @@ void generate_all_coefficients(
     P const time = 0.0, bool const rotate = true);
 
 template<typename P>
+void generate_all_coefficients_max_level(
+    PDE<P> &pde, basis::wavelet_transform<P, resource::host> const &transformer,
+    P const time = 0.0, bool const rotate = true);
+
+template<typename P>
 void generate_dimension_mass_mat(
     PDE<P> &pde,
     basis::wavelet_transform<P, resource::host> const &transformer);

--- a/src/coefficients_tests.cpp
+++ b/src/coefficients_tests.cpp
@@ -18,7 +18,7 @@ void test_coefficients(parser const &parse, std::string const &gold_path,
   auto pde = make_PDE<P>(parse);
   options const opts(parse);
   basis::wavelet_transform<P, resource::host> const transformer(opts, *pde);
-  P const time = 1.0;
+  P const time = 0.0;
   generate_dimension_mass_mat(*pde, transformer);
   generate_all_coefficients(*pde, transformer, time, rotate);
 
@@ -332,7 +332,7 @@ TEMPLATE_TEST_CASE("fokkerplanck2_complete_case4 terms", "[coefficients]",
 
     basis::wavelet_transform<TestType, resource::host> const transformer(opts,
                                                                          *pde);
-    TestType const time = 1.0;
+    TestType const time = 0.0;
     generate_dimension_mass_mat(*pde, transformer);
     generate_all_coefficients(*pde, transformer, time, true);
 

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -93,7 +93,7 @@ void generate_initial_moments(
 template<typename P>
 void write_output(PDE<P> const &pde, parser const &cli_input,
                   fk::vector<P> const &vec, P const time, int const file_index,
-                  int const dof,
+                  int const dof, elements::table const &hash_table,
                   std::string const output_dataset_name = "asgard")
 {
   tools::timer.start("write_output");
@@ -129,6 +129,9 @@ void write_output(PDE<P> const &pde, parser const &cli_input,
     H5Easy::dump(file, "dim" + std::to_string(dim) + "_max",
                  dims[dim].domain_max);
   }
+
+  H5Easy::dump(file, "elements",
+               hash_table.get_active_table().clone_onto_host().to_std());
 
   H5Easy::dump(file, "soln", vec.to_std(), opts);
 

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -130,8 +130,7 @@ void write_output(PDE<P> const &pde, parser const &cli_input,
                  dims[dim].domain_max);
   }
 
-  H5Easy::dump(file, "elements",
-               hash_table.get_active_table().clone_onto_host().to_std());
+  H5Easy::dump(file, "elements", hash_table.get_active_table().to_std());
 
   H5Easy::dump(file, "soln", vec.to_std(), opts);
 

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -2,6 +2,7 @@
 
 #include "pde.hpp"
 #include "tensors.hpp"
+#include "tools.hpp"
 #include "transformations.hpp"
 
 // workaround for missing include issue with highfive
@@ -92,8 +93,10 @@ void generate_initial_moments(
 template<typename P>
 void write_output(PDE<P> const &pde, parser const &cli_input,
                   fk::vector<P> const &vec, P const time, int const file_index,
+                  int const dof,
                   std::string const output_dataset_name = "asgard")
 {
+  tools::timer.start("write_output");
   std::string const output_file_name =
       output_dataset_name + "_" + std::to_string(file_index) + ".h5";
 
@@ -111,6 +114,7 @@ void write_output(PDE<P> const &pde, parser const &cli_input,
   H5Easy::dump(file, "time", time);
   H5Easy::dump(file, "ndims", pde.num_dims);
   H5Easy::dump(file, "max_level", pde.max_level);
+  H5Easy::dump(file, "dof", dof);
   auto const dims = pde.get_dimensions();
   for (size_t dim = 0; dim < dims.size(); ++dim)
   {
@@ -152,6 +156,7 @@ void write_output(PDE<P> const &pde, parser const &cli_input,
     H5Easy::dump(file, "gmres" + std::to_string(i) + "_num_inner",
                  pde.gmres_outputs[i].inner_iter, opts);
   }
+  tools::timer.stop("write_output");
 }
 
 } // namespace asgard

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -144,7 +144,7 @@ int main(int argc, char **argv)
 
   // realspace solution vector - WARNING this is
   // currently infeasible to form for large problems
-  auto const dense_size = asgard::dense_space_size(*pde);
+  auto dense_size = asgard::dense_space_size(*pde);
   asgard::fk::vector<prec> real_space(dense_size);
 
   // temporary workspaces for the transform
@@ -310,6 +310,7 @@ int main(int argc, char **argv)
     if (opts.should_output_realspace(i) || opts.should_plot(i))
     {
       // resize transform workspaces if grid size changed due to adaptivity
+      dense_size          = asgard::dense_space_size(*pde);
       auto transform_wksp = asgard::update_transform_workspace<prec>(
           dense_size, workspace, tmp_workspace);
       real_space.resize(dense_size);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
 
   // -- generate and store coefficient matrices.
   asgard::node_out() << "  generating: coefficient matrices..." << '\n';
-  asgard::generate_all_coefficients<prec>(*pde, transformer);
+  asgard::generate_all_coefficients_max_level<prec>(*pde, transformer);
 
   // -- initialize moments of the PDE
   asgard::node_out() << "  generating: moment vectors..." << '\n';

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -160,9 +160,12 @@ int main(int argc, char **argv)
                                           asgard::resource::host>(
                            workspace, dense_size, dense_size * 2 - 1)};
   // transform initial condition to realspace
-  asgard::wavelet_to_realspace<prec>(*pde, initial_condition,
-                                     adaptive_grid.get_table(), transformer,
-                                     tmp_workspace, real_space);
+  if (cli_input.get_realspace_output_freq() > 0)
+  {
+    asgard::wavelet_to_realspace<prec>(*pde, initial_condition,
+                                       adaptive_grid.get_table(), transformer,
+                                       tmp_workspace, real_space);
+  }
 #endif
 
 #ifdef ASGARD_USE_MATLAB

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -129,7 +129,7 @@ int main(int argc, char **argv)
     m.createFlist(*pde, opts);
     expect(m.get_fList().size() > 0);
 
-    m.createMomentVector(*pde, cli_input, adaptive_grid.get_table());
+    m.createMomentVector(*pde, opts, adaptive_grid.get_table());
     expect(m.get_vector().size() > 0);
   }
 
@@ -213,12 +213,13 @@ int main(int argc, char **argv)
   if (cli_input.get_wavelet_output_freq() > 0)
   {
     asgard::write_output(*pde, cli_input, initial_condition,
-                         static_cast<prec>(0.0), 0, "asgard_wavelet");
+                         static_cast<prec>(0.0), 0, initial_condition.size(),
+                         "asgard_wavelet");
   }
   if (cli_input.get_realspace_output_freq() > 0)
   {
     asgard::write_output(*pde, cli_input, real_space, static_cast<prec>(0.0), 0,
-                         "asgard_real");
+                         initial_condition.size(), "asgard_real");
   }
 #endif
 
@@ -323,13 +324,13 @@ int main(int argc, char **argv)
 #ifdef ASGARD_IO_HIGHFIVE
     if (opts.should_output_wavelet(i))
     {
-      asgard::write_output(*pde, cli_input, f_val, time, i + 1,
+      asgard::write_output(*pde, cli_input, f_val, time, i + 1, f_val.size(),
                            "asgard_wavelet");
     }
     if (opts.should_output_realspace(i))
     {
       asgard::write_output(*pde, cli_input, real_space, time, i + 1,
-                           "asgard_real");
+                           f_val.size(), "asgard_real");
     }
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -214,12 +214,13 @@ int main(int argc, char **argv)
   {
     asgard::write_output(*pde, cli_input, initial_condition,
                          static_cast<prec>(0.0), 0, initial_condition.size(),
-                         "asgard_wavelet");
+                         adaptive_grid.get_table(), "asgard_wavelet");
   }
   if (cli_input.get_realspace_output_freq() > 0)
   {
     asgard::write_output(*pde, cli_input, real_space, static_cast<prec>(0.0), 0,
-                         initial_condition.size(), "asgard_real");
+                         initial_condition.size(), adaptive_grid.get_table(),
+                         "asgard_real");
   }
 #endif
 
@@ -313,7 +314,8 @@ int main(int argc, char **argv)
       dense_size          = asgard::dense_space_size(*pde);
       auto transform_wksp = asgard::update_transform_workspace<prec>(
           dense_size, workspace, tmp_workspace);
-      real_space.resize(dense_size);
+      // real_space.resize(dense_size);
+      real_space = asgard::fk::vector<prec>(dense_size);
 
       asgard::wavelet_to_realspace<prec>(*pde, f_val, adaptive_grid.get_table(),
                                          transformer, transform_wksp,
@@ -326,12 +328,13 @@ int main(int argc, char **argv)
     if (opts.should_output_wavelet(i))
     {
       asgard::write_output(*pde, cli_input, f_val, time, i + 1, f_val.size(),
-                           "asgard_wavelet");
+                           adaptive_grid.get_table(), "asgard_wavelet");
     }
     if (opts.should_output_realspace(i))
     {
       asgard::write_output(*pde, cli_input, real_space, time, i + 1,
-                           f_val.size(), "asgard_real");
+                           f_val.size(), adaptive_grid.get_table(),
+                           "asgard_real");
     }
 #endif
 

--- a/src/moment.cpp
+++ b/src/moment.cpp
@@ -52,8 +52,6 @@ void moment<P>::createMomentVector(PDE<P> const &pde, options const &opts,
     int const degree             = pde.get_dimensions()[0].get_degree();
     auto tmp = combine_dimensions(degree, hash_table, plan.at(rank).row_start,
                                   plan.at(rank).row_stop, this->fList[0]);
-    this->vector = fk::vector<P>();
-    this->vector.resize(tmp.size());
     this->vector      = std::move(tmp);
     auto num_md_funcs = md_funcs.size();
     for (std::size_t s = 1; s < num_md_funcs; ++s)

--- a/src/moment.hpp
+++ b/src/moment.hpp
@@ -32,7 +32,7 @@ class moment
 public:
   moment(std::vector<md_func_type<P>> md_funcs_);
   void createFlist(PDE<P> const &pde, options const &opts);
-  void createMomentVector(PDE<P> const &pde, parser const &opts,
+  void createMomentVector(PDE<P> const &pde, options const &opts,
                           elements::table const &hash_table);
 
   std::vector<md_func_type<P>> const &get_md_funcs() const { return md_funcs; }

--- a/src/moment_tests.cpp
+++ b/src/moment_tests.cpp
@@ -87,7 +87,7 @@ TEMPLATE_TEST_CASE("CreateMomentReducedMatrix", "[moments]", test_precs)
   for (size_t i = 0; i < moments.size(); ++i)
   {
     moments[i].createFlist(*pde, opts);
-    moments[i].createMomentVector(*pde, parse, check);
+    moments[i].createMomentVector(*pde, opts, check);
     moments[i].createMomentReducedMatrix(*pde, check);
 
     auto const gold_filename =

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -666,7 +666,7 @@ public:
           std::vector<fk::matrix<P>> pterm_coeffs;
           for (int level = 0; level <= max_level; ++level)
           {
-            auto const dof = dim.get_degree() * fm::two_raised_to(max_level);
+            auto const dof = dim.get_degree() * fm::two_raised_to(level);
             fk::matrix<P> result_tmp = eye<P>(dof);
             pterm_coeffs.emplace_back(std::move(result_tmp));
           }

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -612,7 +612,7 @@ public:
       {
         auto const dof = fm::two_raised_to(level) * degree;
         expect(dof < INT_MAX);
-        update_dimension_mass_mat(i, eye<P>(dof), level);
+        update_dimension_mass_mat(i, std::move(eye<P>(dof)), level);
       }
     }
 
@@ -806,7 +806,7 @@ public:
     }
   }
 
-  void update_dimension_mass_mat(int const dim_index, fk::matrix<P> const &mass,
+  void update_dimension_mass_mat(int const dim_index, fk::matrix<P> &&mass,
                                  int const level)
   {
     assert(dim_index >= 0);

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -198,6 +198,16 @@ public:
     }
   }
 
+  void set_coefficients(fk::matrix<P> const &&new_coefficients, int const level)
+  {
+    // set the coefficients at the given level
+    expect(coefficients_.size() > static_cast<size_t>(level));
+    // coefficients_[level] = std::move(new_coefficients);
+    this->coefficients_[level].clear_and_resize(new_coefficients.nrows(),
+                                                new_coefficients.ncols()) =
+        std::move(new_coefficients);
+  }
+
   void set_coefficients(std::vector<fk::matrix<P>> const &new_coefficients)
   {
     expect(new_coefficients.size() > 0);
@@ -272,12 +282,14 @@ public:
         new_coefficients.nrows(), new_coefficients.ncols()) = new_coefficients;
   }
 
-  void set_partial_coefficients(fk::matrix<P> const &coeffs, int const pterm,
+  void set_partial_coefficients(fk::matrix<P> const &&coeffs, int const pterm,
                                 int const deg, int const max_lev)
   {
     expect(pterm >= 0);
     expect(pterm < static_cast<int>(partial_terms_.size()));
-    partial_terms_[pterm].set_coefficients(coeffs, deg, max_lev);
+    ignore(deg);
+    // partial_terms_[pterm].set_coefficients(coeffs, deg, max_lev);
+    partial_terms_[pterm].set_coefficients(std::move(coeffs), max_lev);
   }
 
   void set_partial_coefficients(std::vector<fk::matrix<P>> const &coeffs,
@@ -639,6 +651,30 @@ public:
     }
 
     gmres_outputs.resize(cli_input.using_imex() ? 2 : 1);
+
+    // hack to preallocate empty matrix for pterm coefficients for adapt
+    // if (cli_input.do_adapt_levels()) {
+    for (auto i = 0; i < num_dims; ++i)
+    {
+      auto const &dim = this->get_dimensions()[i];
+      for (auto j = 0; j < num_terms; ++j)
+      {
+        auto const &term_1D       = this->get_terms()[j][i];
+        auto const &partial_terms = term_1D.get_partial_terms();
+        for (auto k = 0; k < static_cast<int>(partial_terms.size()); ++k)
+        {
+          std::vector<fk::matrix<P>> pterm_coeffs;
+          for (int level = 0; level <= max_level; ++level)
+          {
+            auto const dof = dim.get_degree() * fm::two_raised_to(max_level);
+            fk::matrix<P> result_tmp = eye<P>(dof);
+            pterm_coeffs.emplace_back(std::move(result_tmp));
+          }
+          this->set_partial_coefficients(j, i, k, std::move(pterm_coeffs));
+        }
+      }
+    }
+    //}
   }
 
   constexpr static int extract_dim0 = 1;
@@ -712,14 +748,15 @@ public:
   }
 
   void set_partial_coefficients(int const term, int const dim, int const pterm,
-                                fk::matrix<P> const &coeffs)
+                                fk::matrix<P> const &&coeffs)
   {
     expect(term >= 0);
     expect(term < num_terms);
     expect(dim >= 0);
     expect(dim < num_dims);
-    terms_[term][dim].set_partial_coefficients(
-        coeffs, pterm, dimensions_[dim].get_degree(), max_level);
+    terms_[term][dim].set_partial_coefficients(std::move(coeffs), pterm,
+                                               dimensions_[dim].get_degree(),
+                                               dimensions_[dim].get_level());
   }
 
   void set_partial_coefficients(int const term, int const dim, int const pterm,

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -202,7 +202,6 @@ public:
   {
     // set the coefficients at the given level
     expect(coefficients_.size() > static_cast<size_t>(level));
-    // coefficients_[level] = std::move(new_coefficients);
     this->coefficients_[level].clear_and_resize(new_coefficients.nrows(),
                                                 new_coefficients.ncols()) =
         std::move(new_coefficients);
@@ -288,7 +287,6 @@ public:
     expect(pterm >= 0);
     expect(pterm < static_cast<int>(partial_terms_.size()));
     ignore(deg);
-    // partial_terms_[pterm].set_coefficients(coeffs, deg, max_lev);
     partial_terms_[pterm].set_coefficients(std::move(coeffs), max_lev);
   }
 
@@ -655,7 +653,6 @@ public:
     gmres_outputs.resize(cli_input.using_imex() ? 2 : 1);
 
     // hack to preallocate empty matrix for pterm coefficients for adapt
-    // if (cli_input.do_adapt_levels()) {
     for (auto i = 0; i < num_dims; ++i)
     {
       auto const &dim = this->get_dimensions()[i];
@@ -676,7 +673,6 @@ public:
         }
       }
     }
-    //}
   }
 
   constexpr static int extract_dim0 = 1;

--- a/src/program_options.cpp
+++ b/src/program_options.cpp
@@ -191,7 +191,7 @@ parser::parser(int argc, char const *const *argv)
   }
 
   if (realspace_output_freq > num_time_steps ||
-      wavelet_output_freq > num_time_steps || plot_freq > num_time_steps)
+      wavelet_output_freq > num_time_steps)
   {
     std::cerr
         << "Requested a write or plot frequency > number of steps - no output "

--- a/src/program_options.hpp
+++ b/src/program_options.hpp
@@ -183,7 +183,7 @@ public:
   static auto constexpr DEFAULT_MIXED_GRID_GROUP  = -1;
   static auto constexpr DEFAULT_TIME_STEPS        = 10;
   static auto constexpr DEFAULT_WRITE_FREQ        = 0;
-  static auto constexpr DEFAULT_PLOT_FREQ         = 1;
+  static auto constexpr DEFAULT_PLOT_FREQ         = 1e9;
   static auto constexpr DEFAULT_USE_IMPLICIT      = false;
   static auto constexpr DEFAULT_USE_IMEX          = false;
   static auto constexpr DEFAULT_USE_FG            = false;

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -464,9 +464,6 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
        "-l " + std::to_string(pde.get_dimensions()[0].get_level())});
   adapt::distributed_grid adaptive_grid_1d(pde_1d, opts_1d);
 
-  // asgard::basis::wavelet_transform<P, asgard::resource::host> const
-  // transformer_1d(opts_1d, pde_1d, false);
-
   // Create workspace for wavelet transform
   auto const dense_size = dense_space_size(pde_1d);
   fk::vector<P, mem_type::owner, resource::host> workspace(dense_size * 2);
@@ -502,12 +499,6 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
     std::cout << " dim1 lev = " << pde.get_dimensions()[1].get_level() << "\n";
     for (auto &m : pde.moments)
     {
-      // m.createFlist(pde, program_opts);
-      // expect(m.get_fList().size() > 0);
-
-      // m.createMomentVector(pde, program_opts, adaptive_grid.get_table());
-      // expect(m.get_vector().size() > 0);
-
       m.createMomentReducedMatrix(pde, adaptive_grid.get_table());
       expect(m.get_moment_matrix().nrows() > 0);
     }

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -416,6 +416,24 @@ implicit_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   return x;
 }
 
+asgard::parser make_parser(std::vector<std::string> const arguments)
+{
+  std::vector<char *> argv;
+  argv.push_back(const_cast<char *>("asgard"));
+  for (const auto &arg : arguments)
+  {
+    argv.push_back(const_cast<char *>(arg.data()));
+  }
+  argv.push_back(nullptr);
+
+  return asgard::parser(argv.size() - 1, argv.data());
+}
+
+asgard::options make_options(std::vector<std::string> const arguments)
+{
+  return asgard::options(make_parser(arguments));
+}
+
 // this function executes an implicit-explicit (imex) time step using the
 // current solution vector x. on exit, the next solution vector is stored in fx.
 template<typename P>
@@ -440,7 +458,14 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
 
   // create 1D version of PDE and element table for wavelet->realspace mappings
   PDE pde_1d = PDE(pde, PDE<P>::extract_dim0);
-  adapt::distributed_grid adaptive_grid_1d(pde_1d, program_opts);
+
+  options const opts_1d = make_options(
+      {"-d 3", "-f",
+       "-l " + std::to_string(pde.get_dimensions()[0].get_level())});
+  adapt::distributed_grid adaptive_grid_1d(pde_1d, opts_1d);
+
+  asgard::basis::wavelet_transform<P, asgard::resource::host> const
+      transformer_1d(program_opts, pde_1d, false);
 
   // Create workspace for wavelet transform
   auto const dense_size = dense_space_size(pde_1d);
@@ -473,8 +498,16 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   // function in x
   if (first_time || update_system)
   {
+    std::cout << " dim0 lev = " << level << "\n";
+    std::cout << " dim1 lev = " << level << "\n";
     for (auto &m : pde.moments)
     {
+      // m.createFlist(pde, program_opts);
+      // expect(m.get_fList().size() > 0);
+
+      // m.createMomentVector(pde, program_opts, adaptive_grid.get_table());
+      // expect(m.get_vector().size() > 0);
+
       m.createMomentReducedMatrix(pde, adaptive_grid.get_table());
       expect(m.get_moment_matrix().nrows() > 0);
     }
@@ -487,6 +520,8 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
     }
 
     pde.E_field.resize(dense_size);
+
+    first_time = false;
   }
 
   auto do_poisson_update = [&](fk::vector<P> const &f_in) {
@@ -495,7 +530,8 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
     fk::vector<P> mom0(dense_size);
     fm::gemv(pde.moments[0].get_moment_matrix(), f_in, mom0);
     fk::vector<P> &mom0_real = pde.moments[0].create_realspace_moment(
-        pde_1d, mom0, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
+        pde_1d, mom0, adaptive_grid_1d.get_table(), transformer_1d,
+        tmp_workspace);
     param_manager.get_parameter("n")->value = [&](P const x_v,
                                                   P const t = 0) -> P {
       ignore(t);
@@ -581,8 +617,22 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   // Create rho_2s
   fk::vector<P> mom0(dense_size);
   fm::gemv(pde.moments[0].get_moment_matrix(), x, mom0);
+
+  /*
+  fk::matrix<P> tmp = asgard::operator_two_scale<P>(degree, level);
+  tmp.transpose();
+
+  fk::vector<P> mom0_real_coeffs(dense_size);
+  fm::gemv(tmp, mom0, mom0_real_coeffs);
+
+  fm::scal(static_cast<P>((1.0 / (std::sqrt(4.0 * PI * std::pow(2, level))))),
+  mom0_real_coeffs); mom0_real_coeffs.print("mom0_real_coeffs");
+  */
+
   fk::vector<P> &mom0_real = pde.moments[0].create_realspace_moment(
-      pde_1d, mom0, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
+      pde_1d, mom0, adaptive_grid_1d.get_table(), transformer_1d,
+      tmp_workspace);
+  // mom0_real.print("mom0_real");
   param_manager.get_parameter("n")->value = [&](P const x_v,
                                                 P const t = 0) -> P {
     ignore(t);
@@ -593,7 +643,8 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   fk::vector<P> mom1(dense_size);
   fm::gemv(pde.moments[1].get_moment_matrix(), x, mom1);
   fk::vector<P> &mom1_real = pde.moments[1].create_realspace_moment(
-      pde_1d, mom1, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
+      pde_1d, mom1, adaptive_grid_1d.get_table(), transformer_1d,
+      tmp_workspace);
   param_manager.get_parameter("u")->value = [&](P const x_v,
                                                 P const t = 0) -> P {
     return interp1(nodes, mom1_real, {x_v})[0] /
@@ -603,7 +654,8 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   fk::vector<P> mom2(dense_size);
   fm::gemv(pde.moments[2].get_moment_matrix(), x, mom2);
   fk::vector<P> &mom2_real = pde.moments[2].create_realspace_moment(
-      pde_1d, mom2, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
+      pde_1d, mom2, adaptive_grid_1d.get_table(), transformer_1d,
+      tmp_workspace);
   param_manager.get_parameter("theta")->value = [&](P const x_v,
                                                     P const t = 0) -> P {
     P const u = param_manager.get_parameter("u")->value(x_v, t);
@@ -611,9 +663,6 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
             param_manager.get_parameter("n")->value(x_v, t)) -
            std::pow(u, 2);
   };
-
-  // Update coeffs
-  generate_all_coefficients<P>(pde, transformer);
 
   // f2 now
   P const tolerance  = program_opts.gmres_tolerance;
@@ -623,6 +672,9 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
 
   if (pde.do_collision_operator)
   {
+    // Update coeffs
+    generate_all_coefficients<P>(pde, transformer);
+
     // f2 now
     operator_matrices.reset_coefficients(matrix_entry::imex_implicit, pde,
                                          adaptive_grid, program_opts);
@@ -666,14 +718,17 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   fm::axpy(f_2, x);    // x is now f0 + f3
   fm::scal(P{0.5}, x); // x = 0.5 * (f0 + f3)
   tools::timer.stop("explicit_2");
-  tools::timer.start("implicit_2");
-
+  if (pde.do_collision_operator)
+  {
+    tools::timer.start("implicit_2");
+  }
   tools::timer.start("implicit_2_mom");
   // Create rho_3s
   // TODO: refactor into more generic function
   fm::gemv(pde.moments[0].get_moment_matrix(), x, mom0);
   mom0_real = pde.moments[0].create_realspace_moment(
-      pde_1d, mom0, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
+      pde_1d, mom0, adaptive_grid_1d.get_table(), transformer_1d,
+      tmp_workspace);
   param_manager.get_parameter("n")->value = [&](P const x_v,
                                                 P const t = 0) -> P {
     ignore(t);
@@ -682,7 +737,8 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
 
   fm::gemv(pde.moments[1].get_moment_matrix(), x, mom1);
   mom1_real = pde.moments[1].create_realspace_moment(
-      pde_1d, mom1, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
+      pde_1d, mom1, adaptive_grid_1d.get_table(), transformer_1d,
+      tmp_workspace);
   param_manager.get_parameter("u")->value = [&](P const x_v,
                                                 P const t = 0) -> P {
     return interp1(nodes, mom1_real, {x_v})[0] /
@@ -691,7 +747,8 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
 
   fm::gemv(pde.moments[2].get_moment_matrix(), x, mom2);
   mom2_real = pde.moments[2].create_realspace_moment(
-      pde_1d, mom2, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
+      pde_1d, mom2, adaptive_grid_1d.get_table(), transformer_1d,
+      tmp_workspace);
   param_manager.get_parameter("theta")->value = [&](P const x_v,
                                                     P const t = 0) -> P {
     P const u = param_manager.get_parameter("u")->value(x_v, t);
@@ -701,14 +758,14 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   };
   tools::timer.stop("implicit_2_mom");
 
-  // Update coeffs
-  tools::timer.start("implicit_2_coeff");
-  generate_all_coefficients<P>(pde, transformer);
-  tools::timer.stop("implicit_2_coeff");
-
   // Final stage f3
   if (pde.do_collision_operator)
   {
+    // Update coeffs
+    tools::timer.start("implicit_2_coeff");
+    generate_all_coefficients<P>(pde, transformer);
+    tools::timer.stop("implicit_2_coeff");
+
     // Final stage f3
     tools::timer.start("implicit_2_solve");
     fk::vector<P> f_3(x);

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -617,20 +617,8 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   fk::vector<P> mom0(dense_size);
   fm::gemv(pde.moments[0].get_moment_matrix(), x, mom0);
 
-  /*
-  fk::matrix<P> tmp = asgard::operator_two_scale<P>(degree, level);
-  tmp.transpose();
-
-  fk::vector<P> mom0_real_coeffs(dense_size);
-  fm::gemv(tmp, mom0, mom0_real_coeffs);
-
-  fm::scal(static_cast<P>((1.0 / (std::sqrt(4.0 * PI * std::pow(2, level))))),
-  mom0_real_coeffs); mom0_real_coeffs.print("mom0_real_coeffs");
-  */
-
   fk::vector<P> &mom0_real = pde.moments[0].create_realspace_moment(
       pde_1d, mom0, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
-  // mom0_real.print("mom0_real");
   param_manager.get_parameter("n")->value = [&](P const x_v,
                                                 P const t = 0) -> P {
     ignore(t);

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -464,8 +464,8 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
        "-l " + std::to_string(pde.get_dimensions()[0].get_level())});
   adapt::distributed_grid adaptive_grid_1d(pde_1d, opts_1d);
 
-  asgard::basis::wavelet_transform<P, asgard::resource::host> const
-      transformer_1d(program_opts, pde_1d, false);
+  // asgard::basis::wavelet_transform<P, asgard::resource::host> const
+  // transformer_1d(opts_1d, pde_1d, false);
 
   // Create workspace for wavelet transform
   auto const dense_size = dense_space_size(pde_1d);
@@ -499,7 +499,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   if (first_time || update_system)
   {
     std::cout << " dim0 lev = " << level << "\n";
-    std::cout << " dim1 lev = " << level << "\n";
+    std::cout << " dim1 lev = " << pde.get_dimensions()[1].get_level() << "\n";
     for (auto &m : pde.moments)
     {
       // m.createFlist(pde, program_opts);
@@ -521,7 +521,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
 
     pde.E_field.resize(dense_size);
 
-    first_time = false;
+    // first_time = false;
   }
 
   auto do_poisson_update = [&](fk::vector<P> const &f_in) {
@@ -530,8 +530,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
     fk::vector<P> mom0(dense_size);
     fm::gemv(pde.moments[0].get_moment_matrix(), f_in, mom0);
     fk::vector<P> &mom0_real = pde.moments[0].create_realspace_moment(
-        pde_1d, mom0, adaptive_grid_1d.get_table(), transformer_1d,
-        tmp_workspace);
+        pde_1d, mom0, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
     param_manager.get_parameter("n")->value = [&](P const x_v,
                                                   P const t = 0) -> P {
       ignore(t);
@@ -630,8 +629,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   */
 
   fk::vector<P> &mom0_real = pde.moments[0].create_realspace_moment(
-      pde_1d, mom0, adaptive_grid_1d.get_table(), transformer_1d,
-      tmp_workspace);
+      pde_1d, mom0, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
   // mom0_real.print("mom0_real");
   param_manager.get_parameter("n")->value = [&](P const x_v,
                                                 P const t = 0) -> P {
@@ -643,8 +641,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   fk::vector<P> mom1(dense_size);
   fm::gemv(pde.moments[1].get_moment_matrix(), x, mom1);
   fk::vector<P> &mom1_real = pde.moments[1].create_realspace_moment(
-      pde_1d, mom1, adaptive_grid_1d.get_table(), transformer_1d,
-      tmp_workspace);
+      pde_1d, mom1, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
   param_manager.get_parameter("u")->value = [&](P const x_v,
                                                 P const t = 0) -> P {
     return interp1(nodes, mom1_real, {x_v})[0] /
@@ -654,8 +651,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   fk::vector<P> mom2(dense_size);
   fm::gemv(pde.moments[2].get_moment_matrix(), x, mom2);
   fk::vector<P> &mom2_real = pde.moments[2].create_realspace_moment(
-      pde_1d, mom2, adaptive_grid_1d.get_table(), transformer_1d,
-      tmp_workspace);
+      pde_1d, mom2, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
   param_manager.get_parameter("theta")->value = [&](P const x_v,
                                                     P const t = 0) -> P {
     P const u = param_manager.get_parameter("u")->value(x_v, t);
@@ -727,8 +723,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   // TODO: refactor into more generic function
   fm::gemv(pde.moments[0].get_moment_matrix(), x, mom0);
   mom0_real = pde.moments[0].create_realspace_moment(
-      pde_1d, mom0, adaptive_grid_1d.get_table(), transformer_1d,
-      tmp_workspace);
+      pde_1d, mom0, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
   param_manager.get_parameter("n")->value = [&](P const x_v,
                                                 P const t = 0) -> P {
     ignore(t);
@@ -737,8 +732,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
 
   fm::gemv(pde.moments[1].get_moment_matrix(), x, mom1);
   mom1_real = pde.moments[1].create_realspace_moment(
-      pde_1d, mom1, adaptive_grid_1d.get_table(), transformer_1d,
-      tmp_workspace);
+      pde_1d, mom1, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
   param_manager.get_parameter("u")->value = [&](P const x_v,
                                                 P const t = 0) -> P {
     return interp1(nodes, mom1_real, {x_v})[0] /
@@ -747,8 +741,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
 
   fm::gemv(pde.moments[2].get_moment_matrix(), x, mom2);
   mom2_real = pde.moments[2].create_realspace_moment(
-      pde_1d, mom2, adaptive_grid_1d.get_table(), transformer_1d,
-      tmp_workspace);
+      pde_1d, mom2, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
   param_manager.get_parameter("theta")->value = [&](P const x_v,
                                                     P const t = 0) -> P {
     P const u = param_manager.get_parameter("u")->value(x_v, t);

--- a/src/time_advance_tests.cpp
+++ b/src/time_advance_tests.cpp
@@ -1502,7 +1502,7 @@ TEMPLATE_TEST_CASE("IMEX time advance - twostream", "[imex]", double)
 }
 
 TEMPLATE_TEST_CASE("IMEX time advance - twostream - ASG", "[imex][adapt]",
-                   test_precs)
+                   double)
 {
   // Disable test for MPI - IMEX needs to be tested further with MPI
   if (!is_active() || get_num_ranks() > 1)

--- a/src/time_advance_tests.cpp
+++ b/src/time_advance_tests.cpp
@@ -1603,8 +1603,8 @@ TEMPLATE_TEST_CASE("IMEX time advance - twostream - ASG", "[imex][adapt]",
     std::cout << "    - E_pot     = " << E_pot << "\n";
 
     std::cout << "  => DOF = " << f_val.size() << " = "
-              << TestType{100.0 *
-                          (static_cast<TestType>(f_val.size()) / fg_dof)}
+              << TestType{100.0} *
+                     (static_cast<TestType>(f_val.size()) / fg_dof)
               << "% FG DOF\n";
 
     // calculate the absolute relative total energy

--- a/src/time_advance_tests.cpp
+++ b/src/time_advance_tests.cpp
@@ -1327,12 +1327,12 @@ TEMPLATE_TEST_CASE("IMEX time advance - landau", "[imex]", test_precs)
   TestType E_kin_initial = 0.0;
 
   // -- time loop
-  for (auto i = 0; i < opts.num_time_steps; ++i)
+  for (int i = 0; i < opts.num_time_steps; ++i)
   {
     std::cout.setstate(std::ios_base::failbit);
-    auto const time          = i * pde->get_dt();
-    auto const update_system = i == 0;
-    auto const sol           = time_advance::adaptive_advance(
+    TestType const time            = i * pde->get_dt();
+    bool const update_system       = i == 0;
+    fk::vector<TestType> const sol = time_advance::adaptive_advance(
         asgard::time_advance::method::imex, *pde, operator_matrices,
         adaptive_grid, transformer, opts, f_val, time, update_system);
 
@@ -1425,12 +1425,12 @@ TEMPLATE_TEST_CASE("IMEX time advance - twostream", "[imex]", double)
   TestType E_kin_initial = 0.0;
 
   // -- time loop
-  for (auto i = 0; i < opts.num_time_steps; ++i)
+  for (int i = 0; i < opts.num_time_steps; ++i)
   {
     std::cout.setstate(std::ios_base::failbit);
-    auto const time          = i * pde->get_dt();
-    auto const update_system = i == 0;
-    auto const sol           = time_advance::adaptive_advance(
+    TestType const time            = i * pde->get_dt();
+    bool const update_system       = i == 0;
+    fk::vector<TestType> const sol = time_advance::adaptive_advance(
         asgard::time_advance::method::imex, *pde, operator_matrices,
         adaptive_grid, transformer, opts, f_val, time, update_system);
 
@@ -1569,12 +1569,12 @@ TEMPLATE_TEST_CASE("IMEX time advance - twostream - ASG", "[imex][adapt]",
   int const fg_dof = std::pow(degree * std::pow(2, levels[0]), 2);
 
   // -- time loop
-  for (auto i = 0; i < opts.num_time_steps; ++i)
+  for (int i = 0; i < opts.num_time_steps; ++i)
   {
     std::cout.setstate(std::ios_base::failbit);
-    auto const time          = i * pde->get_dt();
-    auto const update_system = i == 0;
-    auto const sol           = time_advance::adaptive_advance(
+    TestType const time            = i * pde->get_dt();
+    bool const update_system       = i == 0;
+    fk::vector<TestType> const sol = time_advance::adaptive_advance(
         asgard::time_advance::method::imex, *pde, operator_matrices,
         adaptive_grid, transformer, opts, f_val, time, update_system);
 

--- a/src/time_advance_tests.cpp
+++ b/src/time_advance_tests.cpp
@@ -63,7 +63,14 @@ void time_advance_test(parser const &parse,
   generate_dimension_mass_mat(*pde, transformer);
 
   // -- set coeffs
-  generate_all_coefficients(*pde, transformer);
+  if (parse.do_adapt_levels())
+  {
+    generate_all_coefficients_max_level(*pde, transformer);
+  }
+  else
+  {
+    generate_all_coefficients(*pde, transformer);
+  }
 
   // -- generate initial condition vector.
   auto const initial_condition =

--- a/src/time_advance_tests.cpp
+++ b/src/time_advance_tests.cpp
@@ -1513,7 +1513,7 @@ TEMPLATE_TEST_CASE("IMEX time advance - twostream - ASG", "[imex][adapt]",
   std::string const pde_choice = "two_stream";
   fk::vector<int> const levels{5, 5};
   int const degree            = 3;
-  static int constexpr nsteps = 600;
+  static int constexpr nsteps = 10;
 
   TestType constexpr tolerance =
       std::is_same<TestType, double>::value ? 1.0e-9 : 1.0e-5;

--- a/src/time_advance_tests.cpp
+++ b/src/time_advance_tests.cpp
@@ -1501,6 +1501,160 @@ TEMPLATE_TEST_CASE("IMEX time advance - twostream", "[imex]", double)
   parameter_manager<TestType>::get_instance().reset();
 }
 
+TEMPLATE_TEST_CASE("IMEX time advance - twostream - ASG", "[imex][adapt]",
+                   test_precs)
+{
+  // Disable test for MPI - IMEX needs to be tested further with MPI
+  if (!is_active() || get_num_ranks() > 1)
+  {
+    return;
+  }
+
+  std::string const pde_choice = "two_stream";
+  fk::vector<int> const levels{5, 5};
+  int const degree            = 3;
+  static int constexpr nsteps = 600;
+
+  TestType constexpr tolerance =
+      std::is_same<TestType, double>::value ? 1.0e-9 : 1.0e-5;
+
+  parser parse(pde_choice, levels);
+  parser_mod::set(parse, parser_mod::degree, degree);
+  parser_mod::set(parse, parser_mod::dt, 6.25e-3);
+  parser_mod::set(parse, parser_mod::use_imex_stepping, true);
+  parser_mod::set(parse, parser_mod::use_full_grid, false);
+  parser_mod::set(parse, parser_mod::do_adapt, true);
+  parser_mod::set(parse, parser_mod::max_level, 5);
+  parser_mod::set(parse, parser_mod::adapt_threshold, 1.0e-6);
+  parser_mod::set(parse, parser_mod::num_time_steps, nsteps);
+
+  auto const pde = make_PDE<TestType>(parse);
+
+  options const opts(parse);
+  elements::table const check(opts, *pde);
+
+  adapt::distributed_grid adaptive_grid(*pde, opts);
+  basis::wavelet_transform<TestType, resource::host> const transformer(opts,
+                                                                       *pde);
+
+  // -- compute dimension mass matrices
+  generate_dimension_mass_mat(*pde, transformer);
+
+  // -- set coeffs
+  generate_all_coefficients(*pde, transformer);
+
+  // -- generate moments
+  for (auto &m : pde->moments)
+  {
+    m.createFlist(*pde, opts);
+    expect(m.get_fList().size() > 0);
+
+    m.createMomentVector(*pde, parse, adaptive_grid.get_table());
+    expect(m.get_vector().size() > 0);
+  }
+
+  // -- generate initial condition vector.
+  auto const initial_condition =
+      adaptive_grid.get_initial_condition(*pde, transformer, opts);
+
+  generate_dimension_mass_mat(*pde, transformer);
+
+  fk::vector<TestType> f_val(initial_condition);
+  asgard::matrix_list<TestType> operator_matrices;
+
+  TestType E_pot_initial = 0.0;
+  TestType E_kin_initial = 0.0;
+
+  // number of DOF for the FG case: (degree * 2^level)^2 = 9.216e3
+  int const fg_dof = std::pow(degree * std::pow(2, levels[0]), 2);
+
+  // -- time loop
+  for (auto i = 0; i < opts.num_time_steps; ++i)
+  {
+    std::cout.setstate(std::ios_base::failbit);
+    auto const time          = i * pde->get_dt();
+    auto const update_system = i == 0;
+    auto const sol           = time_advance::adaptive_advance(
+        asgard::time_advance::method::imex, *pde, operator_matrices,
+        adaptive_grid, transformer, opts, f_val, time, update_system);
+
+    f_val.resize(sol.size()) = sol;
+    std::cout.clear();
+
+    // compute the E potential and kinetic energy
+    fk::vector<TestType> E_field_sq(pde->E_field);
+    for (auto &e : E_field_sq)
+    {
+      e = e * e;
+    }
+    dimension<TestType> &dim = pde->get_dimensions()[0];
+    TestType E_pot           = calculate_integral(E_field_sq, dim);
+    TestType E_kin =
+        calculate_integral(pde->moments[2].get_realspace_moment(), dim);
+    if (i == 0)
+    {
+      E_pot_initial = E_pot;
+      E_kin_initial = E_kin;
+    }
+
+    TestType E_tot = E_pot + E_kin;
+    std::cout << i << ": E_tot = " << E_tot << "\n";
+    std::cout << "    - E_kinetic = " << E_kin << "\n";
+    std::cout << "    - E_pot     = " << E_pot << "\n";
+
+    std::cout << "  => DOF = " << f_val.size() << " = "
+              << TestType{100.0 *
+                          (static_cast<TestType>(f_val.size()) / fg_dof)}
+              << "% FG DOF\n";
+
+    // calculate the absolute relative total energy
+    TestType E_relative =
+        std::fabs((E_pot + E_kin) - (E_pot_initial + E_kin_initial));
+    std::cout << " E_relative = " << E_relative << "\n";
+    // REQUIRE(E_relative <= tolerance);
+
+    // calculate integral of moments
+    fk::vector<TestType> mom0 = pde->moments[0].get_realspace_moment();
+    fk::vector<TestType> mom1 = pde->moments[1].get_realspace_moment();
+
+    TestType n_total = calculate_integral(fm::scal(TestType{2.0}, mom0), dim);
+
+    fk::vector<TestType> n_times_u(mom0.size());
+    for (int j = 0; j < n_times_u.size(); j++)
+    {
+      n_times_u[j] = mom0[j] * mom1[j];
+    }
+
+    TestType nu_total = calculate_integral(n_times_u, dim);
+    std::cout << "   n   total = " << n_total << "\n";
+    std::cout << "   n*u total = " << nu_total << "\n";
+
+    // n total should be close to 6.28
+    REQUIRE((n_total - 6.283185) <= 1.0e-4);
+
+    // n*u total should be 0
+    REQUIRE(nu_total <= 1.0e-14);
+
+    // total relative energy change drops and stabilizes around 2.0e-5
+    REQUIRE(E_relative <= 5.5e-5);
+
+    if (i > 0 && i < 100)
+    {
+      // check the initial slight energy decay before it stabilizes
+      // Total energy at time step 1:   5.4952938
+      // Total energy at time step 100: 5.4952734
+      REQUIRE(E_relative >= tolerance);
+    }
+
+    // for this configuration, the DOF of ASG / DOF of FG should be between
+    // 50-60%. Testing against 65% is conservative but will capture issues with
+    // adaptivity
+    REQUIRE(static_cast<TestType>(f_val.size()) / fg_dof <= 0.65);
+  }
+
+  parameter_manager<TestType>::get_instance().reset();
+}
+
 /*****************************************************************************
  * Testing the ability to split a matrix into multiple calls
  *****************************************************************************/

--- a/src/transformations.hpp
+++ b/src/transformations.hpp
@@ -248,12 +248,10 @@ inline void transform_and_combine_dimensions(
         dim, v_functions[i], dim.volume_jacobian_dV, transformer, time));
     int const n = dimension_components.back().size();
     std::vector<int> ipiv(n);
-    fk::matrix<P, mem_type::const_view> const lhs_mass(dim.get_mass_matrix(), 0,
-                                                       n - 1, 0, n - 1);
+    fk::matrix<P> lhs_mass = dim.get_mass_matrix();
     expect(lhs_mass.nrows() == n);
     expect(lhs_mass.ncols() == n);
-    fk::matrix<P> mass_copy(lhs_mass);
-    fm::gesv(mass_copy, dimension_components.back(), ipiv);
+    fm::gesv(lhs_mass, dimension_components.back(), ipiv);
   }
 
   combine_dimensions(degree, table, start, stop, dimension_components,


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

- This introduces adaptivity for IMEX, and adds temporary changes to fix coefficient generation to use the adapted level rather than each level up to `max_level`.
- Fixes issue with 1D transformation in IMEX when running with adaptivity enabled.
- Moves several redundant `generate_all_coefficients` calls in IMEX when not running problem with a collision operator.
- Hash table and degrees of freedom are now saved to file
- Fixes several realspace transformation issues for plotting, file output due to adaptivity grid changes.
- Fixes redundant realspace transformation in `main` even if not plotting or saving realspace data.

Closes #516.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [x] New feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

Ubuntu 20.04

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
