### PR TITLE
Compare return value without naming it

### DIFF
--- a/src/lib_dispatch.cpp
+++ b/src/lib_dispatch.cpp
@@ -709,7 +709,7 @@ void getrf(int *m, int *n, P *A, int *lda, int *ipiv, int *info,
     ignore(m);
 
     P **A_d;
-    if (auto stat = cudaMalloc((void **)&A_d, sizeof(P *)); stat != cudaSuccess)
+    if (cudaMalloc((void **)&A_d, sizeof(P *)) != cudaSuccess)
     {
       throw std::bad_alloc();
     }
@@ -774,12 +774,11 @@ void getri(int *n, P *A, int *lda, int *ipiv, P *work, int *lwork, int *info,
 
     P const **A_d;
     P **work_d;
-    if (auto stat = cudaMalloc((void **)&A_d, sizeof(P *)); stat != cudaSuccess)
+    if (cudaMalloc((void **)&A_d, sizeof(P *)) != cudaSuccess)
     {
       throw std::bad_alloc();
     }
-    if (auto stat = cudaMalloc((void **)&work_d, sizeof(P *));
-        stat != cudaSuccess)
+    if (cudaMalloc((void **)&work_d, sizeof(P *)) != cudaSuccess)
     {
       throw std::bad_alloc();
     }
@@ -855,15 +854,15 @@ void batched_gemm(P **const &a, int *lda, char const *transa, P **const &b,
     P **c_d;
     size_t const list_size = *num_batch * sizeof(P *);
 
-    if (auto stat = cudaMalloc((void **)&a_d, list_size); stat != cudaSuccess)
+    if (cudaMalloc((void **)&a_d, list_size) != cudaSuccess)
     {
       throw std::bad_alloc();
     }
-    if (auto stat = cudaMalloc((void **)&b_d, list_size); stat != cudaSuccess)
+    if (cudaMalloc((void **)&b_d, list_size) != cudaSuccess)
     {
       throw std::bad_alloc();
     }
-    if (auto stat = cudaMalloc((void **)&c_d, list_size); stat != cudaSuccess)
+    if (cudaMalloc((void **)&c_d, list_size) != cudaSuccess)
     {
       throw std::bad_alloc();
     }
@@ -957,15 +956,15 @@ void batched_gemv(P **const &a, int *lda, char const *trans, P **const &x,
     P **y_d;
     size_t const list_size = *num_batch * sizeof(P *);
 
-    if (auto stat = cudaMalloc((void **)&a_d, list_size); stat != cudaSuccess)
+    if (cudaMalloc((void **)&a_d, list_size) != cudaSuccess)
     {
       throw std::bad_alloc();
     }
-    if (auto stat = cudaMalloc((void **)&x_d, list_size); stat != cudaSuccess)
+    if (cudaMalloc((void **)&x_d, list_size) != cudaSuccess)
     {
       throw std::bad_alloc();
     }
-    if (auto stat = cudaMalloc((void **)&y_d, list_size); stat != cudaSuccess)
+    if (cudaMalloc((void **)&y_d, list_size) != cudaSuccess)
     {
       throw std::bad_alloc();
     }

--- a/src/tensors.hpp
+++ b/src/tensors.hpp
@@ -838,8 +838,7 @@ inline void
 allocate_device(P *&ptr, int64_t const num_elems, bool const initialize = true)
 {
 #ifdef ASGARD_USE_CUDA
-  if (auto success = cudaMalloc((void **)&ptr, num_elems * sizeof(P));
-      success != cudaSuccess)
+  if (cudaMalloc((void **)&ptr, num_elems * sizeof(P)) != cudaSuccess)
   {
     throw std::bad_alloc();
   }


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

@mkstoyanov pointed out in #527 that we can check the return value of cudaMalloc in one step and without storing the result.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [ ] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
