### PR TITLE
Fix kronmult operator size when not using adaptivity

### DIFF
--- a/src/basis.hpp
+++ b/src/basis.hpp
@@ -44,7 +44,13 @@ public:
 
   wavelet_transform(options const &program_opts, PDE<P> const &pde,
                     bool const quiet = true)
-      : wavelet_transform(program_opts.max_level,
+      : // Choose which max level to use depending on whether adaptivity is
+        // enabled.
+        // If adaptivity is enabled, use the program_opts.max_level
+        // Otherwise, use the max_level defined in the PDE (max level of all
+        // dims)
+        wavelet_transform(program_opts.do_adapt_levels ? program_opts.max_level
+                                                       : pde.max_level,
                           pde.get_dimensions()[0].get_degree(), quiet)
   {}
 

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -571,8 +571,7 @@ public:
         expect(term_1D.get_partial_terms().size() > 0);
 
         auto const max_dof =
-            fm::two_raised_to(static_cast<int64_t>(cli_input.get_max_level())) *
-            degree;
+            fm::two_raised_to(static_cast<int64_t>(max_level)) * degree;
         expect(max_dof < INT_MAX);
 
         term_1D.set_coefficients(eye<P>(max_dof));
@@ -604,8 +603,7 @@ public:
     for (auto i = 0; i < num_dims; ++i)
     {
       auto const max_dof =
-          fm::two_raised_to(static_cast<int64_t>(cli_input.get_max_level())) *
-          degree;
+          fm::two_raised_to(static_cast<int64_t>(max_level)) * degree;
       expect(max_dof < INT_MAX);
       update_dimension_mass_mat(i, eye<P>(max_dof));
     }


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

This adjusts several places where the max level for adaptivity was being used to create the kronmult operator workspace and PDE coefficients. When not running with adaptivity enabled, this uses the maximum level defined over all dimensions instead, saving time and memory.

This fixes having to use a temporary workaround of specifying the `-m` option even when running without adaptivity enabled.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

Ubuntu 20.04 + CUDA build, landau damping problem

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
