### PR TITLE
Fix vector overflow

### DIFF
--- a/src/asgard_kronmult_matrix.cpp
+++ b/src/asgard_kronmult_matrix.cpp
@@ -48,7 +48,7 @@ make_kronmult_dense(PDE<precision> const &pde,
   }
 
   fk::vector<int, mem_type::owner, resource::host> iA(
-      num_rows * num_cols * num_terms * num_dimensions);
+      int64_t{num_rows} * num_cols * num_terms * num_dimensions);
   fk::vector<precision, mem_type::owner, resource::host> vA(osize);
 
 #ifdef ASGARD_USE_CUDA

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -220,9 +220,9 @@ simple_gmres(matrix_replacement mat, fk::vector<P> &x, fk::vector<P> const &b,
     x = x + (fk::matrix<P, mem_type::view>(basis, 0, basis.nrows() - 1, 0,
                                            restart - 1) *
              s_view);
-    P const norm_r_outer                               = compute_residual();
-    krylov_sol(std::min(krylov_sol.size() - 1, i + 1)) = norm_r_outer;
-    error                                              = norm_r_outer / norm_b;
+    P const norm_r_outer = compute_residual();
+    krylov_sol(std::min(krylov_sol.size() - 1, int64_t{i + 1})) = norm_r_outer;
+    error = norm_r_outer / norm_b;
 
     if (error <= tolerance)
     {


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Running a large problem such as `./asgard -p two_stream -d 3 -l "7 7" -t 1.5625e-3 -f -x -n 1` after #541 causes an overflow when allocating the kronmult `iA` vector.

This changes `fk::vector` to use `int64_t` for the vector size to prevent overflow for large vectors.

The `update_row` and `update_col` functions also need to be updated to use int64_t, but these require updating `lib_dispatch::copy` to use int64_t as well. For now, a check was added to make sure the vector size is less than INT_MAX.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

Ubuntu 20.04

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
