### PR TITLE
Adjust loop order, simd pragma

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,23 +110,11 @@ endif ()
 
 if (ASGARD_RECOMMENDED_DEFAULTS)
   # add compiler flags we always want to use
-  set (RECOMMENDED_WARNINGS -Wall -Wextra -Wpedantic -Wshadow)
-  set (RECOMMENDED_ARCHS -march=native -mtune=native)
-  # RECOMMENDED_ARCHS improves CPU knonmult performance but adds additional compilation time.
-  if (ASGARD_USE_CUDA)
-    foreach (CXX_FLAG IN LISTS RECOMMENDED_ARCHS)
-      if (CMAKE_CXX_FLAGS MATCHES "${CXX_FLAG}")
-        string(REPLACE "${CXX_FLAG}" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
-      endif ()
-    endforeach ()
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wshadow")
+  # Improves CPU knonmult performance but adds additional compilation time.
+  if (NOT ASGARD_USE_CUDA)
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -mtune=native")
   endif ()
-  foreach (CXX_FLAG IN LISTS RECOMMENDED_WARNINGS $<$<BOOL:${ASGARD_USE_CUDA}>:RECOMMENDED_ARCHS:>)
-    if (NOT CMAKE_CXX_FLAGS MATCHES "${CXX_FLAG}")
-      set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAG}")
-    endif ()
-  endforeach ()
-  string (STRIP ${CMAKE_CXX_FLAGS} CMAKE_CXX_FLAGS)
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" CACHE STRING "compiler flags" FORCE)
 endif ()
 
 # add scripts directory location

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,12 +106,15 @@ option (ASGARD_BUILD_DOCS "Build the documentation." OFF)
 
 if (${ASGARD_USE_PCH})
   set (USE_PCH ON CACHE BOOL "Turn on kronmult precompiled header support" FORCE)
-endif()
+endif ()
 
 if (ASGARD_RECOMMENDED_DEFAULTS)
   # add compiler flags we always want to use
-  string(APPEND CMAKE_CXX_FLAGS " -Wall -Wextra -Wpedantic -Wshadow")
-endif()
+  set (RECOMMENDED_CXXFLAGS "-march=native -Wall -Wextra -Wpedantic -Wshadow")
+  if (NOT CMAKE_CXX_FLAGS MATCHES "${RECOMMENDED_CXXFLAGS}")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${RECOMMENDED_CXXFLAGS}" CACHE STRING "compiler flags" FORCE)
+  endif ()
+endif ()
 
 # add scripts directory location
 set(ASGARD_SCRIPTS_DIR "${CMAKE_SOURCE_DIR}/scripts/")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,10 +110,23 @@ endif ()
 
 if (ASGARD_RECOMMENDED_DEFAULTS)
   # add compiler flags we always want to use
-  set (RECOMMENDED_CXXFLAGS "-march=native -Wall -Wextra -Wpedantic -Wshadow")
-  if (NOT CMAKE_CXX_FLAGS MATCHES "${RECOMMENDED_CXXFLAGS}")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${RECOMMENDED_CXXFLAGS}" CACHE STRING "compiler flags" FORCE)
+  set (RECOMMENDED_WARNINGS -Wall -Wextra -Wpedantic -Wshadow)
+  set (RECOMMENDED_ARCHS -march=native -mtune=native)
+  # RECOMMENDED_ARCHS improves CPU knonmult performance but adds additional compilation time.
+  if (ASGARD_USE_CUDA)
+    foreach (CXX_FLAG IN LISTS RECOMMENDED_ARCHS)
+      if (CMAKE_CXX_FLAGS MATCHES "${CXX_FLAG}")
+        string(REPLACE "${CXX_FLAG}" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+      endif ()
+    endforeach ()
   endif ()
+  foreach (CXX_FLAG IN LISTS RECOMMENDED_WARNINGS $<$<BOOL:${ASGARD_USE_CUDA}>:RECOMMENDED_ARCHS:>)
+    if (NOT CMAKE_CXX_FLAGS MATCHES "${CXX_FLAG}")
+      set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAG}")
+    endif ()
+  endforeach ()
+  string (STRIP ${CMAKE_CXX_FLAGS} CMAKE_CXX_FLAGS)
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" CACHE STRING "compiler flags" FORCE)
 endif ()
 
 # add scripts directory location

--- a/src/basis_tests.cpp
+++ b/src/basis_tests.cpp
@@ -117,7 +117,7 @@ void test_operator_two_scale(int const levels, int const degree)
   fk::matrix<P> const gold = fk::matrix<P>(read_matrix_from_txt_file(filename));
   fk::matrix<P> const test = operator_two_scale<P>(degree, levels);
 
-  auto constexpr tol_factor = get_tolerance<P>(10);
+  auto constexpr tol_factor = get_tolerance<P>(100);
 
   rmse_comparison(gold, test, tol_factor);
 }
@@ -161,7 +161,7 @@ TEMPLATE_TEST_CASE("operator_two_scale function working appropriately",
 template<typename P, resource resrc>
 void test_fmwt_block_generation(int const level, int const degree)
 {
-  P constexpr tol = std::is_same_v<P, float> ? 1e-4 : 1e-14;
+  P constexpr tol = std::is_same_v<P, float> ? 1e-4 : 1e-13;
 
   // none of these options matter except for max level and degree
   auto const pde_choice = "diffusion_2";

--- a/src/coefficients_tests.cpp
+++ b/src/coefficients_tests.cpp
@@ -234,7 +234,7 @@ TEMPLATE_TEST_CASE("fokkerplanck1_4p3 terms", "[coefficients]", double, float)
   auto const gold_path =
       coefficients_base_dir / "fokkerplanck1_4p3_coefficients";
   TestType const tol_factor =
-      std::is_same<TestType, double>::value ? 1e-14 : 1e-4;
+      std::is_same<TestType, double>::value ? 1e-13 : 1e-4;
 
   SECTION("level 2, degree 5")
   {

--- a/src/device/asgard_kronmult_cpu.cpp
+++ b/src/device/asgard_kronmult_cpu.cpp
@@ -94,14 +94,10 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
 #pragma omp simd
               for (int s = 0; s < n; s++)
                 Y[k][s] += pA[2 * i + 1][j * lda + s] * W[k][j];
+#pragma omp simd collapse(2)
           for (int j = 0; j < n; j++)
-          {
-#pragma omp simd
             for (int k = 0; k < n; k++)
-            {
               pY[i][n * j + k] += Y[j][k];
-            }
-          }
         }
       }
       else if constexpr (dimensions == 3)
@@ -127,9 +123,9 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
 #pragma omp simd
               for (int s = 0; s < n; s++)
                 Y[l][k][s] += pA[3 * i + 2][j * lda + s] * W[l][k][j];
+#pragma omp simd collapse(3)
         for (int j = 0; j < n; j++)
           for (int l = 0; l < n; l++)
-#pragma omp simd
             for (int k = 0; k < n; k++)
               pY[i][n * n * j + n * l + k] += Y[j][l][k];
       }
@@ -138,9 +134,9 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
         T W[n][n][n][n] = {{{{{0}}}}}, Y[n][n][n][n] = {{{{{0}}}}};
         for (int j = 0; j < n; j++)
           for (int s = 0; s < n; s++)
+#pragma omp simd collapse(3)
             for (int p = 0; p < n; p++)
               for (int l = 0; l < n; l++)
-#pragma omp simd
                 for (int k = 0; k < n; k++)
                   W[s][p][l][k] +=
                       pX[i][n * n * n * j + n * n * p + n * l + k] *
