### PR TITLE
Avoid static_cast with timers

### DIFF
--- a/src/asgard_kronmult_benchmark.cpp
+++ b/src/asgard_kronmult_benchmark.cpp
@@ -44,9 +44,7 @@ int main(int argc, char **argv)
 
   auto time_end = std::chrono::system_clock::now();
   double elapsed =
-      static_cast<double>(std::chrono::duration_cast<std::chrono::milliseconds>(
-                              time_end - time_start)
-                              .count());
+      std::chrono::duration<double, std::milli>(time_end - time_start).count();
 
   std::cout << "benchmark setup time: " << elapsed / 1000 << " seconds.\n";
 
@@ -99,9 +97,7 @@ int main(int argc, char **argv)
   }
   time_end = std::chrono::system_clock::now();
   double felapsed =
-      static_cast<double>(std::chrono::duration_cast<std::chrono::milliseconds>(
-                              time_end - time_start)
-                              .count());
+      std::chrono::duration<double, std::milli>(time_end - time_start).count();
 
   std::cout << std::fixed << std::setprecision(4);
   std::cout << "single precision: ";
@@ -125,9 +121,7 @@ int main(int argc, char **argv)
   }
   time_end = std::chrono::system_clock::now();
   double delapsed =
-      static_cast<double>(std::chrono::duration_cast<std::chrono::milliseconds>(
-                              time_end - time_start)
-                              .count());
+      std::chrono::duration<double, std::milli>(time_end - time_start).count();
 
   std::cout << "double precision: ";
   if (delapsed == 0)

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -14,7 +14,7 @@ std::string simple_timer::report()
   std::ostringstream report;
   report << "\nperformance report, all times in ms...\n\n";
   char const *fmt =
-      "%s - avg: %.4f min: %.3f max: %.3f med: %.4f %s calls: %d \n";
+      "%s - avg: %.7f min: %.7f max: %.7f med: %.7f %s calls: %d \n";
   for (auto [id, times] : id_to_times_)
   {
     auto const avg =

--- a/src/tools.hpp
+++ b/src/tools.hpp
@@ -48,9 +48,7 @@ public:
       auto const gflops = flops / 1e9;
       expect(dur >= 0.0);
 
-      auto const gflops_per_sec = dur == 0.0
-                                      ? std::numeric_limits<double>::infinity()
-                                      : gflops / (dur * 1e-3); // to seconds
+      auto const gflops_per_sec = gflops / (dur * 1e-3); // to seconds
 
       insert(id_to_flops_, identifier, gflops_per_sec);
       expect(id_to_times_.count(identifier) == id_to_flops_.count(identifier));

--- a/src/tools.hpp
+++ b/src/tools.hpp
@@ -36,12 +36,11 @@ public:
     expect(id_to_start_.count(identifier) == 1);
     auto const beg = id_to_start_[identifier];
     auto const end = std::chrono::high_resolution_clock::now();
-    auto const dur =
-        std::chrono::duration_cast<std::chrono::microseconds>(end - beg)
-            .count();
+    double const dur =
+        std::chrono::duration<double, std::milli>(end - beg).count();
 
     id_to_start_.erase(identifier);
-    insert(id_to_times_, identifier, dur * 1e-3); // to ms
+    insert(id_to_times_, identifier, dur);
 
     if (flops != -1)
     {
@@ -49,9 +48,9 @@ public:
       auto const gflops = flops / 1e9;
       expect(dur >= 0.0);
 
-      auto const gflops_per_sec =
-          dur == 0.0 ? std::numeric_limits<double>::infinity()
-                     : gflops / (static_cast<double>(dur) * 1e-6); // to seconds
+      auto const gflops_per_sec = dur == 0.0
+                                      ? std::numeric_limits<double>::infinity()
+                                      : gflops / (dur * 1e-3); // to seconds
 
       insert(id_to_flops_, identifier, gflops_per_sec);
       expect(id_to_times_.count(identifier) == id_to_flops_.count(identifier));


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

https://en.cppreference.com/w/cpp/chrono/duration/duration_cast has an example of using a floating-point duration, thus avoiding static_cast.

This actually causes `tools_test` to fail and I had to increase the precision in the report std::string to verify that there is no error.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [ ] Bugfix
- [ ] New feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [x] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
