### PR TITLE
Kernel improvements

### DIFF
--- a/src/device/asgard_kronmult.hpp
+++ b/src/device/asgard_kronmult.hpp
@@ -11,8 +11,8 @@ namespace asgard::kronmult
 #ifdef USE_GPU
 
 template<typename T, int n>
-void gpu1d(T const *const pA[], int const lda, T const *const pX[],
-           T *pY[], int const num_batch)
+void gpu1d(T const *const pA[], int const lda, T const *const pX[], T *pY[],
+           int const num_batch)
 {
   static_assert(n == 2 or n == 3 or n == 4,
                 "unimplemented size n (i.e., polynomial degree)");
@@ -22,41 +22,44 @@ void gpu1d(T const *const pA[], int const lda, T const *const pX[],
            // block repeats some integer ops.
 
   constexpr int num_threads = 1024;
-  constexpr int batch_per_block = (n==3) ? 10 * num_threads/32 : num_threads / n;
+  constexpr int batch_per_block =
+      (n == 3) ? 10 * num_threads / 32 : num_threads / n;
 
   int num_blocks = blocks(num_batch, batch_per_block, max_blocks);
 
   kernel::gpu1d<T, num_threads, n>
-        <<<num_blocks, num_threads>>>(pA, lda, pX, pY, num_batch);
+      <<<num_blocks, num_threads>>>(pA, lda, pX, pY, num_batch);
 }
 
 template<typename T, int n>
-void gpu2d(T const *const pA[], int const lda, T const *const pX[],
-           T *pY[], int const num_batch)
+void gpu2d(T const *const pA[], int const lda, T const *const pX[], T *pY[],
+           int const num_batch)
 {
   static_assert(n == 2 or n == 3 or n == 4,
                 "unimplemented size n (i.e., polynomial degree)");
 
-  constexpr int max_blocks = 300;
+  constexpr int max_blocks  = 300;
   constexpr int num_threads = 1024;
-  constexpr int batch_per_block = (n==2) ? num_threads/4 : ( (n==3) ? 3 * (num_threads / 32) : num_threads / 16 );
+  constexpr int batch_per_block =
+      (n == 2) ? num_threads / 4
+               : ((n == 3) ? 3 * (num_threads / 32) : num_threads / 16);
 
   int num_blocks = blocks(num_batch, batch_per_block, max_blocks);
 
   kernel::gpu2d<T, num_threads, n>
-        <<<num_blocks, num_threads>>>(pA, lda, pX, pY, num_batch);
+      <<<num_blocks, num_threads>>>(pA, lda, pX, pY, num_batch);
 }
 
 template<typename T, int n>
-void gpu3d(T const *const pA[], int const lda, T const *const pX[],
-           T *pY[], int const num_batch)
+void gpu3d(T const *const pA[], int const lda, T const *const pX[], T *pY[],
+           int const num_batch)
 {
   static_assert(n == 2 or n == 3 or n == 4,
                 "unimplemented size n (i.e., polynomial degree)");
 
-  constexpr int max_blocks = 300;
-  constexpr int num_threads = 1024;
-  constexpr int batch_per_block = num_threads / ( (n == 2) ? 8 : 32 );
+  constexpr int max_blocks      = 300;
+  constexpr int num_threads     = 1024;
+  constexpr int batch_per_block = num_threads / ((n == 2) ? 8 : 32);
 
   int num_blocks = blocks(num_batch, batch_per_block, max_blocks);
 

--- a/src/device/asgard_kronmult.hpp
+++ b/src/device/asgard_kronmult.hpp
@@ -11,8 +11,8 @@ namespace asgard::kronmult
 #ifdef USE_GPU
 
 template<typename T, int n>
-void gpu1d(T const *const Aarray_[], int const lda, T const *const pX_[],
-           T *pY_[], int const num_batch)
+void gpu1d(T const *const pA[], int const lda, T const *const pX[],
+           T *pY[], int const num_batch)
 {
   static_assert(n == 2 or n == 3 or n == 4,
                 "unimplemented size n (i.e., polynomial degree)");
@@ -20,73 +20,36 @@ void gpu1d(T const *const Aarray_[], int const lda, T const *const pX_[],
   constexpr int max_blocks =
       300; // we want enough blocks to saturate the GPU, but note that each
            // block repeats some integer ops.
-  if constexpr (n == 2)
-  {
-    int constexpr num_threads = 1024;
-    int num_blocks            = std::min(
-        max_blocks, (num_batch + num_threads / 2 - 1) /
-                        (num_threads / 2)); // one operation takes two threads
-    kernel::gpu1d<T, num_threads, 2>
-        <<<num_blocks, num_threads>>>(Aarray_, lda, pX_, pY_, num_batch);
-  }
-  else if constexpr (n == 3)
-  {
-    int constexpr num_threads = 32;
-    int num_blocks            = std::min(
-        max_blocks, (num_batch + 9) / 10); // one operation takes two threads
-    kernel::gpu1d<T, num_threads, 3>
-        <<<num_blocks, num_threads>>>(Aarray_, lda, pX_, pY_, num_batch);
-  }
-  else if constexpr (n == 4)
-  {
-    int constexpr num_threads = 1024;
-    int num_blocks = std::min(max_blocks, (num_batch + num_threads / 4 - 1) /
-                                              (num_threads / 4));
-    kernel::gpu1d<T, num_threads, 4>
-        <<<num_blocks, num_threads>>>(Aarray_, lda, pX_, pY_, num_batch);
-  }
+
+  constexpr int num_threads = 1024;
+  constexpr int batch_per_block = (n==3) ? 10 * num_threads/32 : num_threads / n;
+
+  int num_blocks = blocks(num_batch, batch_per_block, max_blocks);
+
+  kernel::gpu1d<T, num_threads, n>
+        <<<num_blocks, num_threads>>>(pA, lda, pX, pY, num_batch);
 }
 
 template<typename T, int n>
-void gpu2d(T const *const Aarray_[], int const lda, T const *const pX_[],
-           T *pY_[], int const num_batch)
+void gpu2d(T const *const pA[], int const lda, T const *const pX[],
+           T *pY[], int const num_batch)
 {
   static_assert(n == 2 or n == 3 or n == 4,
                 "unimplemented size n (i.e., polynomial degree)");
 
   constexpr int max_blocks = 300;
-  if constexpr (n == 2)
-  {
-    int constexpr num_threads = 1024;
-    int num_blocks            = std::min(
-        max_blocks, (num_batch + num_threads / 4 - 1) /
-                        (num_threads / 4)); // one operation takes two threads
-    kernel::gpu2d<T, num_threads, 2>
-        <<<num_blocks, num_threads>>>(Aarray_, lda, pX_, pY_, num_batch);
-  }
-  else if constexpr (n == 3)
-  {
-    int constexpr num_threads = 1024;
-    int num_blocks            = std::min(
-        max_blocks, (num_batch + 3 * (num_threads / 32) - 1) /
-                        (3 * (num_threads / 32))); // one operation takes two threads
-    kernel::gpu2d<T, num_threads, 3>
-        <<<num_blocks, num_threads>>>(Aarray_, lda, pX_, pY_, num_batch);
-  }
-  else if constexpr (n == 4)
-  {
-    int constexpr num_threads = 1024;
-    int num_blocks            = std::min(
-        max_blocks, (num_batch + num_threads / 16 - 1) /
-                        (num_threads / 16)); // one operation takes two threads
-    kernel::gpu2d<T, num_threads, 4>
-        <<<num_blocks, num_threads>>>(Aarray_, lda, pX_, pY_, num_batch);
-  }
+  constexpr int num_threads = 1024;
+  constexpr int batch_per_block = (n==2) ? num_threads/4 : ( (n==3) ? 3 * (num_threads / 32) : num_threads / 16 );
+
+  int num_blocks = blocks(num_batch, batch_per_block, max_blocks);
+
+  kernel::gpu2d<T, num_threads, n>
+        <<<num_blocks, num_threads>>>(pA, lda, pX, pY, num_batch);
 }
 
 template<typename T, int n>
-void gpu3d(T const *const Aarray_[], int const lda, T const *const pX_[],
-           T *pY_[], int const batchCount)
+void gpu3d(T const *const pA[], int const lda, T const *const pX[],
+           T *pY[], int const num_batch)
 {
   static_assert(n == 2 or n == 3 or n == 4,
                 "unimplemented size n (i.e., polynomial degree)");
@@ -95,17 +58,17 @@ void gpu3d(T const *const Aarray_[], int const lda, T const *const pX_[],
   constexpr int num_threads = 1024;
   constexpr int batch_per_block = num_threads / ( (n == 2) ? 8 : 32 );
 
-  int num_blocks = blocks(batchCount, batch_per_block, max_blocks);
+  int num_blocks = blocks(num_batch, batch_per_block, max_blocks);
 
   if constexpr (n == 2 or n == 3)
   {
     kernel::gpu3d<T, num_threads, n>
-        <<<num_blocks, num_threads>>>(Aarray_, lda, pX_, pY_, batchCount);
+        <<<num_blocks, num_threads>>>(pA, lda, pX, pY, num_batch);
   }
   else if constexpr (n == 4)
   {
     kernel::gpu3d_n4<T, num_threads>
-        <<<num_blocks, num_threads>>>(Aarray_, lda, pX_, pY_, batchCount);
+        <<<num_blocks, num_threads>>>(pA, lda, pX, pY, num_batch);
   }
 }
 

--- a/src/device/asgard_kronmult.hpp
+++ b/src/device/asgard_kronmult.hpp
@@ -88,7 +88,7 @@ template<typename T, int n>
 void gpu3d(T const *const Aarray_[], int const lda, T const *const pX_[],
            T *pY_[], int const batchCount)
 {
-  static_assert(n == 2 or n == 3,
+  static_assert(n == 2 or n == 3 or n == 4,
                 "unimplemented size n (i.e., polynomial degree)");
 
   constexpr int max_blocks = 300;
@@ -109,6 +109,14 @@ void gpu3d(T const *const Aarray_[], int const lda, T const *const pX_[],
                         (num_threads / 27)); // one operation takes two threads
     kernel::gpu3d<T, num_threads, 3>
         <<<num_blocks, num_threads>>>(Aarray_, lda, pX_, pY_, batchCount);
+  }
+  else if constexpr (n == 4)
+  {
+    int constexpr num_threads = 1024;
+    int num_blocks            = std::min(
+        max_blocks, (batchCount + num_threads / 32 - 1) /
+                        (num_threads / 32));
+    kernel::gpu3d_n4<T, num_threads><<<num_blocks, num_threads>>>(Aarray_, lda, pX_, pY_, batchCount);
   }
 }
 

--- a/src/device/asgard_kronmult1d.hpp
+++ b/src/device/asgard_kronmult1d.hpp
@@ -44,29 +44,39 @@ __global__ void gpu1d(T const *const pA[], int const lda, T const *const pX[],
   static_assert(n == 2 or n == 3 or n == 4,
                 "kernel works only for n = 2, 3, 4");
 
-  constexpr int i_per_block = (n==3) ? (10 * (num_threads / 32)) : (num_threads / n);
+  constexpr int i_per_block =
+      (n == 3) ? (10 * (num_threads / 32)) : (num_threads / n);
 
   __shared__ T X[num_threads];
 
   // i is the index of the batch, locali is the index within the thread-block
   int locali;
-  if constexpr (n == 3){
+  if constexpr (n == 3)
+  {
     locali = 10 * (threadIdx.x / 32) + (threadIdx.x % 32) / n;
-  }else{
+  }
+  else
+  {
     locali = threadIdx.x / n;
   }
 
   int i = locali + blockIdx.x * i_per_block; // index within the batch
   int j; // indicated whether this is an even or odd thread
-  if constexpr (n ==3){
+  if constexpr (n == 3)
+  {
     j = (threadIdx.x % 32) % n;
-  }else{
+  }
+  else
+  {
     j = threadIdx.x % n;
   }
   int localx0; // the entry of x within the cache
-  if constexpr (n ==3){
+  if constexpr (n == 3)
+  {
     localx0 = 32 * (threadIdx.x / 32) + n * ((threadIdx.x % 32) / n);
-  }else{
+  }
+  else
+  {
     localx0 = n * locali;
   }
 

--- a/src/device/asgard_kronmult1d.hpp
+++ b/src/device/asgard_kronmult1d.hpp
@@ -44,8 +44,9 @@ __global__ void gpu1d(T const *const pA[], int const lda, T const *const pX[],
   static_assert(n == 2 or n == 3 or n == 4,
                 "kernel works only for n = 2, 3, 4");
 
+  constexpr int team_size = 32;
   constexpr int i_per_block =
-      (n == 3) ? (10 * (num_threads / 32)) : (num_threads / n);
+      (n == 3) ? (10 * (num_threads / team_size)) : (num_threads / n);
 
   __shared__ T X[num_threads];
 
@@ -53,7 +54,7 @@ __global__ void gpu1d(T const *const pA[], int const lda, T const *const pX[],
   int locali;
   if constexpr (n == 3)
   {
-    locali = 10 * (threadIdx.x / 32) + (threadIdx.x % 32) / n;
+    locali = 10 * (threadIdx.x / team_size) + (threadIdx.x % team_size) / n;
   }
   else
   {
@@ -64,7 +65,7 @@ __global__ void gpu1d(T const *const pA[], int const lda, T const *const pX[],
   int j; // indicated whether this is an even or odd thread
   if constexpr (n == 3)
   {
-    j = (threadIdx.x % 32) % n;
+    j = (threadIdx.x % team_size) % n;
   }
   else
   {
@@ -73,7 +74,8 @@ __global__ void gpu1d(T const *const pA[], int const lda, T const *const pX[],
   int localx0; // the entry of x within the cache
   if constexpr (n == 3)
   {
-    localx0 = 32 * (threadIdx.x / 32) + n * ((threadIdx.x % 32) / n);
+    localx0 = team_size * (threadIdx.x / team_size) +
+              n * ((threadIdx.x % team_size) / n);
   }
   else
   {

--- a/src/device/asgard_kronmult2d.hpp
+++ b/src/device/asgard_kronmult2d.hpp
@@ -14,33 +14,43 @@ __global__ void gpu2d(T const *const pA[], int const lda, T const *const pX[],
                 "kernel works only for n = 2, 3, 4");
 
   constexpr int threads_per_i = n * n;
-  constexpr int i_per_block = (n==3) ? (3 * (num_threads / 32)) : (num_threads / threads_per_i);
+  constexpr int i_per_block =
+      (n == 3) ? (3 * (num_threads / 32)) : (num_threads / threads_per_i);
 
   __shared__ T X[num_threads]; // cache for intermediate values
   __shared__ T A[num_threads]; // cache for the matrices
 
   int locali;
-  if constexpr (n == 3){
+  if constexpr (n == 3)
+  {
     locali = 3 * (threadIdx.x / 32) + (threadIdx.x % 32) / threads_per_i;
-  }else{
-    locali = threadIdx.x / threads_per_i; // i is the index of the batch, locali is the
-                                          // index within the thread-block
   }
-  int i = locali +
-          blockIdx.x * i_per_block; // global index within the batch
+  else
+  {
+    locali =
+        threadIdx.x / threads_per_i; // i is the index of the batch, locali is
+                                     // the index within the thread-block
+  }
+  int i = locali + blockIdx.x * i_per_block; // global index within the batch
   int j;
-  if constexpr (n ==3){
+  if constexpr (n == 3)
+  {
     j = (threadIdx.x % 32) % threads_per_i;
-  }else{
+  }
+  else
+  {
     j = threadIdx.x % threads_per_i;
   }
 
   int matj = j % n + (j / n) * lda;
 
   int ix;
-  if constexpr (n ==3){
+  if constexpr (n == 3)
+  {
     ix = 32 * (threadIdx.x / 32) + 9 * ((threadIdx.x % 32) / 9);
-  }else{
+  }
+  else
+  {
     ix = threads_per_i * locali;
   }
   int iat = ix + j / n;

--- a/src/device/asgard_kronmult2d.hpp
+++ b/src/device/asgard_kronmult2d.hpp
@@ -12,31 +12,46 @@ __global__ void gpu2d(T const *const pA[], int const lda, T const *const pX[],
 {
   static_assert(n == 2 or n == 3 or n == 4,
                 "kernel works only for n = 2, 3, 4");
-  static_assert(n != 3 or (n == 3 and num_threads == 32),
-                "restriction on warp size limit this kernel to 32 threads");
+//  static_assert(n != 3 or (n == 3 and num_threads == 32),
+//                "restriction on warp size limit this kernel to 32 threads");
 
   constexpr int threads_per_i = n * n;
+  constexpr int i_per_block = (n==3) ? (3 * (num_threads / 32)) : (num_threads / threads_per_i);
 
   __shared__ T X[num_threads]; // cache for intermediate values
   __shared__ T A[num_threads]; // cache for the matrices
 
-  int locali =
-      threadIdx.x / threads_per_i; // i is the index of the batch, locali is the
-                                   // index within the thread-block
+  int locali;
+  if constexpr (n == 3){
+    locali = 3 * (threadIdx.x / 32) + (threadIdx.x % 32) / threads_per_i;
+  }else{
+    locali = threadIdx.x / threads_per_i; // i is the index of the batch, locali is the
+                                          // index within the thread-block
+  }
   int i = locali +
-          blockIdx.x *
-              (num_threads / threads_per_i); // global index within the batch
-  int j    = threadIdx.x % threads_per_i;
+          blockIdx.x * i_per_block; // global index within the batch
+  int j;
+  if constexpr (n ==3){
+    j = (threadIdx.x % 32) % threads_per_i;
+  }else{
+    j = threadIdx.x % threads_per_i;
+  }
+
   int matj = j % n + (j / n) * lda;
 
-  int ix  = threads_per_i * locali;
+  int ix;
+  if constexpr (n ==3){
+    ix = 32 * (threadIdx.x / 32) + 9 * ((threadIdx.x % 32) / 9);
+  }else{
+    ix = threads_per_i * locali;
+  }
   int iat = ix + j / n;
   int ia  = ix + n * (j / n);
-  ix += threadIdx.x % n;
+  ix += j % n;
   if constexpr (n == 3)
   { // done at compile time since n is a template parameter
     // disable the last two threads of the warp since 32 does not divide into 3
-    if (threadIdx.x >= 27)
+    if (threadIdx.x % 32 >= 27)
     {
       i = num_batch;
     }
@@ -81,7 +96,7 @@ __global__ void gpu2d(T const *const pA[], int const lda, T const *const pX[],
 
     atomicAdd(&pY[i][j], yinc);
 
-    i += gridDim.x * (num_threads / threads_per_i);
+    i += gridDim.x * i_per_block;
   }
 }
 

--- a/src/device/asgard_kronmult2d.hpp
+++ b/src/device/asgard_kronmult2d.hpp
@@ -12,8 +12,6 @@ __global__ void gpu2d(T const *const pA[], int const lda, T const *const pX[],
 {
   static_assert(n == 2 or n == 3 or n == 4,
                 "kernel works only for n = 2, 3, 4");
-//  static_assert(n != 3 or (n == 3 and num_threads == 32),
-//                "restriction on warp size limit this kernel to 32 threads");
 
   constexpr int threads_per_i = n * n;
   constexpr int i_per_block = (n==3) ? (3 * (num_threads / 32)) : (num_threads / threads_per_i);

--- a/src/device/asgard_kronmult3d.hpp
+++ b/src/device/asgard_kronmult3d.hpp
@@ -11,8 +11,6 @@ __global__ void gpu3d(T const *const pA[], int const lda, T const *const pX[],
                       T *pY[], int const num_batch)
 {
   static_assert(n == 2 or n == 3, "kernel works only for n = 2, 3");
-//  static_assert(n != 3 or (n == 3 and num_threads == 32),
-//                "restriction on warp size limit this kernel to 32 threads");
 
   // for n = 3, using full warp of threads 32 instead of 27 (masking the 27)
   constexpr int data_per_proc = (n==3) ? 32 : n * n * n;

--- a/src/device/asgard_kronmult3d.hpp
+++ b/src/device/asgard_kronmult3d.hpp
@@ -87,6 +87,56 @@ __global__ void gpu3d(T const *const pA[], int const lda, T const *const pX[],
   }
 }
 
+// 3d, n = 4 means data has 64 entries, matrices 16
+// using one warp per batch entry, processing the data in two cycles
+template<typename T, int num_threads>
+__global__ void gpu3d_n4(T const *const pA[], int const lda, T const *const pX[],
+                         T *pY[], int const num_batch)
+{
+  __shared__ T X[2][num_threads]; // cache for intermediate values
+  __shared__ T W[2][num_threads]; // cache for intermediate values
+  __shared__ T A[num_threads];
+
+  // do all integer logic once
+  int locali = threadIdx.x / 32;
+  int i = locali + blockIdx.x * (num_threads / 32);
+  int j = threadIdx.x % 32; // local index within the warp
+  int matj = j % 4 + (j / 8) * lda;
+
+  int ix = 32 * locali;
+  int ia2 = ix + j / 16 + 4 * ( (j%16) / 8 );
+  int iw = ix + j%4 + 16 * ( j/16 );
+  int ia1 = ix + (j%16)/4 + 4 * ( j/16 );
+  int iy = ix + 4 * ( j/4 );
+  int ia0 = ix + j%8;
+  ix += threadIdx.x % 16;
+
+  while (i < num_batch)
+  {
+    X[0][threadIdx.x] = pX[i][j];
+    X[1][threadIdx.x] = pX[i][j + 32];
+    A[threadIdx.x] = pA[3 * i][matj];
+
+    W[0][threadIdx.x] = X[0][ix] * A[ia2] + X[0][ix + 16] * A[ia2 + 8] + X[1][ix] * A[ia2 + 16] + X[1][ix + 16] * A[ia2 + 24];
+    W[1][threadIdx.x] = X[0][ix] * A[ia2+2] + X[0][ix + 16] * A[ia2 + 10] + X[1][ix] * A[ia2 + 18] + X[1][ix + 16] * A[ia2 + 26];
+
+    A[threadIdx.x] = pA[3 * i + 1][matj];
+
+    X[0][threadIdx.x] = W[0][iw] * A[ia1] + W[0][iw + 4] * A[ia1 + 8] + W[0][iw + 8] * A[ia1 + 16] + W[0][iw + 12] * A[ia1 + 24];
+    X[1][threadIdx.x] = W[1][iw] * A[ia1] + W[1][iw + 4] * A[ia1 + 8] + W[1][iw + 8] * A[ia1 + 16] + W[1][iw + 12] * A[ia1 + 24];
+
+    A[threadIdx.x] = pA[3 * i + 2][matj];
+
+    T yinc = A[ia0] * X[0][iy] + A[ia0+8] * X[0][iy+1] + A[ia0+16] * X[0][iy+2] + A[ia0+24] * X[0][iy+3];
+    atomicAdd(&pY[i][j], yinc);
+
+    yinc = A[ia0] * X[1][iy] + A[ia0+8] * X[1][iy+1] + A[ia0+16] * X[1][iy+2] + A[ia0+24] * X[1][iy+3];
+    atomicAdd(&pY[i][j + 32], yinc);
+
+    i += gridDim.x * (num_threads / 32);
+  }
+}
+
 #endif
 
 } // namespace asgard::kronmult::kernel

--- a/src/device/asgard_kronmult_common.hpp
+++ b/src/device/asgard_kronmult_common.hpp
@@ -12,7 +12,6 @@
 
 namespace asgard::kronmult
 {
-
 /*!
  * \brief Computes the number of CUDA blocks.
  *
@@ -20,10 +19,12 @@ namespace asgard::kronmult
  * \param work_per_block is the work that a single thread block will execute
  * \param max_blocks is the maximum number of blocks
  */
-inline int blocks(int work_size, int work_per_block, int max_blocks){
-    return std::min(max_blocks, (work_size + work_per_block-1) / work_per_block);
+inline int blocks(int work_size, int work_per_block, int max_blocks)
+{
+  return std::min(max_blocks,
+                  (work_size + work_per_block - 1) / work_per_block);
 }
 
-}
+} // namespace asgard::kronmult
 
 // TODO add intrinsics here too for the CPU

--- a/src/device/asgard_kronmult_common.hpp
+++ b/src/device/asgard_kronmult_common.hpp
@@ -10,4 +10,20 @@
 
 #endif
 
+namespace asgard::kronmult
+{
+
+/*!
+ * \brief Computes the number of CUDA blocks.
+ *
+ * \param work_size is the total amount of work, e.g., size of the batch
+ * \param work_per_block is the work that a single thread block will execute
+ * \param max_blocks is the maximum number of blocks
+ */
+inline int blocks(int work_size, int work_per_block, int max_blocks){
+    return std::min(max_blocks, (work_size + work_per_block-1) / work_per_block);
+}
+
+}
+
 // TODO add intrinsics here too for the CPU

--- a/src/device/kronmult_cuda.cpp
+++ b/src/device/kronmult_cuda.cpp
@@ -370,6 +370,10 @@ void call_kronmult(int const n, P *x_ptrs[], P *output_ptrs[], P *work_ptrs[],
         kronmult::gpu3d<P, 3>(operator_ptrs, lda, x_ptrs, output_ptrs,
                               num_krons);
         break;
+      case 4:
+        kronmult::gpu3d<P, 4>(operator_ptrs, lda, x_ptrs, output_ptrs,
+                              num_krons);
+        break;
       default:
         kronmult3_xbatched<P><<<num_blocks, num_threads>>>(
             n, operator_ptrs, lda, x_ptrs, output_ptrs, work_ptrs, num_krons);


### PR DESCRIPTION
* enabled more than 32 threads when using the kernels for quadratic basis
* cleanup for the block-threads logic and some of the variable names

PS: 3D continuity equation, 8-9 levels and quadratic-cubic basis hit the double precision flop limit of my RTX 2080Ti.

PSS: 2080Ti and 3080 have reduced double-precision capabilities, the Volta gets a teraflop from max of 5.