@@ -148,8 +144,8 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
         for (int p = 0; p < n; p++)
           for (int j = 0; j < n; j++)
             for (int s = 0; s < n; s++)
+#pragma omp simd collapse(2)
               for (int l = 0; l < n; l++)
-#pragma omp simd
                 for (int k = 0; k < n; k++)
                   Y[p][s][l][k] += W[p][j][l][k] * pA[4 * i + 1][j * lda + s];
         std::fill(&W[0][0][0][0], &W[0][0][0][0] + sizeof(W) / sizeof(T),
@@ -170,10 +166,10 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
 #pragma omp simd
                 for (int s = 0; s < n; s++)
                   Y[p][l][k][s] += pA[4 * i + 3][j * lda + s] * W[p][l][k][j];
+#pragma omp simd collapse(4)
         for (int j = 0; j < n; j++)
           for (int p = 0; p < n; p++)
             for (int l = 0; l < n; l++)
-#pragma omp simd
               for (int k = 0; k < n; k++)
                 pY[i][n * n * n * j + n * n * p + n * l + k] += Y[j][p][l][k];
       }
@@ -182,10 +178,10 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
         T W[n][n][n][n][n] = {{{{{{0}}}}}}, Y[n][n][n][n][n] = {{{{{{0}}}}}};
         for (int j = 0; j < n; j++)
           for (int s = 0; s < n; s++)
+#pragma omp simd collapse(4)
             for (int v = 0; v < n; v++)
               for (int p = 0; p < n; p++)
                 for (int l = 0; l < n; l++)
