### PR TITLE
allow the use of an existing catch2 installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,11 +37,18 @@ function (register_project name dir url default_tag)
 endfunction ()
 
 #  Catch two testing framework.
-register_project (Catch2
-                  CATCH2
-                  https://github.com/catchorg/Catch2.git
-                  v3.1.0
-)
+#  The default behavior is to build catch together with ASGarD,
+#  but if Catch2_ROOT is explicitly provided then search
+#  for an existing installation.
+if (Catch2_ROOT)
+  find_package(Catch2 REQUIRED)
+else()
+  register_project (Catch2
+                    CATCH2
+                    https://github.com/catchorg/Catch2.git
+                    v3.1.0
+  )
+endif()
 
 #Mark CATCH variables as advanced.
 get_cmake_property(_variableNames VARIABLES)


### PR DESCRIPTION
Catch2 takes time to compile and it is compiled every time we rebuild the project, e.g., to switch CUDA on/off or to enable different set of flags.

The default is kept in place but it is possible to use an external installation of Catch2 with the additional option `Catch2_ROOT`

https://cmake.org/cmake/help/latest/envvar/PackageName_ROOT.html#envvar:%3CPackageName%3E_ROOT