-#pragma omp simd
                   for (int k = 0; k < n; k++)
                     Y[s][v][p][l][k] +=
                         pX[i][n * n * n * n * j + n * n * n * v + n * n * p +
@@ -194,9 +190,9 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
         for (int v = 0; v < n; v++)
           for (int j = 0; j < n; j++)
             for (int s = 0; s < n; s++)
+#pragma omp simd collapse(3)
               for (int p = 0; p < n; p++)
                 for (int l = 0; l < n; l++)
-#pragma omp simd
                   for (int k = 0; k < n; k++)
                     W[v][s][p][l][k] +=
                         Y[v][j][p][l][k] * pA[5 * i + 1][j * lda + s];
@@ -206,8 +202,8 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
           for (int p = 0; p < n; p++)
             for (int j = 0; j < n; j++)
               for (int s = 0; s < n; s++)
+#pragma omp simd collapse(2)
                 for (int l = 0; l < n; l++)
-#pragma omp simd
                   for (int k = 0; k < n; k++)
                     Y[v][p][s][l][k] +=
                         W[v][p][j][l][k] * pA[5 * i + 2][j * lda + s];
@@ -233,11 +229,11 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
                   for (int s = 0; s < n; s++)
                     Y[v][p][l][k][s] +=
                         pA[5 * i + 4][j * lda + s] * W[v][p][l][k][j];
+#pragma omp simd collapse(5)
         for (int j = 0; j < n; j++)
           for (int v = 0; v < n; v++)
             for (int p = 0; p < n; p++)
               for (int l = 0; l < n; l++)
-#pragma omp simd
                 for (int k = 0; k < n; k++)
                   pY[i][n * n * n * n * j + n * n * n * v + n * n * p + n * l +
                         k] += Y[j][v][p][l][k];
@@ -248,11 +244,11 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
           Y[n][n][n][n][n][n] = {{{{{{{0}}}}}}};
         for (int j = 0; j < n; j++)
           for (int s = 0; s < n; s++)
+#pragma omp simd collapse(5)
             for (int w = 0; w < n; w++)
               for (int v = 0; v < n; v++)
                 for (int p = 0; p < n; p++)
                   for (int l = 0; l < n; l++)
-#pragma omp simd
                     for (int k = 0; k < n; k++)
                       W[s][w][v][p][l][k] +=
                           pX[i][n * n * n * n * n * j + n * n * n * n * w +
@@ -261,10 +257,10 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
         for (int w = 0; w < n; w++)
           for (int j = 0; j < n; j++)
             for (int s = 0; s < n; s++)
+#pragma omp simd collapse(4)
               for (int v = 0; v < n; v++)
                 for (int p = 0; p < n; p++)
                   for (int l = 0; l < n; l++)
-#pragma omp simd
                     for (int k = 0; k < n; k++)
                       Y[w][s][v][p][l][k] +=
                           W[w][j][v][p][l][k] * pA[6 * i + 1][j * lda + s];
@@ -274,9 +270,9 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
           for (int v = 0; v < n; v++)
             for (int j = 0; j < n; j++)
               for (int s = 0; s < n; s++)
+#pragma omp simd collapse(3)
                 for (int p = 0; p < n; p++)
                   for (int l = 0; l < n; l++)
-#pragma omp simd
                     for (int k = 0; k < n; k++)
                       W[w][v][s][p][l][k] +=
                           Y[w][v][j][p][l][k] * pA[6 * i + 2][j * lda + s];
@@ -287,8 +283,8 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
             for (int p = 0; p < n; p++)
               for (int j = 0; j < n; j++)
                 for (int s = 0; s < n; s++)
+#pragma omp simd collapse(2)
                   for (int l = 0; l < n; l++)
-#pragma omp simd
                     for (int k = 0; k < n; k++)
                       Y[w][v][p][s][l][k] +=
                           W[w][v][p][j][l][k] * pA[6 * i + 3][j * lda + s];
@@ -316,12 +312,12 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
                     for (int s = 0; s < n; s++)
                       Y[w][v][p][l][k][s] +=
                           pA[6 * i + 5][j * lda + s] * W[w][v][p][l][k][j];
+#pragma omp simd collapse(6)
         for (int j = 0; j < n; j++)
           for (int w = 0; w < n; w++)
             for (int v = 0; v < n; v++)
               for (int p = 0; p < n; p++)
                 for (int l = 0; l < n; l++)
-#pragma omp simd
                   for (int k = 0; k < n; k++)
                     pY[i][n * n * n * n * n * j + n * n * n * n * w +
                           n * n * n * v + n * n * p + n * l + k] +=

--- a/src/device/asgard_kronmult_cpu.cpp
+++ b/src/device/asgard_kronmult_cpu.cpp
@@ -58,16 +58,10 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
       {
         T Y[n] = {{0}};
         for (int j = 0; j < n; j++)
-        {
           for (int k = 0; k < n; k++)
-          {
             Y[k] += pA[i][j * lda + k] * pX[i][j];
-          }
-        }
         for (int j = 0; j < n; j++)
-        {
           pY[i][j] += Y[j];
-        }
       }
       else if constexpr (dimensions == 2)
       {
@@ -177,19 +171,11 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
                 for (int s = 0; s < n; s++)
                   Y[p][l][k][s] += pA[4 * i + 3][j * lda + s] * W[p][l][k][j];
         for (int j = 0; j < n; j++)
-        {
           for (int p = 0; p < n; p++)
-          {
             for (int l = 0; l < n; l++)
-            {
 #pragma omp simd
               for (int k = 0; k < n; k++)
-              {
                 pY[i][n * n * n * j + n * n * p + n * l + k] += Y[j][p][l][k];
-              }
-            }
-          }
-        }
       }
       else if constexpr (dimensions == 5)
       {
@@ -248,23 +234,13 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
                     Y[v][p][l][k][s] +=
                         pA[5 * i + 4][j * lda + s] * W[v][p][l][k][j];
         for (int j = 0; j < n; j++)
-        {
           for (int v = 0; v < n; v++)
-          {
             for (int p = 0; p < n; p++)
-            {
               for (int l = 0; l < n; l++)
-              {
 #pragma omp simd
                 for (int k = 0; k < n; k++)
-                {
                   pY[i][n * n * n * n * j + n * n * n * v + n * n * p + n * l +
                         k] += Y[j][v][p][l][k];
-                }
-              }
-            }
-          }
-        }
       }
       else if constexpr (dimensions == 6)
       {

--- a/src/device/asgard_kronmult_cpu.cpp
+++ b/src/device/asgard_kronmult_cpu.cpp
@@ -85,8 +85,8 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
           T W[n][n] = {{{0}}};
           T Y[n][n] = {{{0}}};
           for (int j = 0; j < n; j++)
+#pragma omp simd collapse(2)
             for (int s = 0; s < n; s++)
-#pragma omp simd
               for (int k = 0; k < n; k++)
                 W[s][k] += pX[i][n * j + k] * pA[2 * i][j * lda + s];
           for (int k = 0; k < n; k++)
@@ -104,16 +104,16 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
       {
         T W[n][n][n] = {{{{0}}}}, Y[n][n][n] = {{{{0}}}};
         for (int j = 0; j < n; j++)
+#pragma omp simd collapse(3)
           for (int s = 0; s < n; s++)
             for (int l = 0; l < n; l++)
-#pragma omp simd
               for (int k = 0; k < n; k++)
                 Y[s][l][k] +=
                     pX[i][n * n * j + n * l + k] * pA[3 * i][j * lda + s];
         for (int l = 0; l < n; l++)
           for (int j = 0; j < n; j++)
+#pragma omp simd collapse(2)
             for (int s = 0; s < n; s++)
-#pragma omp simd
               for (int k = 0; k < n; k++)
                 W[l][s][k] += Y[l][j][k] * pA[3 * i + 1][j * lda + s];
         std::fill(&Y[0][0][0], &Y[0][0][0] + sizeof(W) / sizeof(T), T{0.});
@@ -133,8 +133,8 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
       {
         T W[n][n][n][n] = {{{{{0}}}}}, Y[n][n][n][n] = {{{{{0}}}}};
         for (int j = 0; j < n; j++)
+#pragma omp simd collapse(4)
           for (int s = 0; s < n; s++)
-#pragma omp simd collapse(3)
             for (int p = 0; p < n; p++)
               for (int l = 0; l < n; l++)
                 for (int k = 0; k < n; k++)
@@ -143,8 +143,8 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
                       pA[4 * i][j * lda + s];
         for (int p = 0; p < n; p++)
           for (int j = 0; j < n; j++)
+#pragma omp simd collapse(3)
             for (int s = 0; s < n; s++)
-#pragma omp simd collapse(2)
               for (int l = 0; l < n; l++)
                 for (int k = 0; k < n; k++)
                   Y[p][s][l][k] += W[p][j][l][k] * pA[4 * i + 1][j * lda + s];
@@ -153,8 +153,8 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
         for (int p = 0; p < n; p++)
           for (int l = 0; l < n; l++)
             for (int j = 0; j < n; j++)
+#pragma omp simd collapse(2)
               for (int s = 0; s < n; s++)
-#pragma omp simd
                 for (int k = 0; k < n; k++)
                   W[p][l][s][k] += Y[p][l][j][k] * pA[4 * i + 2][j * lda + s];
         std::fill(&Y[0][0][0][0], &Y[0][0][0][0] + sizeof(W) / sizeof(T),
@@ -177,8 +177,8 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
       {
         T W[n][n][n][n][n] = {{{{{{0}}}}}}, Y[n][n][n][n][n] = {{{{{{0}}}}}};
         for (int j = 0; j < n; j++)
+#pragma omp simd collapse(5)
           for (int s = 0; s < n; s++)
-#pragma omp simd collapse(4)
             for (int v = 0; v < n; v++)
               for (int p = 0; p < n; p++)
                 for (int l = 0; l < n; l++)
@@ -189,8 +189,8 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
                         pA[5 * i][j * lda + s];
         for (int v = 0; v < n; v++)
           for (int j = 0; j < n; j++)
+#pragma omp simd collapse(4)
             for (int s = 0; s < n; s++)
-#pragma omp simd collapse(3)
               for (int p = 0; p < n; p++)
                 for (int l = 0; l < n; l++)
                   for (int k = 0; k < n; k++)
@@ -201,8 +201,8 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
         for (int v = 0; v < n; v++)
           for (int p = 0; p < n; p++)
             for (int j = 0; j < n; j++)
+#pragma omp simd collapse(3)
               for (int s = 0; s < n; s++)
-#pragma omp simd collapse(2)
                 for (int l = 0; l < n; l++)
                   for (int k = 0; k < n; k++)
                     Y[v][p][s][l][k] +=
@@ -213,8 +213,8 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
           for (int p = 0; p < n; p++)
             for (int l = 0; l < n; l++)
               for (int j = 0; j < n; j++)
+#pragma omp simd collapse(2)
                 for (int s = 0; s < n; s++)
-#pragma omp simd
                   for (int k = 0; k < n; k++)
                     W[v][p][l][s][k] +=
                         Y[v][p][l][j][k] * pA[5 * i + 3][j * lda + s];
@@ -243,8 +243,8 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
         T W[n][n][n][n][n][n] = {{{{{{{0}}}}}}},
           Y[n][n][n][n][n][n] = {{{{{{{0}}}}}}};
         for (int j = 0; j < n; j++)
+#pragma omp simd collapse(6)
           for (int s = 0; s < n; s++)
-#pragma omp simd collapse(5)
             for (int w = 0; w < n; w++)
               for (int v = 0; v < n; v++)
                 for (int p = 0; p < n; p++)
@@ -256,8 +256,8 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
                           pA[6 * i][j * lda + s];
         for (int w = 0; w < n; w++)
           for (int j = 0; j < n; j++)
+#pragma omp simd collapse(5)
             for (int s = 0; s < n; s++)
-#pragma omp simd collapse(4)
               for (int v = 0; v < n; v++)
                 for (int p = 0; p < n; p++)
                   for (int l = 0; l < n; l++)
@@ -269,8 +269,8 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
         for (int w = 0; w < n; w++)
           for (int v = 0; v < n; v++)
             for (int j = 0; j < n; j++)
+#pragma omp simd collapse(4)
               for (int s = 0; s < n; s++)
-#pragma omp simd collapse(3)
                 for (int p = 0; p < n; p++)
                   for (int l = 0; l < n; l++)
                     for (int k = 0; k < n; k++)
@@ -282,8 +282,8 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
           for (int v = 0; v < n; v++)
             for (int p = 0; p < n; p++)
               for (int j = 0; j < n; j++)
+#pragma omp simd collapse(3)
                 for (int s = 0; s < n; s++)
-#pragma omp simd collapse(2)
                   for (int l = 0; l < n; l++)
                     for (int k = 0; k < n; k++)
                       Y[w][v][p][s][l][k] +=
@@ -295,8 +295,8 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
             for (int p = 0; p < n; p++)
               for (int l = 0; l < n; l++)
                 for (int j = 0; j < n; j++)
+#pragma omp simd collapse(2)
                   for (int s = 0; s < n; s++)
-#pragma omp simd
                     for (int k = 0; k < n; k++)
                       W[w][v][p][l][s][k] +=
                           Y[w][v][p][l][j][k] * pA[6 * i + 4][j * lda + s];

--- a/src/device/asgard_kronmult_cpu.cpp
+++ b/src/device/asgard_kronmult_cpu.cpp
@@ -84,14 +84,14 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
         {
           T W[n][n] = {{{0}}};
           T Y[n][n] = {{{0}}};
+#pragma omp simd collapse(3)
           for (int j = 0; j < n; j++)
-#pragma omp simd collapse(2)
             for (int s = 0; s < n; s++)
               for (int k = 0; k < n; k++)
                 W[s][k] += pX[i][n * j + k] * pA[2 * i][j * lda + s];
+#pragma omp simd collapse(3)
           for (int k = 0; k < n; k++)
             for (int j = 0; j < n; j++)
-#pragma omp simd
               for (int s = 0; s < n; s++)
                 Y[k][s] += pA[2 * i + 1][j * lda + s] * W[k][j];
 #pragma omp simd collapse(2)
@@ -103,24 +103,24 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
       else if constexpr (dimensions == 3)
       {
         T W[n][n][n] = {{{{0}}}}, Y[n][n][n] = {{{{0}}}};
+#pragma omp simd collapse(4)
         for (int j = 0; j < n; j++)
-#pragma omp simd collapse(3)
           for (int s = 0; s < n; s++)
             for (int l = 0; l < n; l++)
               for (int k = 0; k < n; k++)
                 Y[s][l][k] +=
                     pX[i][n * n * j + n * l + k] * pA[3 * i][j * lda + s];
+#pragma omp simd collapse(4)
         for (int l = 0; l < n; l++)
           for (int j = 0; j < n; j++)
-#pragma omp simd collapse(2)
             for (int s = 0; s < n; s++)
               for (int k = 0; k < n; k++)
                 W[l][s][k] += Y[l][j][k] * pA[3 * i + 1][j * lda + s];
         std::fill(&Y[0][0][0], &Y[0][0][0] + sizeof(W) / sizeof(T), T{0.});
+#pragma omp simd collapse(4)
         for (int l = 0; l < n; l++)
           for (int k = 0; k < n; k++)
             for (int j = 0; j < n; j++)
-#pragma omp simd
               for (int s = 0; s < n; s++)
                 Y[l][k][s] += pA[3 * i + 2][j * lda + s] * W[l][k][j];
 #pragma omp simd collapse(3)
@@ -132,8 +132,8 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
       else if constexpr (dimensions == 4)
       {
         T W[n][n][n][n] = {{{{{0}}}}}, Y[n][n][n][n] = {{{{{0}}}}};
+#pragma omp simd collapse(5)
         for (int j = 0; j < n; j++)
-#pragma omp simd collapse(4)
           for (int s = 0; s < n; s++)
             for (int p = 0; p < n; p++)
               for (int l = 0; l < n; l++)
@@ -141,29 +141,29 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
                   W[s][p][l][k] +=
                       pX[i][n * n * n * j + n * n * p + n * l + k] *
                       pA[4 * i][j * lda + s];
+#pragma omp simd collapse(5)
         for (int p = 0; p < n; p++)
           for (int j = 0; j < n; j++)
-#pragma omp simd collapse(3)
             for (int s = 0; s < n; s++)
               for (int l = 0; l < n; l++)
                 for (int k = 0; k < n; k++)
                   Y[p][s][l][k] += W[p][j][l][k] * pA[4 * i + 1][j * lda + s];
         std::fill(&W[0][0][0][0], &W[0][0][0][0] + sizeof(W) / sizeof(T),
                   T{0.});
+#pragma omp simd collapse(5)
         for (int p = 0; p < n; p++)
           for (int l = 0; l < n; l++)
             for (int j = 0; j < n; j++)
-#pragma omp simd collapse(2)
               for (int s = 0; s < n; s++)
                 for (int k = 0; k < n; k++)
                   W[p][l][s][k] += Y[p][l][j][k] * pA[4 * i + 2][j * lda + s];
         std::fill(&Y[0][0][0][0], &Y[0][0][0][0] + sizeof(W) / sizeof(T),
                   T{0.});
+#pragma omp simd collapse(5)
         for (int p = 0; p < n; p++)
           for (int l = 0; l < n; l++)
             for (int k = 0; k < n; k++)
               for (int j = 0; j < n; j++)
-#pragma omp simd
                 for (int s = 0; s < n; s++)
                   Y[p][l][k][s] += pA[4 * i + 3][j * lda + s] * W[p][l][k][j];
 #pragma omp simd collapse(4)
@@ -176,8 +176,8 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
       else if constexpr (dimensions == 5)
       {
         T W[n][n][n][n][n] = {{{{{{0}}}}}}, Y[n][n][n][n][n] = {{{{{{0}}}}}};
+#pragma omp simd collapse(6)
         for (int j = 0; j < n; j++)
-#pragma omp simd collapse(5)
           for (int s = 0; s < n; s++)
             for (int v = 0; v < n; v++)
               for (int p = 0; p < n; p++)
@@ -187,9 +187,9 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
                         pX[i][n * n * n * n * j + n * n * n * v + n * n * p +
                               n * l + k] *
                         pA[5 * i][j * lda + s];
+#pragma omp simd collapse(6)
         for (int v = 0; v < n; v++)
           for (int j = 0; j < n; j++)
-#pragma omp simd collapse(4)
             for (int s = 0; s < n; s++)
               for (int p = 0; p < n; p++)
                 for (int l = 0; l < n; l++)
@@ -198,10 +198,10 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
                         Y[v][j][p][l][k] * pA[5 * i + 1][j * lda + s];
         std::fill(&Y[0][0][0][0][0], &Y[0][0][0][0][0] + sizeof(W) / sizeof(T),
                   T{0.});
+#pragma omp simd collapse(6)
         for (int v = 0; v < n; v++)
           for (int p = 0; p < n; p++)
             for (int j = 0; j < n; j++)
-#pragma omp simd collapse(3)
               for (int s = 0; s < n; s++)
                 for (int l = 0; l < n; l++)
                   for (int k = 0; k < n; k++)
@@ -209,23 +209,23 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
                         W[v][p][j][l][k] * pA[5 * i + 2][j * lda + s];
         std::fill(&W[0][0][0][0][0], &W[0][0][0][0][0] + sizeof(W) / sizeof(T),
                   T{0.});
+#pragma omp simd collapse(6)
         for (int v = 0; v < n; v++)
           for (int p = 0; p < n; p++)
             for (int l = 0; l < n; l++)
               for (int j = 0; j < n; j++)
-#pragma omp simd collapse(2)
                 for (int s = 0; s < n; s++)
                   for (int k = 0; k < n; k++)
                     W[v][p][l][s][k] +=
                         Y[v][p][l][j][k] * pA[5 * i + 3][j * lda + s];
         std::fill(&Y[0][0][0][0][0], &Y[0][0][0][0][0] + sizeof(W) / sizeof(T),
                   T{0.});
+#pragma omp simd collapse(6)
         for (int v = 0; v < n; v++)
           for (int p = 0; p < n; p++)
             for (int l = 0; l < n; l++)
               for (int k = 0; k < n; k++)
                 for (int j = 0; j < n; j++)
-#pragma omp simd
                   for (int s = 0; s < n; s++)
                     Y[v][p][l][k][s] +=
                         pA[5 * i + 4][j * lda + s] * W[v][p][l][k][j];
@@ -242,8 +242,8 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
       {
         T W[n][n][n][n][n][n] = {{{{{{{0}}}}}}},
           Y[n][n][n][n][n][n] = {{{{{{{0}}}}}}};
+#pragma omp simd collapse(7)
         for (int j = 0; j < n; j++)
-#pragma omp simd collapse(6)
           for (int s = 0; s < n; s++)
             for (int w = 0; w < n; w++)
               for (int v = 0; v < n; v++)
@@ -254,9 +254,9 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
                           pX[i][n * n * n * n * n * j + n * n * n * n * w +
                                 n * n * n * v + n * n * p + n * l + k] *
                           pA[6 * i][j * lda + s];
+#pragma omp simd collapse(7)
         for (int w = 0; w < n; w++)
           for (int j = 0; j < n; j++)
-#pragma omp simd collapse(5)
             for (int s = 0; s < n; s++)
               for (int v = 0; v < n; v++)
                 for (int p = 0; p < n; p++)
@@ -266,10 +266,10 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
                           W[w][j][v][p][l][k] * pA[6 * i + 1][j * lda + s];
         std::fill(&W[0][0][0][0][0][0],
                   &W[0][0][0][0][0][0] + sizeof(W) / sizeof(T), T{0.});
+#pragma omp simd collapse(7)
         for (int w = 0; w < n; w++)
           for (int v = 0; v < n; v++)
             for (int j = 0; j < n; j++)
-#pragma omp simd collapse(4)
               for (int s = 0; s < n; s++)
                 for (int p = 0; p < n; p++)
                   for (int l = 0; l < n; l++)
@@ -278,11 +278,11 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
                           Y[w][v][j][p][l][k] * pA[6 * i + 2][j * lda + s];
         std::fill(&Y[0][0][0][0][0][0],
                   &Y[0][0][0][0][0][0] + sizeof(W) / sizeof(T), T{0.});
+#pragma omp simd collapse(7)
         for (int w = 0; w < n; w++)
           for (int v = 0; v < n; v++)
             for (int p = 0; p < n; p++)
               for (int j = 0; j < n; j++)
-#pragma omp simd collapse(3)
                 for (int s = 0; s < n; s++)
                   for (int l = 0; l < n; l++)
                     for (int k = 0; k < n; k++)
@@ -290,25 +290,25 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
                           W[w][v][p][j][l][k] * pA[6 * i + 3][j * lda + s];
         std::fill(&W[0][0][0][0][0][0],
                   &W[0][0][0][0][0][0] + sizeof(W) / sizeof(T), T{0.});
+#pragma omp simd collapse(7)
         for (int w = 0; w < n; w++)
           for (int v = 0; v < n; v++)
             for (int p = 0; p < n; p++)
               for (int l = 0; l < n; l++)
                 for (int j = 0; j < n; j++)
-#pragma omp simd collapse(2)
                   for (int s = 0; s < n; s++)
                     for (int k = 0; k < n; k++)
                       W[w][v][p][l][s][k] +=
                           Y[w][v][p][l][j][k] * pA[6 * i + 4][j * lda + s];
         std::fill(&Y[0][0][0][0][0][0],
                   &Y[0][0][0][0][0][0] + sizeof(W) / sizeof(T), T{0.});
+#pragma omp simd collapse(7)
         for (int w = 0; w < n; w++)
           for (int v = 0; v < n; v++)
             for (int p = 0; p < n; p++)
               for (int l = 0; l < n; l++)
                 for (int k = 0; k < n; k++)
                   for (int j = 0; j < n; j++)
-#pragma omp simd
                     for (int s = 0; s < n; s++)
                       Y[w][v][p][l][k][s] +=
                           pA[6 * i + 5][j * lda + s] * W[w][v][p][l][k][j];

--- a/src/device/asgard_kronmult_cpu.cpp
+++ b/src/device/asgard_kronmult_cpu.cpp
@@ -88,17 +88,21 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
         }
         else if constexpr (n >= 3)
         {
-          T W[n][n] = {{{0}}}, Y[n][n] = {{{0}}};
+          T W[n][n] = {{{0}}};
+          T Y[n][n] = {{{0}}};
           for (int j = 0; j < n; j++)
-            for (int k = 0; k < n; k++)
-              for (int s = 0; s < n; s++)
+            for (int s = 0; s < n; s++)
+#pragma omp simd
+              for (int k = 0; k < n; k++)
                 W[s][k] += pX[i][n * j + k] * pA[2 * i][j * lda + s];
-          for (int j = 0; j < n; j++)
-            for (int k = 0; k < n; k++)
+          for (int k = 0; k < n; k++)
+            for (int j = 0; j < n; j++)
+#pragma omp simd
               for (int s = 0; s < n; s++)
                 Y[k][s] += pA[2 * i + 1][j * lda + s] * W[k][j];
           for (int j = 0; j < n; j++)
           {
+#pragma omp simd
             for (int k = 0; k < n; k++)
             {
               pY[i][n * j + k] += Y[j][k];
@@ -110,64 +114,66 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
       {
         T W[n][n][n] = {{{{0}}}}, Y[n][n][n] = {{{{0}}}};
         for (int j = 0; j < n; j++)
-          for (int l = 0; l < n; l++)
-            for (int k = 0; k < n; k++)
-              for (int s = 0; s < n; s++)
+          for (int s = 0; s < n; s++)
+            for (int l = 0; l < n; l++)
+#pragma omp simd
+              for (int k = 0; k < n; k++)
                 Y[s][l][k] +=
                     pX[i][n * n * j + n * l + k] * pA[3 * i][j * lda + s];
-        for (int j = 0; j < n; j++)
-          for (int l = 0; l < n; l++)
-            for (int k = 0; k < n; k++)
-              for (int s = 0; s < n; s++)
+        for (int l = 0; l < n; l++)
+          for (int j = 0; j < n; j++)
+            for (int s = 0; s < n; s++)
+#pragma omp simd
+              for (int k = 0; k < n; k++)
                 W[l][s][k] += Y[l][j][k] * pA[3 * i + 1][j * lda + s];
         std::fill(&Y[0][0][0], &Y[0][0][0] + sizeof(W) / sizeof(T), T{0.});
-        for (int j = 0; j < n; j++)
-          for (int l = 0; l < n; l++)
-            for (int k = 0; k < n; k++)
+        for (int l = 0; l < n; l++)
+          for (int k = 0; k < n; k++)
+            for (int j = 0; j < n; j++)
+#pragma omp simd
               for (int s = 0; s < n; s++)
                 Y[l][k][s] += pA[3 * i + 2][j * lda + s] * W[l][k][j];
         for (int j = 0; j < n; j++)
-        {
           for (int l = 0; l < n; l++)
-          {
+#pragma omp simd
             for (int k = 0; k < n; k++)
-            {
               pY[i][n * n * j + n * l + k] += Y[j][l][k];
-            }
-          }
-        }
       }
       else if constexpr (dimensions == 4)
       {
         T W[n][n][n][n] = {{{{{0}}}}}, Y[n][n][n][n] = {{{{{0}}}}};
         for (int j = 0; j < n; j++)
-          for (int p = 0; p < n; p++)
-            for (int l = 0; l < n; l++)
-              for (int k = 0; k < n; k++)
-                for (int s = 0; s < n; s++)
+          for (int s = 0; s < n; s++)
+            for (int p = 0; p < n; p++)
+              for (int l = 0; l < n; l++)
+#pragma omp simd
+                for (int k = 0; k < n; k++)
                   W[s][p][l][k] +=
                       pX[i][n * n * n * j + n * n * p + n * l + k] *
                       pA[4 * i][j * lda + s];
-        for (int j = 0; j < n; j++)
-          for (int p = 0; p < n; p++)
-            for (int l = 0; l < n; l++)
-              for (int k = 0; k < n; k++)
-                for (int s = 0; s < n; s++)
+        for (int p = 0; p < n; p++)
+          for (int j = 0; j < n; j++)
+            for (int s = 0; s < n; s++)
+              for (int l = 0; l < n; l++)
+#pragma omp simd
+                for (int k = 0; k < n; k++)
                   Y[p][s][l][k] += W[p][j][l][k] * pA[4 * i + 1][j * lda + s];
         std::fill(&W[0][0][0][0], &W[0][0][0][0] + sizeof(W) / sizeof(T),
                   T{0.});
-        for (int j = 0; j < n; j++)
-          for (int p = 0; p < n; p++)
-            for (int l = 0; l < n; l++)
-              for (int k = 0; k < n; k++)
-                for (int s = 0; s < n; s++)
+        for (int p = 0; p < n; p++)
+          for (int l = 0; l < n; l++)
+            for (int j = 0; j < n; j++)
+              for (int s = 0; s < n; s++)
+#pragma omp simd
+                for (int k = 0; k < n; k++)
                   W[p][l][s][k] += Y[p][l][j][k] * pA[4 * i + 2][j * lda + s];
         std::fill(&Y[0][0][0][0], &Y[0][0][0][0] + sizeof(W) / sizeof(T),
                   T{0.});
-        for (int j = 0; j < n; j++)
-          for (int p = 0; p < n; p++)
-            for (int l = 0; l < n; l++)
-              for (int k = 0; k < n; k++)
+        for (int p = 0; p < n; p++)
+          for (int l = 0; l < n; l++)
+            for (int k = 0; k < n; k++)
+              for (int j = 0; j < n; j++)
+#pragma omp simd
                 for (int s = 0; s < n; s++)
                   Y[p][l][k][s] += pA[4 * i + 3][j * lda + s] * W[p][l][k][j];
         for (int j = 0; j < n; j++)
@@ -176,6 +182,7 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
           {
             for (int l = 0; l < n; l++)
             {
+#pragma omp simd
               for (int k = 0; k < n; k++)
               {
                 pY[i][n * n * n * j + n * n * p + n * l + k] += Y[j][p][l][k];
@@ -188,50 +195,55 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
       {
         T W[n][n][n][n][n] = {{{{{{0}}}}}}, Y[n][n][n][n][n] = {{{{{{0}}}}}};
         for (int j = 0; j < n; j++)
-          for (int v = 0; v < n; v++)
-            for (int p = 0; p < n; p++)
-              for (int l = 0; l < n; l++)
-                for (int k = 0; k < n; k++)
-                  for (int s = 0; s < n; s++)
+          for (int s = 0; s < n; s++)
+            for (int v = 0; v < n; v++)
+              for (int p = 0; p < n; p++)
+                for (int l = 0; l < n; l++)
+#pragma omp simd
+                  for (int k = 0; k < n; k++)
                     Y[s][v][p][l][k] +=
                         pX[i][n * n * n * n * j + n * n * n * v + n * n * p +
                               n * l + k] *
                         pA[5 * i][j * lda + s];
-        for (int j = 0; j < n; j++)
-          for (int v = 0; v < n; v++)
-            for (int p = 0; p < n; p++)
-              for (int l = 0; l < n; l++)
-                for (int k = 0; k < n; k++)
-                  for (int s = 0; s < n; s++)
+        for (int v = 0; v < n; v++)
+          for (int j = 0; j < n; j++)
+            for (int s = 0; s < n; s++)
+              for (int p = 0; p < n; p++)
+                for (int l = 0; l < n; l++)
+#pragma omp simd
+                  for (int k = 0; k < n; k++)
                     W[v][s][p][l][k] +=
                         Y[v][j][p][l][k] * pA[5 * i + 1][j * lda + s];
         std::fill(&Y[0][0][0][0][0], &Y[0][0][0][0][0] + sizeof(W) / sizeof(T),
                   T{0.});
-        for (int j = 0; j < n; j++)
-          for (int v = 0; v < n; v++)
-            for (int p = 0; p < n; p++)
-              for (int l = 0; l < n; l++)
-                for (int k = 0; k < n; k++)
-                  for (int s = 0; s < n; s++)
+        for (int v = 0; v < n; v++)
+          for (int p = 0; p < n; p++)
+            for (int j = 0; j < n; j++)
+              for (int s = 0; s < n; s++)
+                for (int l = 0; l < n; l++)
+#pragma omp simd
+                  for (int k = 0; k < n; k++)
                     Y[v][p][s][l][k] +=
                         W[v][p][j][l][k] * pA[5 * i + 2][j * lda + s];
         std::fill(&W[0][0][0][0][0], &W[0][0][0][0][0] + sizeof(W) / sizeof(T),
                   T{0.});
-        for (int j = 0; j < n; j++)
-          for (int v = 0; v < n; v++)
-            for (int p = 0; p < n; p++)
-              for (int l = 0; l < n; l++)
-                for (int k = 0; k < n; k++)
-                  for (int s = 0; s < n; s++)
+        for (int v = 0; v < n; v++)
+          for (int p = 0; p < n; p++)
+            for (int l = 0; l < n; l++)
+              for (int j = 0; j < n; j++)
+                for (int s = 0; s < n; s++)
+#pragma omp simd
+                  for (int k = 0; k < n; k++)
                     W[v][p][l][s][k] +=
                         Y[v][p][l][j][k] * pA[5 * i + 3][j * lda + s];
         std::fill(&Y[0][0][0][0][0], &Y[0][0][0][0][0] + sizeof(W) / sizeof(T),
                   T{0.});
-        for (int j = 0; j < n; j++)
-          for (int v = 0; v < n; v++)
-            for (int p = 0; p < n; p++)
-              for (int l = 0; l < n; l++)
-                for (int k = 0; k < n; k++)
+        for (int v = 0; v < n; v++)
+          for (int p = 0; p < n; p++)
+            for (int l = 0; l < n; l++)
+              for (int k = 0; k < n; k++)
+                for (int j = 0; j < n; j++)
+#pragma omp simd
                   for (int s = 0; s < n; s++)
                     Y[v][p][l][k][s] +=
                         pA[5 * i + 4][j * lda + s] * W[v][p][l][k][j];
@@ -243,6 +255,7 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
             {
               for (int l = 0; l < n; l++)
               {
+#pragma omp simd
                 for (int k = 0; k < n; k++)
                 {
                   pY[i][n * n * n * n * j + n * n * n * v + n * n * p + n * l +
@@ -258,90 +271,85 @@ void run_cpu_variant(T const *const pA[], int const lda, T const *const pX[],
         T W[n][n][n][n][n][n] = {{{{{{{0}}}}}}},
           Y[n][n][n][n][n][n] = {{{{{{{0}}}}}}};
         for (int j = 0; j < n; j++)
-          for (int w = 0; w < n; w++)
-            for (int v = 0; v < n; v++)
-              for (int p = 0; p < n; p++)
-                for (int l = 0; l < n; l++)
-                  for (int k = 0; k < n; k++)
-                    for (int s = 0; s < n; s++)
+          for (int s = 0; s < n; s++)
+            for (int w = 0; w < n; w++)
+              for (int v = 0; v < n; v++)
+                for (int p = 0; p < n; p++)
+                  for (int l = 0; l < n; l++)
+#pragma omp simd
+                    for (int k = 0; k < n; k++)
                       W[s][w][v][p][l][k] +=
                           pX[i][n * n * n * n * n * j + n * n * n * n * w +
                                 n * n * n * v + n * n * p + n * l + k] *
                           pA[6 * i][j * lda + s];
-        for (int j = 0; j < n; j++)
-          for (int w = 0; w < n; w++)
-            for (int v = 0; v < n; v++)
-              for (int p = 0; p < n; p++)
-                for (int l = 0; l < n; l++)
-                  for (int k = 0; k < n; k++)
-                    for (int s = 0; s < n; s++)
+        for (int w = 0; w < n; w++)
+          for (int j = 0; j < n; j++)
+            for (int s = 0; s < n; s++)
+              for (int v = 0; v < n; v++)
+                for (int p = 0; p < n; p++)
+                  for (int l = 0; l < n; l++)
+#pragma omp simd
+                    for (int k = 0; k < n; k++)
                       Y[w][s][v][p][l][k] +=
                           W[w][j][v][p][l][k] * pA[6 * i + 1][j * lda + s];
         std::fill(&W[0][0][0][0][0][0],
                   &W[0][0][0][0][0][0] + sizeof(W) / sizeof(T), T{0.});
-        for (int j = 0; j < n; j++)
-          for (int w = 0; w < n; w++)
-            for (int v = 0; v < n; v++)
-              for (int p = 0; p < n; p++)
-                for (int l = 0; l < n; l++)
-                  for (int k = 0; k < n; k++)
-                    for (int s = 0; s < n; s++)
+        for (int w = 0; w < n; w++)
+          for (int v = 0; v < n; v++)
+            for (int j = 0; j < n; j++)
+              for (int s = 0; s < n; s++)
+                for (int p = 0; p < n; p++)
+                  for (int l = 0; l < n; l++)
+#pragma omp simd
+                    for (int k = 0; k < n; k++)
                       W[w][v][s][p][l][k] +=
                           Y[w][v][j][p][l][k] * pA[6 * i + 2][j * lda + s];
         std::fill(&Y[0][0][0][0][0][0],
                   &Y[0][0][0][0][0][0] + sizeof(W) / sizeof(T), T{0.});
-        for (int j = 0; j < n; j++)
-          for (int w = 0; w < n; w++)
-            for (int v = 0; v < n; v++)
-              for (int p = 0; p < n; p++)
-                for (int l = 0; l < n; l++)
-                  for (int k = 0; k < n; k++)
-                    for (int s = 0; s < n; s++)
+        for (int w = 0; w < n; w++)
+          for (int v = 0; v < n; v++)
+            for (int p = 0; p < n; p++)
+              for (int j = 0; j < n; j++)
+                for (int s = 0; s < n; s++)
+                  for (int l = 0; l < n; l++)
+#pragma omp simd
+                    for (int k = 0; k < n; k++)
                       Y[w][v][p][s][l][k] +=
                           W[w][v][p][j][l][k] * pA[6 * i + 3][j * lda + s];
         std::fill(&W[0][0][0][0][0][0],
                   &W[0][0][0][0][0][0] + sizeof(W) / sizeof(T), T{0.});
-        for (int j = 0; j < n; j++)
-          for (int w = 0; w < n; w++)
-            for (int v = 0; v < n; v++)
-              for (int p = 0; p < n; p++)
-                for (int l = 0; l < n; l++)
-                  for (int k = 0; k < n; k++)
-                    for (int s = 0; s < n; s++)
+        for (int w = 0; w < n; w++)
+          for (int v = 0; v < n; v++)
+            for (int p = 0; p < n; p++)
+              for (int l = 0; l < n; l++)
+                for (int j = 0; j < n; j++)
+                  for (int s = 0; s < n; s++)
+#pragma omp simd
+                    for (int k = 0; k < n; k++)
                       W[w][v][p][l][s][k] +=
                           Y[w][v][p][l][j][k] * pA[6 * i + 4][j * lda + s];
         std::fill(&Y[0][0][0][0][0][0],
                   &Y[0][0][0][0][0][0] + sizeof(W) / sizeof(T), T{0.});
-        for (int j = 0; j < n; j++)
-          for (int w = 0; w < n; w++)
-            for (int v = 0; v < n; v++)
-              for (int p = 0; p < n; p++)
-                for (int l = 0; l < n; l++)
-                  for (int k = 0; k < n; k++)
+        for (int w = 0; w < n; w++)
+          for (int v = 0; v < n; v++)
+            for (int p = 0; p < n; p++)
+              for (int l = 0; l < n; l++)
+                for (int k = 0; k < n; k++)
+                  for (int j = 0; j < n; j++)
+#pragma omp simd
                     for (int s = 0; s < n; s++)
                       Y[w][v][p][l][k][s] +=
                           pA[6 * i + 5][j * lda + s] * W[w][v][p][l][k][j];
         for (int j = 0; j < n; j++)
-        {
           for (int w = 0; w < n; w++)
-          {
             for (int v = 0; v < n; v++)
-            {
               for (int p = 0; p < n; p++)
-              {
                 for (int l = 0; l < n; l++)
-                {
+#pragma omp simd
                   for (int k = 0; k < n; k++)
-                  {
                     pY[i][n * n * n * n * n * j + n * n * n * n * w +
                           n * n * n * v + n * n * p + n * l + k] +=
                         Y[j][w][v][p][l][k];
-                  }
-                }
-              }
-            }
-          }
-        }
       }
     } // for output-length
   }   // for loop

--- a/src/quadrature_tests.cpp
+++ b/src/quadrature_tests.cpp
@@ -68,7 +68,7 @@ TEMPLATE_TEST_CASE("legendre weights and roots function", "[matlab]", double,
                    float)
 {
   TestType const tol_factor =
-      std::is_same<TestType, double>::value ? 1e-16 : 1e-6;
+      std::is_same<TestType, double>::value ? 1e-15 : 1e-6;
 
   SECTION("legendre_weights(10, -1, 1)")
   {


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

- Adding `-march=native` to our suggested CXXFLAGS which allows for SIMD instructions beyond SSE2
- Reordering loops to maximize when memory is accessed sequentially (I suspect the compiler can/is also reordering loops)
  - I adjusted `j` ignoring `lda` in hope that we can rearrange those matrices in a future PR.  
- Using `#pragma omp simd` generates [FMA3 instructions](https://en.wikipedia.org/wiki/FMA_instruction_set).
- Fixing precision errors cause by adding `-march=native`

test CPU
```
$ lscpu 
Architecture:           x86_64
  CPU op-mode(s):       32-bit, 64-bit
  Address sizes:        46 bits physical, 48 bits virtual
  Byte Order:           Little Endian
CPU(s):                 40
  On-line CPU(s) list:  0-39
Vendor ID:              GenuineIntel
  Model name:           Intel(R) Xeon(R) CPU E5-2630 v4 @ 2.20GHz
    CPU family:         6
    Model:              79
    Thread(s) per core: 2
    Core(s) per socket: 10
    Socket(s):          2
    Stepping:           1
    CPU max MHz:        3100.0000
    CPU min MHz:        1200.0000
    BogoMIPS:           4389.49
    Flags:              fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid 
                        aperfmperf pni pclmulqdq dtes64 monitor ds_cpl smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb cat_l3 
                        cdp_l3 invpcid_single pti intel_ppin ssbd ibrs ibpb stibp fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm cqm rdt_a rdseed adx smap intel_pt xsaveopt cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local dtherm ida ar
                        at pln pts md_clear flush_l1d
Caches (sum of all):    
  L1d:                  640 KiB (20 instances)
  L1i:                  640 KiB (20 instances)
  L2:                   5 MiB (20 instances)
  L3:                   50 MiB (2 instances)
NUMA:                   
  NUMA node(s):         2
  NUMA node0 CPU(s):    0-9,20-29
  NUMA node1 CPU(s):    10-19,30-39
Vulnerabilities:        
  Itlb multihit:        KVM: Mitigation: VMX unsupported
  L1tf:                 Mitigation; PTE Inversion
  Mds:                  Mitigation; Clear CPU buffers; SMT vulnerable
  Meltdown:             Mitigation; PTI
  Mmio stale data:      Mitigation; Clear CPU buffers; SMT vulnerable
  Retbleed:             Not affected
  Spec store bypass:    Mitigation; Speculative Store Bypass disabled via prctl
  Spectre v1:           Mitigation; usercopy/swapgs barriers and __user pointer sanitization
  Spectre v2:           Mitigation; Retpolines, IBPB conditional, IBRS_FW, STIBP conditional, RSB filling, PBRSB-eIBRS Not affected
  Srbds:                Not affected
  Tsx async abort:      Mitigation; Clear CPU buffers; SMT vulnerable
```

this branch
```
svh@PC102795:~/Documents/asgard/build$ OMP_PROC_BIND=close OMP_NUM_THREADS=20 ./asgard-kronmult-benchmark 2 4 4096 12288 1000
benchmarking:
dimensions: 2  n: 4  num_y: 4096  operator_size: 12288  num_matrices: 1000
benchmark setup time: 6.556 seconds.
single precision: 180.3850 Gflops / second.
double precision: 112.0134 Gflops / second.
svh@PC102795:~/Documents/asgard/build$ OMP_PROC_BIND=close OMP_NUM_THREADS=20 ./asgard-kronmult-benchmark 3 4 4096 12288 1000
benchmarking:
dimensions: 3  n: 4  num_y: 4096  operator_size: 12288  num_matrices: 1000
benchmark setup time: 8.522 seconds.
single precision: 145.1275 Gflops / second.
double precision: 92.5695 Gflops / second.
svh@PC102795:~/Documents/asgard/build$ OMP_PROC_BIND=close OMP_NUM_THREADS=20 ./asgard-kronmult-benchmark 4 4 4096 12288 1000
benchmarking:
dimensions: 4  n: 4  num_y: 4096  operator_size: 12288  num_matrices: 1000
benchmark setup time: 10.329 seconds.
single precision: 224.7669 Gflops / second.
double precision: 152.4232 Gflops / second.
svh@PC102795:~/Documents/asgard/build$ OMP_PROC_BIND=close OMP_NUM_THREADS=20 ./asgard-kronmult-benchmark 2 2 4096 12288 1000
benchmarking:
dimensions: 2  n: 2  num_y: 4096  operator_size: 12288  num_matrices: 1000
benchmark setup time: 6.558 seconds.
single precision: 45.6006 Gflops / second.
double precision: 19.2957 Gflops / second.
svh@PC102795:~/Documents/asgard/build$ OMP_PROC_BIND=close OMP_NUM_THREADS=20 ./asgard-kronmult-benchmark 3 2 4096 12288 1000
benchmarking:
dimensions: 3  n: 2  num_y: 4096  operator_size: 12288  num_matrices: 1000
benchmark setup time: 8.484 seconds.
single precision: 127.6913 Gflops / second.
double precision: 64.9877 Gflops / second.
svh@PC102795:~/Documents/asgard/build$ OMP_PROC_BIND=close OMP_NUM_THREADS=20 ./asgard-kronmult-benchmark 4 2 4096 12288 1000
benchmarking:
dimensions: 4  n: 2  num_y: 4096  operator_size: 12288  num_matrices: 1000
benchmark setup time: 10.284 seconds.
single precision: 130.9308 Gflops / second.
double precision: 118.2861 Gflops / second.
svh@PC102795:~/Documents/asgard/build$ OMP_PROC_BIND=close OMP_NUM_THREADS=20 ./asgard-kronmult-benchmark 6 2 4096 12288 1000
benchmarking:
dimensions: 6  n: 2  num_y: 4096  operator_size: 12288  num_matrices: 1000
benchmark setup time: 13.124 seconds.
single precision: 75.4268 Gflops / second.
double precision: 63.8377 Gflops / second.
```

develop
```
$ OMP_PROC_BIND=close OMP_NUM_THREADS=20 ./asgard-kronmult-benchmark 2 4 4096 12288 1000
benchmarking:
dimensions: 2  n: 4  num_y: 4096  operator_size: 12288  num_matrices: 1000
benchmark setup time: 6.837 seconds.
single precision: 61.9943 Gflops / second.
double precision: 78.9516 Gflops / second.
svh@PC102795:~/Documents/asgard/build$ OMP_PROC_BIND=close OMP_NUM_THREADS=20 ./asgard-kronmult-benchmark 3 4 4096 12288 1000
benchmarking:
dimensions: 3  n: 4  num_y: 4096  operator_size: 12288  num_matrices: 1000
benchmark setup time: 9.206 seconds.
single precision: 107.7183 Gflops / second.
double precision: 55.1977 Gflops / second.
svh@PC102795:~/Documents/asgard/build$ OMP_PROC_BIND=close OMP_NUM_THREADS=20 ./asgard-kronmult-benchmark 4 4 4096 12288 1000
benchmarking:
dimensions: 4  n: 4  num_y: 4096  operator_size: 12288  num_matrices: 1000
benchmark setup time: 10.953 seconds.
single precision: 185.6154 Gflops / second.
double precision: 108.5053 Gflops / second.
svh@PC102795:~/Documents/asgard/build$ OMP_PROC_BIND=close OMP_NUM_THREADS=20 ./asgard-kronmult-benchmark 2 2 4096 12288 1000
benchmarking:
dimensions: 2  n: 2  num_y: 4096  operator_size: 12288  num_matrices: 1000
benchmark setup time: 6.695 seconds.
single precision: 80.1699 Gflops / second.
double precision: 25.4522 Gflops / second.
svh@PC102795:~/Documents/asgard/build$ OMP_PROC_BIND=close OMP_NUM_THREADS=20 ./asgard-kronmult-benchmark 3 2 4096 12288 1000
benchmarking:
dimensions: 3  n: 2  num_y: 4096  operator_size: 12288  num_matrices: 1000
benchmark setup time: 9.074 seconds.
single precision: 73.9265 Gflops / second.
double precision: 48.2701 Gflops / second.
svh@PC102795:~/Documents/asgard/build$ OMP_PROC_BIND=close OMP_NUM_THREADS=20 ./asgard-kronmult-benchmark 4 2 4096 12288 1000
benchmarking:
dimensions: 4  n: 2  num_y: 4096  operator_size: 12288  num_matrices: 1000
benchmark setup time: 10.418 seconds.
single precision: 72.4156 Gflops / second.
double precision: 59.6082 Gflops / second.
svh@PC102795:~/Documents/asgard/build$ OMP_PROC_BIND=close OMP_NUM_THREADS=20 ./asgard-kronmult-benchmark 6 2 4096 12288 1000
benchmarking:
dimensions: 6  n: 2  num_y: 4096  operator_size: 12288  num_matrices: 1000
benchmark setup time: 14.111 seconds.
single precision: 110.1744 Gflops / second.
double precision: 52.2424 Gflops / second.
```

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [ ] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

My workstation, Ubuntu 22.04

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
