### PR TITLE
removed reference counts from matrix and vector

### DIFF
--- a/src/tensors.hpp
+++ b/src/tensors.hpp
@@ -500,9 +500,9 @@ private:
   // to this private constructor, also with a dummy variable
   template<mem_type omem, mem_type m_ = mem,
            typename = enable_for_all_views<m_>>
-  explicit vector(fk::matrix<P, omem, resrc> const &source,
-                  int dummy, int const column_index,
-                  int const row_start, int const row_stop);
+  explicit vector(fk::matrix<P, omem, resrc> const &source, int dummy,
+                  int const column_index, int const row_start,
+                  int const row_stop);
 
   //! pointer to elements
   P *data_;
@@ -763,9 +763,9 @@ private:
   // to this private constructor, also with a dummy variable
   template<mem_type omem, mem_type m_ = mem,
            typename = enable_for_all_views<m_>>
-  explicit matrix(fk::vector<P, omem, resrc> const &source,
-                  int dummy, int const num_rows,
-                  int const num_cols, int const start_index);
+  explicit matrix(fk::vector<P, omem, resrc> const &source, int dummy,
+                  int const num_rows, int const num_cols,
+                  int const start_index);
 
   P *data_;    //< pointer to elements
   int nrows_;  //< row dimension
@@ -947,15 +947,13 @@ namespace asgard
 //-----------------------------------------------------------------------------
 template<typename P, mem_type mem, resource resrc>
 template<mem_type, typename>
-fk::vector<P, mem, resrc>::vector()
-    : data_{nullptr}, size_{0}
+fk::vector<P, mem, resrc>::vector() : data_{nullptr}, size_{0}
 {}
 // right now, initializing with zero for e.g. passing in answer vectors to blas
 // but this is probably slower if needing to declare in a perf. critical region
 template<typename P, mem_type mem, resource resrc>
 template<mem_type, typename>
-fk::vector<P, mem, resrc>::vector(int const size)
-    : size_{size}
+fk::vector<P, mem, resrc>::vector(int const size) : size_{size}
 {
   expect(size >= 0);
 
@@ -1066,8 +1064,7 @@ template<mem_type, typename, mem_type omem>
 fk::vector<P, mem, resrc>::vector(fk::matrix<P, omem, resrc> const &source,
                                   int const column_index, int const row_start,
                                   int const row_stop)
-    : vector(source, 0, column_index, row_start,
-             row_stop)
+    : vector(source, 0, column_index, row_start, row_stop)
 {}
 
 // modifiable view version - delegates to private constructor
@@ -1076,8 +1073,7 @@ template<mem_type, typename, mem_type omem, mem_type, typename>
 fk::vector<P, mem, resrc>::vector(fk::matrix<P, omem, resrc> &source,
                                   int const column_index, int const row_start,
                                   int const row_stop)
-    : vector(source, 0, column_index, row_start,
-             row_stop)
+    : vector(source, 0, column_index, row_start, row_stop)
 {}
 
 template<typename P, mem_type mem, resource resrc>
@@ -1122,7 +1118,7 @@ fk::vector<P, mem, resrc>::vector(vector<P, mem, resrc> const &a)
   }
   else
   {
-    data_      = a.data();
+    data_ = a.data();
   }
 }
 
@@ -1181,7 +1177,7 @@ fk::vector<P, mem, resrc>::operator=(vector<P, mem, resrc> &&a)
   if (&a == this)
     return *this;
 
-  size_      = a.size_;
+  size_ = a.size_;
   P *const temp{data_};
   data_   = a.data_;
   a.data_ = temp; // b/c a's destructor will be called
@@ -1766,9 +1762,8 @@ template<typename P, mem_type mem, resource resrc>
 template<mem_type, typename>
 fk::matrix<P, mem, resrc>::matrix(
     std::initializer_list<std::initializer_list<P>> llist)
-    : nrows_{static_cast<int>(llist.size())}, ncols_{static_cast<int>(
-                                                  llist.begin()->size())},
-      stride_{nrows_}
+    : nrows_{static_cast<int>(llist.size())},
+      ncols_{static_cast<int>(llist.begin()->size())}, stride_{nrows_}
 {
   if constexpr (resrc == resource::host)
   {
@@ -1894,7 +1889,7 @@ fk::matrix<P, mem, resrc>::matrix(matrix<P, mem, resrc> const &a)
   }
   else
   {
-    data_      = a.data();
+    data_ = a.data();
   }
 }
 
@@ -1928,7 +1923,7 @@ fk::matrix<P, mem, resrc>::operator=(matrix<P, mem, resrc> const &a)
   }
   else
   {
-    data_      = a.data();
+    data_ = a.data();
   }
 
   return *this;

--- a/src/tensors.hpp
+++ b/src/tensors.hpp
@@ -408,31 +408,6 @@ public:
    */
   P *data(int const elem = 0) const { return data_ + elem; }
 
-  /*! this is to allow specific other types to access the private ref counter of
-   *  owners - specifically, we want to allow a matrix<view> to be made from a
-   *  vector<owner/view>
-   *  \param access badge limiting public access.
-   *  \return reference count of owners.
-   */
-  std::shared_ptr<int>
-  get_ref_count(access_badge<matrix<P, mem_type::view, resrc>> const access)
-  {
-    ignore(access);
-    return ref_count_;
-  }
-  /*! this is to allow specific other types to access the private ref counter of
-   *  owners - specifically, we want to allow a matrix<view> to be made from a
-   *  vector<owner/view>
-   *  \param access badge limiting public access.
-   *  \return reference count of owners.
-   */
-  std::shared_ptr<int> get_ref_count(
-      access_badge<matrix<P, mem_type::const_view, resrc>> const access) const
-  {
-    ignore(access);
-    return ref_count_;
-  }
-
   // utility functions
 
   /*! Prints out the values of a vector
@@ -513,12 +488,6 @@ public:
    */
   const_iterator end() const { return data() + size(); }
 
-  /*! number of outstanding views for an owner
-   * \return number of outstanding views for an owner
-   */
-  template<mem_type m_ = mem, typename = enable_for_owner<m_>>
-  int get_num_views() const;
-
 private:
   // const/nonconst view constructors delegate to this private constructor
   // delegated is a dummy variable to enable resolution
@@ -532,15 +501,13 @@ private:
   template<mem_type omem, mem_type m_ = mem,
            typename = enable_for_all_views<m_>>
   explicit vector(fk::matrix<P, omem, resrc> const &source,
-                  std::shared_ptr<int> source_ref_count, int const column_index,
+                  int dummy, int const column_index,
                   int const row_start, int const row_stop);
 
   //! pointer to elements
   P *data_;
   //! size of container
   int size_;
-  //! reference counter of owners
-  std::shared_ptr<int> ref_count_ = nullptr;
 };
 
 template<typename P, mem_type mem, resource resrc>
@@ -758,24 +725,6 @@ public:
   template<resource r_ = resrc, typename = enable_for_host<r_>>
   void dump_to_octave(std::filesystem::path const &filename) const;
 
-  template<mem_type m_ = mem, typename = enable_for_owner<m_>>
-  int get_num_views() const;
-
-  // this is to allow specific other types to access the private ref counter of
-  // owners - specifically, we want to allow a vector<view> to be made from a
-  // matrix<owner/view>
-  std::shared_ptr<int>
-  get_ref_count(access_badge<vector<P, mem_type::view, resrc>> const)
-  {
-    return ref_count_;
-  }
-
-  std::shared_ptr<int> get_ref_count(
-      access_badge<vector<P, mem_type::const_view, resrc>> const) const
-  {
-    return ref_count_;
-  }
-
   using iterator       = matrix_iterator<P *, P &>;
   using const_iterator = matrix_iterator<P const *, P const &>;
 
@@ -815,7 +764,7 @@ private:
   template<mem_type omem, mem_type m_ = mem,
            typename = enable_for_all_views<m_>>
   explicit matrix(fk::vector<P, omem, resrc> const &source,
-                  std::shared_ptr<int> source_ref_count, int const num_rows,
+                  int dummy, int const num_rows,
                   int const num_cols, int const start_index);
 
   P *data_;    //< pointer to elements
@@ -824,7 +773,6 @@ private:
   int stride_; //< leading dimension;
                // number of elements in memory between successive matrix
                // elements in a row
-  std::shared_ptr<int> ref_count_ = nullptr;
 };
 
 //-----------------------------------------------------------------------------
@@ -1000,14 +948,14 @@ namespace asgard
 template<typename P, mem_type mem, resource resrc>
 template<mem_type, typename>
 fk::vector<P, mem, resrc>::vector()
-    : data_{nullptr}, size_{0}, ref_count_{std::make_shared<int>(0)}
+    : data_{nullptr}, size_{0}
 {}
 // right now, initializing with zero for e.g. passing in answer vectors to blas
 // but this is probably slower if needing to declare in a perf. critical region
 template<typename P, mem_type mem, resource resrc>
 template<mem_type, typename>
 fk::vector<P, mem, resrc>::vector(int const size)
-    : size_{size}, ref_count_{std::make_shared<int>(0)}
+    : size_{size}
 {
   expect(size >= 0);
 
@@ -1027,7 +975,7 @@ fk::vector<P, mem, resrc>::vector(int const size)
 template<typename P, mem_type mem, resource resrc>
 template<mem_type, typename>
 fk::vector<P, mem, resrc>::vector(std::initializer_list<P> list)
-    : size_{static_cast<int>(list.size())}, ref_count_{std::make_shared<int>(0)}
+    : size_{static_cast<int>(list.size())}
 {
   if constexpr (resrc == resource::host)
   {
@@ -1044,8 +992,7 @@ fk::vector<P, mem, resrc>::vector(std::initializer_list<P> list)
 template<typename P, mem_type mem, resource resrc>
 template<mem_type, typename, resource, typename>
 fk::vector<P, mem, resrc>::vector(std::vector<P> const &v)
-    : data_{new P[v.size()]}, size_{static_cast<int>(v.size())},
-      ref_count_{std::make_shared<int>(0)}
+    : data_{new P[v.size()]}, size_{static_cast<int>(v.size())}
 {
   std::copy(v.begin(), v.end(), data_);
 }
@@ -1058,7 +1005,7 @@ template<typename P, mem_type mem, resource resrc>
 template<mem_type, typename>
 fk::vector<P, mem, resrc>::vector(
     fk::matrix<P, mem_type::owner, resrc> const &mat)
-    : data_(nullptr), size_(mat.size()), ref_count_{std::make_shared<int>(0)}
+    : data_(nullptr), size_(mat.size())
 {
   if (size_ != 0)
   {
@@ -1119,7 +1066,7 @@ template<mem_type, typename, mem_type omem>
 fk::vector<P, mem, resrc>::vector(fk::matrix<P, omem, resrc> const &source,
                                   int const column_index, int const row_start,
                                   int const row_stop)
-    : vector(source, source.get_ref_count({}), column_index, row_start,
+    : vector(source, 0, column_index, row_start,
              row_stop)
 {}
 
@@ -1129,7 +1076,7 @@ template<mem_type, typename, mem_type omem, mem_type, typename>
 fk::vector<P, mem, resrc>::vector(fk::matrix<P, omem, resrc> &source,
                                   int const column_index, int const row_start,
                                   int const row_stop)
-    : vector(source, source.get_ref_count({}), column_index, row_start,
+    : vector(source, 0, column_index, row_start,
              row_stop)
 {}
 
@@ -1142,8 +1089,6 @@ fk::vector<P, mem, resrc>::~vector()
 {
   if constexpr (mem == mem_type::owner)
   {
-    expect(ref_count_.use_count() == 1);
-
     if constexpr (resrc == resource::host)
     {
       delete[] data_;
@@ -1164,8 +1109,6 @@ fk::vector<P, mem, resrc>::vector(vector<P, mem, resrc> const &a)
 {
   if constexpr (mem == mem_type::owner)
   {
-    ref_count_ = std::make_shared<int>(0);
-
     if constexpr (resrc == resource::host)
     {
       data_ = new P[a.size()];
@@ -1180,7 +1123,6 @@ fk::vector<P, mem, resrc>::vector(vector<P, mem, resrc> const &a)
   else
   {
     data_      = a.data();
-    ref_count_ = a.ref_count_;
   }
 }
 
@@ -1222,12 +1164,6 @@ template<typename P, mem_type mem, resource resrc>
 fk::vector<P, mem, resrc>::vector(vector<P, mem, resrc> &&a)
     : data_{a.data_}, size_{a.size_}
 {
-  if constexpr (mem == mem_type::owner)
-  {
-    expect(a.ref_count_.use_count() == 1);
-  }
-  ref_count_ = std::make_shared<int>(0);
-  ref_count_.swap(a.ref_count_);
   a.data_ = nullptr; // b/c a's destructor will be called
   a.size_ = 0;
 }
@@ -1245,15 +1181,7 @@ fk::vector<P, mem, resrc>::operator=(vector<P, mem, resrc> &&a)
   if (&a == this)
     return *this;
 
-  if constexpr (mem == mem_type::owner)
-  {
-    expect(ref_count_.use_count() == 1);
-    expect(a.ref_count_.use_count() == 1);
-  }
-
   size_      = a.size_;
-  ref_count_ = std::make_shared<int>(0);
-  ref_count_.swap(a.ref_count_);
   P *const temp{data_};
   data_   = a.data_;
   a.data_ = temp; // b/c a's destructor will be called
@@ -1266,8 +1194,7 @@ fk::vector<P, mem, resrc>::operator=(vector<P, mem, resrc> &&a)
 template<typename P, mem_type mem, resource resrc>
 template<typename PP, mem_type omem, mem_type, typename, resource, typename>
 fk::vector<P, mem, resrc>::vector(vector<PP, omem> const &a)
-    : data_{new P[a.size()]}, size_{a.size()}, ref_count_{
-                                                   std::make_shared<int>(0)}
+    : data_{new P[a.size()]}, size_{a.size()}
 {
   for (auto i = 0; i < a.size(); ++i)
   {
@@ -1300,7 +1227,7 @@ fk::vector<P, mem, resrc>::operator=(vector<PP, omem> const &a)
 template<typename P, mem_type mem, resource resrc>
 template<mem_type omem, mem_type, typename, mem_type, typename>
 fk::vector<P, mem, resrc>::vector(vector<P, omem, resrc> const &a)
-    : size_(a.size()), ref_count_(std::make_shared<int>(0))
+    : size_(a.size())
 {
   if constexpr (resrc == resource::host)
   {
@@ -1620,8 +1547,7 @@ template<resource, typename>
 void fk::vector<P, mem, resrc>::print(std::string_view const label) const
 {
   if constexpr (mem == mem_type::owner)
-    std::cout << label << "(owner, ref_count = " << ref_count_.use_count()
-              << ")" << '\n';
+    std::cout << label << "(owner)" << '\n';
   else if constexpr (mem == mem_type::view)
     std::cout << label << "(view)" << '\n';
   else if constexpr (mem == mem_type::const_view)
@@ -1756,21 +1682,12 @@ fk::vector<P, mem, resrc>::extract(int const start, int const stop) const
   return sub_vector;
 }
 
-// get number of outstanding views for an owner
-template<typename P, mem_type mem, resource resrc>
-template<mem_type, typename>
-int fk::vector<P, mem, resrc>::get_num_views() const
-{
-  return ref_count_.use_count() - 1;
-}
-
 // const/nonconst view constructors delegate to this private constructor
 template<typename P, mem_type mem, resource resrc>
 template<mem_type, typename, mem_type omem>
 fk::vector<P, mem, resrc>::vector(fk::vector<P, omem, resrc> const &vec,
                                   int const start_index, int const stop_index,
                                   bool const delegated)
-    : ref_count_{vec.ref_count_}
 {
   // ignore dummy argument to avoid compiler warnings
   ignore(delegated);
@@ -1791,11 +1708,9 @@ fk::vector<P, mem, resrc>::vector(fk::vector<P, omem, resrc> const &vec,
 // this private constructor
 template<typename P, mem_type mem, resource resrc>
 template<mem_type omem, mem_type, typename>
-fk::vector<P, mem, resrc>::vector(fk::matrix<P, omem, resrc> const &source,
-                                  std::shared_ptr<int> source_ref_count,
+fk::vector<P, mem, resrc>::vector(fk::matrix<P, omem, resrc> const &source, int,
                                   int const column_index, int const row_start,
                                   int const row_stop)
-    : ref_count_(source_ref_count)
 {
   expect(column_index >= 0);
   expect(column_index < source.ncols());
@@ -1822,8 +1737,7 @@ fk::vector<P, mem, resrc>::vector(fk::matrix<P, omem, resrc> const &source,
 template<typename P, mem_type mem, resource resrc>
 template<mem_type, typename>
 fk::matrix<P, mem, resrc>::matrix()
-    : data_{nullptr}, nrows_{0}, ncols_{0}, stride_{nrows_},
-      ref_count_{std::make_shared<int>(0)}
+    : data_{nullptr}, nrows_{0}, ncols_{0}, stride_{nrows_}
 
 {}
 
@@ -1832,8 +1746,7 @@ fk::matrix<P, mem, resrc>::matrix()
 template<typename P, mem_type mem, resource resrc>
 template<mem_type, typename>
 fk::matrix<P, mem, resrc>::matrix(int const m, int const n)
-    : nrows_{m}, ncols_{n}, stride_{nrows_}, ref_count_{
-                                                 std::make_shared<int>(0)}
+    : nrows_{m}, ncols_{n}, stride_{nrows_}
 
 {
   expect(m >= 0);
@@ -1855,7 +1768,7 @@ fk::matrix<P, mem, resrc>::matrix(
     std::initializer_list<std::initializer_list<P>> llist)
     : nrows_{static_cast<int>(llist.size())}, ncols_{static_cast<int>(
                                                   llist.begin()->size())},
-      stride_{nrows_}, ref_count_{std::make_shared<int>(0)}
+      stride_{nrows_}
 {
   if constexpr (resrc == resource::host)
   {
@@ -1924,7 +1837,7 @@ template<mem_type, typename, mem_type omem>
 fk::matrix<P, mem, resrc>::matrix(fk::vector<P, omem, resrc> const &source,
                                   int const num_rows, int const num_cols,
                                   int const start_index)
-    : matrix(source, source.get_ref_count({}), num_rows, num_cols, start_index)
+    : matrix(source, 0, num_rows, num_cols, start_index)
 {}
 
 // create matrix view of existing vector
@@ -1934,7 +1847,7 @@ template<mem_type, typename, mem_type omem, mem_type, typename>
 fk::matrix<P, mem, resrc>::matrix(fk::vector<P, omem, resrc> &source,
                                   int const num_rows, int const num_cols,
                                   int const start_index)
-    : matrix(source, source.get_ref_count({}), num_rows, num_cols, start_index)
+    : matrix(source, 0, num_rows, num_cols, start_index)
 {}
 
 // destructor
@@ -1947,7 +1860,6 @@ fk::matrix<P, mem, resrc>::~matrix()
 {
   if constexpr (mem == mem_type::owner)
   {
-    expect(ref_count_.use_count() == 1);
     if constexpr (resrc == resource::host)
     {
       delete[] data_;
@@ -1969,8 +1881,6 @@ fk::matrix<P, mem, resrc>::matrix(matrix<P, mem, resrc> const &a)
 {
   if constexpr (mem == mem_type::owner)
   {
-    ref_count_ = std::make_shared<int>(0);
-
     if constexpr (resrc == resource::host)
     {
       data_ = new P[a.size()]();
@@ -1985,7 +1895,6 @@ fk::matrix<P, mem, resrc>::matrix(matrix<P, mem, resrc> const &a)
   else
   {
     data_      = a.data();
-    ref_count_ = a.ref_count_;
   }
 }
 
@@ -2020,7 +1929,6 @@ fk::matrix<P, mem, resrc>::operator=(matrix<P, mem, resrc> const &a)
   else
   {
     data_      = a.data();
-    ref_count_ = a.ref_count_;
   }
 
   return *this;
@@ -2031,8 +1939,7 @@ fk::matrix<P, mem, resrc>::operator=(matrix<P, mem, resrc> const &a)
 template<typename P, mem_type mem, resource resrc>
 template<mem_type omem, mem_type, typename, mem_type, typename>
 fk::matrix<P, mem, resrc>::matrix(matrix<P, omem, resrc> const &a)
-    : nrows_{a.nrows()}, ncols_{a.ncols()}, stride_{a.nrows()},
-      ref_count_{std::make_shared<int>(0)}
+    : nrows_{a.nrows()}, ncols_{a.ncols()}, stride_{a.nrows()}
 {
   if constexpr (resrc == resource::host)
   {
@@ -2072,7 +1979,7 @@ template<typename P, mem_type mem, resource resrc>
 template<typename PP, mem_type omem, mem_type, typename, resource, typename>
 fk::matrix<P, mem, resrc>::matrix(matrix<PP, omem> const &a)
     : data_{new P[a.size()]()}, nrows_{a.nrows()}, ncols_{a.ncols()},
-      stride_{a.nrows()}, ref_count_{std::make_shared<int>(0)}
+      stride_{a.nrows()}
 
 {
   for (auto j = 0; j < a.ncols(); ++j)
@@ -2164,14 +2071,6 @@ template<typename P, mem_type mem, resource resrc>
 fk::matrix<P, mem, resrc>::matrix(matrix<P, mem, resrc> &&a)
     : data_{a.data()}, nrows_{a.nrows()}, ncols_{a.ncols()}, stride_{a.stride()}
 {
-  if constexpr (mem == mem_type::owner)
-  {
-    expect(a.ref_count_.use_count() == 1);
-  }
-
-  ref_count_ = std::make_shared<int>(0);
-  ref_count_.swap(a.ref_count_);
-
   a.data_  = nullptr; // b/c a's destructor will be called
   a.nrows_ = 0;
   a.ncols_ = 0;
@@ -2192,14 +2091,6 @@ fk::matrix<P, mem, resrc>::operator=(matrix<P, mem, resrc> &&a)
 
   expect((nrows() == a.nrows()) &&
          (ncols() == a.ncols() && stride() == a.stride()));
-
-  // check for destination orphaning; see below
-  if constexpr (mem == mem_type::owner)
-  {
-    expect(ref_count_.use_count() == 1 && a.ref_count_.use_count() == 1);
-  }
-  ref_count_ = std::make_shared<int>(0);
-  ref_count_.swap(a.ref_count_);
 
   P *temp{data_};
   // this would orphan views on the destination
@@ -2676,8 +2567,6 @@ template<mem_type, typename>
 fk::matrix<P, mem_type::owner, resrc> &
 fk::matrix<P, mem, resrc>::clear_and_resize(int const rows, int const cols)
 {
-  expect(ref_count_.use_count() == 1);
-
   expect(rows >= 0);
   expect(cols >= 0);
   if (rows == 0 || cols == 0)
@@ -2762,9 +2651,7 @@ template<resource, typename>
 void fk::matrix<P, mem, resrc>::print(std::string label) const
 {
   if constexpr (mem == mem_type::owner)
-    std::cout << label << "(owner, "
-              << "outstanding views == " << std::to_string(get_num_views())
-              << ")" << '\n';
+    std::cout << label << "(owner)" << '\n';
 
   else if constexpr (mem == mem_type::view)
     std::cout << label << "(view, "
@@ -2823,14 +2710,6 @@ void fk::matrix<P, mem, resrc>::dump_to_octave(
   std::cout.rdbuf(coutbuf);
 }
 
-// get number of outstanding views for an owner
-template<typename P, mem_type mem, resource resrc>
-template<mem_type, typename>
-int fk::matrix<P, mem, resrc>::get_num_views() const
-{
-  return ref_count_.use_count() - 1;
-}
-
 // public const/nonconst view constructors delegate to this private
 // constructor
 template<typename P, mem_type mem, resource resrc>
@@ -2839,7 +2718,6 @@ fk::matrix<P, mem, resrc>::matrix(fk::matrix<P, omem, resrc> const &owner,
                                   int const start_row, int const stop_row,
                                   int const start_col, int const stop_col,
                                   bool const delegated)
-    : ref_count_(owner.ref_count_)
 {
   ignore(delegated);
   data_   = nullptr;
@@ -2868,11 +2746,9 @@ fk::matrix<P, mem, resrc>::matrix(fk::matrix<P, omem, resrc> const &owner,
 // this private constructor
 template<typename P, mem_type mem, resource resrc>
 template<mem_type omem, mem_type, typename>
-fk::matrix<P, mem, resrc>::matrix(fk::vector<P, omem, resrc> const &source,
-                                  std::shared_ptr<int> source_ref_count,
+fk::matrix<P, mem, resrc>::matrix(fk::vector<P, omem, resrc> const &source, int,
                                   int const num_rows, int const num_cols,
                                   int const start_index)
-    : ref_count_(source_ref_count)
 {
   expect(start_index >= 0);
   expect(num_rows > 0);

--- a/src/tensors_tests.cpp
+++ b/src/tensors_tests.cpp
@@ -385,7 +385,6 @@ TEMPLATE_TEST_CASE("fk::vector interface: constructors, copy/move", "[tensors]",
     fk::vector<TestType> moved_own(gold);
     fk::vector<TestType, mem_type::view> moved_v(moved_own);
     fk::vector<TestType, mem_type::view> test_v(std::move(moved_v));
-    REQUIRE(moved_own.get_num_views() == 1);
     REQUIRE(moved_v.data() == nullptr);
     REQUIRE(test_v.data() == moved_own.data());
     REQUIRE(test_v == gold);
@@ -393,7 +392,6 @@ TEMPLATE_TEST_CASE("fk::vector interface: constructors, copy/move", "[tensors]",
     // const views
     fk::vector<TestType, mem_type::const_view> moved_cv(gold);
     fk::vector<TestType, mem_type::const_view> test_cv(std::move(moved_cv));
-    REQUIRE(gold.get_num_views() == 1);
     REQUIRE(moved_cv.data() == nullptr);
     REQUIRE(test_cv.data() == gold.data());
     REQUIRE(test_cv == gold);
@@ -813,7 +811,7 @@ TEMPLATE_TEST_CASE("fk::vector utilities", "[tensors]", double, float, int)
     if constexpr (std::is_floating_point<TestType>::value)
     {
       golden_string =
-          "golden vector(owner, ref_count = 2)\n  2.0000e+00  3.0000e+00  "
+          "golden vector(owner)\n  2.0000e+00  3.0000e+00  "
           "4.0000e+00  5.0000e+00  6.0000e+00\n";
       golden_string_v = "golden vector(view)\n  2.0000e+00  3.0000e+00  "
                         "4.0000e+00  5.0000e+00  6.0000e+00\n";
@@ -822,7 +820,7 @@ TEMPLATE_TEST_CASE("fk::vector utilities", "[tensors]", double, float, int)
     }
     else
     {
-      golden_string = "golden vector(owner, ref_count = 2)\n2 3 "
+      golden_string = "golden vector(owner)\n2 3 "
                       "4 5 6 \n";
       golden_string_v = "golden vector(view)\n2 3 "
                         "4 5 6 \n";
@@ -1023,50 +1021,6 @@ TEMPLATE_TEST_CASE("fk::vector utilities", "[tensors]", double, float, int)
     REQUIRE(std::accumulate(test_v.begin(), test_v.end(), 0.0) == sum);
     REQUIRE(std::accumulate(test_cv.begin(), test_cv.end(), 0.0) == sum);
   }
-
-  SECTION("vector ref counting")
-  {
-    // on construction, vectors have 0 views
-    fk::vector<TestType> test;
-    REQUIRE(test.get_num_views() == 0);
-    fk::vector<TestType> const test_init({1});
-    REQUIRE(test_init.get_num_views() == 0);
-    fk::vector<TestType> const test_sz(1);
-    REQUIRE(test_sz.get_num_views() == 0);
-    fk::vector<TestType> const test_conv(fk::vector<int>(1));
-    REQUIRE(test_conv.get_num_views() == 0);
-    fk::vector<TestType> const test_copy(test);
-    REQUIRE(test_copy.get_num_views() == 0);
-
-    // creating views increments view count
-    fk::vector<TestType, mem_type::view> const test_view(test);
-    REQUIRE(test.get_num_views() == 1);
-
-    fk::vector<TestType, mem_type::view> const test_view_2(test_view);
-    REQUIRE(test.get_num_views() == 2);
-
-    fk::vector<TestType, mem_type::const_view> const test_cview(test_view);
-    REQUIRE(test.get_num_views() == 3);
-
-    // creating const views increments view count
-    fk::vector<TestType, mem_type::const_view> const test_cview_2(test);
-    REQUIRE(test.get_num_views() == 4);
-
-    fk::vector<TestType, mem_type::const_view> const test_cview_3(test_cview_2);
-    REQUIRE(test.get_num_views() == 5);
-
-    // copies have a fresh view count
-    fk::vector<TestType> const test_cp(test);
-    REQUIRE(test_cp.get_num_views() == 0);
-    REQUIRE(test.get_num_views() == 5);
-
-    // test that view count gets decremented when views go out of scope
-    {
-      fk::vector<TestType, mem_type::const_view> const test_view_3(test);
-      REQUIRE(test.get_num_views() == 6);
-    }
-    REQUIRE(test.get_num_views() == 5);
-  }
 } // end fk::vector utilities
 
 TEMPLATE_TEST_CASE("fk::vector device functions", "[tensors]", double, float,
@@ -1144,7 +1098,6 @@ TEMPLATE_TEST_CASE("fk::vector device functions", "[tensors]", double, float,
       fk::matrix<TestType> base{{0, 1, 2}, {3, 4, 5}, {6, 7, 8}};
 
       fk::matrix<TestType, mem_type::view> view(base, 1, 2, 1, 2);
-      REQUIRE(base.get_num_views() == 1);
 
       {
         // create vector from first column in base
@@ -1153,11 +1106,9 @@ TEMPLATE_TEST_CASE("fk::vector device functions", "[tensors]", double, float,
         int const r_end   = 2;
         fk::vector<TestType, mem_type::view> from_owner(base, col, r_start,
                                                         r_end);
-        REQUIRE(base.get_num_views() == 2);
 
         // create vector from partial column in view
         fk::vector<TestType, mem_type::view> from_view(view, 1, 1, 1);
-        REQUIRE(base.get_num_views() == 3);
 
         fk::vector<TestType> const gold_initial{0, 3, 6};
         fk::vector<TestType> const gold_initial_v{8};
@@ -1180,25 +1131,21 @@ TEMPLATE_TEST_CASE("fk::vector device functions", "[tensors]", double, float,
         REQUIRE(base == after_mod);
         REQUIRE(view == after_mod_v);
       }
-      REQUIRE(base.get_num_views() == 1);
     }
 
     SECTION("const views from vector constructor")
     {
       fk::vector<TestType> const base{0, 1, 2, 3, 4, 5, 6, 7};
 
-      REQUIRE(base.get_num_views() == 0);
       fk::vector<TestType, mem_type::const_view> const view(base, 1, 7);
-      REQUIRE(base.get_num_views() == 1);
+
       {
         // create 2x3 matrix from last six elems in base
         fk::matrix<TestType, mem_type::const_view> const from_owner(base, 2, 3,
                                                                     2);
-        REQUIRE(base.get_num_views() == 2);
         // create 2x2 matrix from middle of view
         fk::matrix<TestType, mem_type::const_view> const from_view(view, 2, 2,
                                                                    1);
-        REQUIRE(base.get_num_views() == 3);
 
         // clang-format off
       fk::matrix<TestType> const gold_initial   {{2, 4, 6},
@@ -1210,12 +1157,9 @@ TEMPLATE_TEST_CASE("fk::vector device functions", "[tensors]", double, float,
         REQUIRE(from_owner == gold_initial);
         REQUIRE(from_view == gold_initial_v);
       }
-      REQUIRE(base.get_num_views() == 1);
       fk::matrix<TestType, mem_type::const_view> view_2(base, 1, 7);
-      REQUIRE(base.get_num_views() == 2);
       fk::matrix<TestType, mem_type::const_view> const view_m(
           std::move(view_2));
-      REQUIRE(base.get_num_views() == 2);
     }
   }
 
@@ -1251,10 +1195,8 @@ TEMPLATE_TEST_CASE("fk::vector device functions", "[tensors]", double, float,
           gold.clone_onto_device());
 
       fk::vector<TestType, mem_type::view, resource::device> const view_d(vect);
-      REQUIRE(vect.get_num_views() == 1);
       fk::vector<TestType, mem_type::view, resource::device> const view_copy_d(
           view_d);
-      REQUIRE(vect.get_num_views() == 2);
       fk::vector<TestType, mem_type::owner, resource::host> const copy_h(
           view_copy_d.clone_onto_host());
       REQUIRE(copy_h == gold);
@@ -1265,10 +1207,8 @@ TEMPLATE_TEST_CASE("fk::vector device functions", "[tensors]", double, float,
           gold.clone_onto_device());
       fk::vector<TestType, mem_type::const_view, resource::device> const view_d(
           vect);
-      REQUIRE(vect.get_num_views() == 1);
       fk::vector<TestType, mem_type::const_view, resource::device> const
           view_copy_d(view_d);
-      REQUIRE(vect.get_num_views() == 2);
 
       fk::vector<TestType, mem_type::owner, resource::host> const copy_h(
           view_copy_d.clone_onto_host());
@@ -1281,14 +1221,12 @@ TEMPLATE_TEST_CASE("fk::vector device functions", "[tensors]", double, float,
           gold.clone_onto_device());
 
       fk::vector<TestType, mem_type::view, resource::device> view_d(vect);
-      REQUIRE(vect.get_num_views() == 1);
 
       fk::vector<TestType, mem_type::view, resource::device> view_moved_d(
           std::move(view_d));
       REQUIRE(view_d.data() == nullptr);
       REQUIRE(view_d.size() == 0);
       REQUIRE(view_moved_d.data() == vect.data());
-      REQUIRE(vect.get_num_views() == 1);
 
       fk::vector<TestType, mem_type::owner, resource::host> const moved_h(
           view_moved_d.clone_onto_host());
@@ -1301,14 +1239,12 @@ TEMPLATE_TEST_CASE("fk::vector device functions", "[tensors]", double, float,
           gold.clone_onto_device());
 
       fk::vector<TestType, mem_type::const_view, resource::device> view_d(vect);
-      REQUIRE(vect.get_num_views() == 1);
 
       fk::vector<TestType, mem_type::const_view, resource::device> view_moved_d(
           std::move(view_d));
       REQUIRE(view_d.data() == nullptr);
       REQUIRE(view_d.size() == 0);
       REQUIRE(view_moved_d.data() == vect.data());
-      REQUIRE(vect.get_num_views() == 1);
 
       fk::vector<TestType, mem_type::owner, resource::host> const moved_h(
           view_moved_d.clone_onto_host());
@@ -1551,38 +1487,6 @@ TEMPLATE_TEST_CASE("fk::vector device functions", "[tensors]", double, float,
 
   SECTION("views")
   {
-    // ref counting on device
-    {
-      fk::vector<TestType, mem_type::owner, resource::device> vect(
-          gold.clone_onto_device());
-      REQUIRE(vect.get_num_views() == 0);
-      fk::vector<TestType, mem_type::const_view, resource::device> const
-          vect_cview(vect);
-      REQUIRE(vect.get_num_views() == 1);
-      fk::vector<TestType, mem_type::const_view, resource::device> const
-          vect_cview2(vect_cview);
-      REQUIRE(vect.get_num_views() == 2);
-      fk::vector<TestType, mem_type::view, resource::device> vect_view(vect);
-      REQUIRE(vect.get_num_views() == 3);
-
-      {
-        fk::vector<TestType, mem_type::view, resource::device> const
-            vect_view_2(vect_view);
-        REQUIRE(vect.get_num_views() == 4);
-        fk::vector<TestType, mem_type::const_view, resource::device> const
-            vect_cview_2(vect_cview);
-        REQUIRE(vect.get_num_views() == 5);
-        fk::vector<TestType, mem_type::view, resource::device> const vect_view3(
-            vect_view_2);
-        REQUIRE(vect.get_num_views() == 6);
-      }
-      REQUIRE(vect.get_num_views() == 3);
-
-      fk::vector<TestType, mem_type::view, resource::device> const view_moved(
-          std::move(vect_view));
-      REQUIRE(vect.get_num_views() == 3);
-    }
-
     // view semantics on device
     {
       fk::vector<TestType, mem_type::owner, resource::device> vect(
@@ -2007,16 +1911,13 @@ TEMPLATE_TEST_CASE("fk::matrix interface: constructors, copy/move", "[tensors]",
   {
     fk::vector<TestType> base{0, 1, 2, 3, 4, 5, 6, 7};
 
-    REQUIRE(base.get_num_views() == 0);
     fk::vector<TestType, mem_type::view> view(base, 1, 7);
-    REQUIRE(base.get_num_views() == 1);
+
     {
       // create 2x3 matrix from last six elems in base
       fk::matrix<TestType, mem_type::view> from_owner(base, 2, 3, 2);
-      REQUIRE(base.get_num_views() == 2);
       // create 2x2 matrix from middle of view
       fk::matrix<TestType, mem_type::view> from_view(view, 2, 2, 1);
-      REQUIRE(base.get_num_views() == 3);
 
       // clang-format off
       fk::matrix<TestType> const gold_initial   {{2, 4, 6},
@@ -2045,28 +1946,23 @@ TEMPLATE_TEST_CASE("fk::matrix interface: constructors, copy/move", "[tensors]",
       REQUIRE(base == after_mod);
       REQUIRE(view == after_mod_v);
     }
-    REQUIRE(base.get_num_views() == 1);
     fk::matrix<TestType, mem_type::view> view_2(base, 1, 7);
-    REQUIRE(base.get_num_views() == 2);
     fk::matrix<TestType, mem_type::view> const view_m(std::move(view_2));
-    REQUIRE(base.get_num_views() == 2);
   }
 
   SECTION("const views from vector constructor")
   {
     fk::vector<TestType> const base{0, 1, 2, 3, 4, 5, 6, 7};
 
-    REQUIRE(base.get_num_views() == 0);
     fk::vector<TestType, mem_type::const_view> const view(base, 1, 7);
-    REQUIRE(base.get_num_views() == 1);
+
     {
       // create 2x3 matrix from last six elems in base
       fk::matrix<TestType, mem_type::const_view> const from_owner(base, 2, 3,
                                                                   2);
-      REQUIRE(base.get_num_views() == 2);
+
       // create 2x2 matrix from middle of view
       fk::matrix<TestType, mem_type::const_view> const from_view(view, 2, 2, 1);
-      REQUIRE(base.get_num_views() == 3);
 
       // clang-format off
       fk::matrix<TestType> const gold_initial   {{2, 4, 6},
@@ -2078,11 +1974,8 @@ TEMPLATE_TEST_CASE("fk::matrix interface: constructors, copy/move", "[tensors]",
       REQUIRE(from_owner == gold_initial);
       REQUIRE(from_view == gold_initial_v);
     }
-    REQUIRE(base.get_num_views() == 1);
     fk::matrix<TestType, mem_type::const_view> view_2(base, 1, 7);
-    REQUIRE(base.get_num_views() == 2);
     fk::matrix<TestType, mem_type::const_view> const view_m(std::move(view_2));
-    REQUIRE(base.get_num_views() == 2);
   }
 
 } // end fk::matrix constructors, copy/move
@@ -2938,7 +2831,7 @@ TEMPLATE_TEST_CASE("fk::matrix utilities", "[tensors]", double, float, int)
     if constexpr (std::is_floating_point<TestType>::value)
     {
       golden_string =
-          "golden matrix(owner, outstanding views == 2)\n  1.2000e+01  "
+          "golden matrix(owner)\n  1.2000e+01  "
           "2.2000e+01  3.2000e+01\n  "
           "1.3000e+01  "
           "2.3000e+01  3.3000e+01\n  1.4000e+01  2.4000e+01  3.4000e+01\n  "
@@ -2969,7 +2862,7 @@ TEMPLATE_TEST_CASE("fk::matrix utilities", "[tensors]", double, float, int)
     }
     else
     {
-      golden_string = "golden matrix(owner, outstanding views == 2)\n12 22 32 "
+      golden_string = "golden matrix(owner)\n12 22 32 "
                       "\n13 23 33 \n14 24 34 \n15 25 "
                       "35 \n16 26 36 \n";
 
@@ -3135,47 +3028,6 @@ TEMPLATE_TEST_CASE("fk::matrix utilities", "[tensors]", double, float, int)
     REQUIRE(std::accumulate(test_cv.begin(), test_cv.end(), 0) == sum);
     REQUIRE(std::accumulate(test_v_p.begin(), test_v_p.end(), 0) == sum_p);
   }
-
-  SECTION("matrix ref counting")
-  {
-    // on construction, matrices have 0 views
-    fk::matrix<TestType> test;
-    REQUIRE(test.get_num_views() == 0);
-    fk::matrix<TestType> const test_init({{1}});
-    REQUIRE(test_init.get_num_views() == 0);
-    fk::matrix<TestType> const test_sz(1, 1);
-    REQUIRE(test_sz.get_num_views() == 0);
-    fk::matrix<TestType> const test_conv(fk::matrix<int>(1, 1));
-    REQUIRE(test_conv.get_num_views() == 0);
-    fk::matrix<TestType> const test_copy(test);
-    REQUIRE(test_copy.get_num_views() == 0);
-
-    // creating views increments view count
-    fk::matrix<TestType, mem_type::view> const test_view(test);
-    REQUIRE(test.get_num_views() == 1);
-    fk::matrix<TestType, mem_type::const_view> const test_view_2(test);
-    REQUIRE(test.get_num_views() == 2);
-
-    // copies have a fresh view count
-    fk::matrix<TestType> const test_cp(test);
-    REQUIRE(test_cp.get_num_views() == 0);
-    REQUIRE(test.get_num_views() == 2);
-
-    // test that view count gets decremented when views go out of scope
-    {
-      fk::matrix<TestType, mem_type::const_view> const test_view_3(test);
-      REQUIRE(test.get_num_views() == 3);
-    }
-    REQUIRE(test.get_num_views() == 2);
-
-    // moving views does not affect the view count
-    fk::matrix<TestType, mem_type::const_view> test_view_3(test);
-    REQUIRE(test.get_num_views() == 3);
-    fk::matrix<TestType, mem_type::const_view> test_view_4(
-        std::move(test_view_3));
-    REQUIRE(test.get_num_views() == 3);
-  }
-
 } // end fk::matrix utilities
 
 TEMPLATE_TEST_CASE("fk::matrix device transfer functions", "[tensors]", double,
@@ -3307,10 +3159,10 @@ TEMPLATE_TEST_CASE("fk::matrix device transfer functions", "[tensors]", double,
       fk::matrix<TestType, mem_type::owner, resource::device> mat(
           gold.clone_onto_device());
       fk::matrix<TestType, mem_type::view, resource::device> const view_d(mat);
-      REQUIRE(mat.get_num_views() == 1);
+
       fk::matrix<TestType, mem_type::view, resource::device> const view_copy_d(
           view_d);
-      REQUIRE(mat.get_num_views() == 2);
+
       fk::matrix<TestType, mem_type::owner, resource::host> const copy_h(
           view_copy_d.clone_onto_host());
       REQUIRE(copy_h == gold);
@@ -3322,10 +3174,10 @@ TEMPLATE_TEST_CASE("fk::matrix device transfer functions", "[tensors]", double,
           gold.clone_onto_device());
       fk::matrix<TestType, mem_type::const_view, resource::device> const view_d(
           mat);
-      REQUIRE(mat.get_num_views() == 1);
+
       fk::matrix<TestType, mem_type::const_view, resource::device> const
           view_copy_d(view_d);
-      REQUIRE(mat.get_num_views() == 2);
+
       fk::matrix<TestType, mem_type::owner, resource::host> const copy_h(
           view_copy_d.clone_onto_host());
       REQUIRE(copy_h == gold);
@@ -3337,14 +3189,12 @@ TEMPLATE_TEST_CASE("fk::matrix device transfer functions", "[tensors]", double,
           gold.clone_onto_device());
 
       fk::matrix<TestType, mem_type::view, resource::device> view_d(mat);
-      REQUIRE(mat.get_num_views() == 1);
 
       fk::matrix<TestType, mem_type::view, resource::device> view_moved_d(
           std::move(view_d));
       REQUIRE(view_d.data() == nullptr);
       REQUIRE(view_d.size() == 0);
       REQUIRE(view_moved_d.data() == mat.data());
-      REQUIRE(mat.get_num_views() == 1);
 
       fk::matrix<TestType, mem_type::owner, resource::host> const moved_h(
           view_moved_d.clone_onto_host());
@@ -3357,14 +3207,12 @@ TEMPLATE_TEST_CASE("fk::matrix device transfer functions", "[tensors]", double,
           gold.clone_onto_device());
 
       fk::matrix<TestType, mem_type::const_view, resource::device> view_d(mat);
-      REQUIRE(mat.get_num_views() == 1);
 
       fk::matrix<TestType, mem_type::const_view, resource::device> view_moved_d(
           std::move(view_d));
       REQUIRE(view_d.data() == nullptr);
       REQUIRE(view_d.size() == 0);
       REQUIRE(view_moved_d.data() == mat.data());
-      REQUIRE(mat.get_num_views() == 1);
 
       fk::matrix<TestType, mem_type::owner, resource::host> const moved_h(
           view_moved_d.clone_onto_host());
@@ -3591,39 +3439,6 @@ TEMPLATE_TEST_CASE("fk::matrix device transfer functions", "[tensors]", double,
     // clang-format on
     fk::matrix<TestType> const gold_copy_h(gold_copy.clone_onto_host());
     REQUIRE(gold_copy_h == test);
-  }
-  SECTION("views - ref counting on device")
-  {
-    fk::matrix<TestType, mem_type::owner, resource::device> mat(
-        gold.clone_onto_device());
-    REQUIRE(mat.get_num_views() == 0);
-    fk::matrix<TestType, mem_type::const_view, resource::device> const mat_view(
-        mat);
-    REQUIRE(mat.get_num_views() == 1);
-    fk::matrix<TestType, mem_type::view, resource::device> const mat_view_2(
-        mat);
-    REQUIRE(mat.get_num_views() == 2);
-    {
-      fk::matrix<TestType, mem_type::const_view, resource::device> const
-          mat_view_3(mat);
-      REQUIRE(mat.get_num_views() == 3);
-      fk::matrix<TestType, mem_type::const_view, resource::device> const
-          mat_view_4(mat_view);
-      REQUIRE(mat.get_num_views() == 4);
-    }
-    REQUIRE(mat.get_num_views() == 2);
-    fk::matrix<TestType, mem_type::view, resource::device> mat_view_5(mat);
-    REQUIRE(mat.get_num_views() == 3);
-    fk::matrix<TestType, mem_type::view, resource::device> mat_view_6(
-        std::move(mat_view_5));
-    REQUIRE(mat.get_num_views() == 3);
-
-    fk::matrix<TestType, mem_type::view, resource::device> const mat_view_7(
-        mat_view_6);
-    REQUIRE(mat.get_num_views() == 4);
-    fk::matrix<TestType, mem_type::const_view, resource::device> const
-        mat_view_8(mat_view_6);
-    REQUIRE(mat.get_num_views() == 5);
   }
 
   SECTION("views - semantics on device")

--- a/src/tensors_tests.cpp
+++ b/src/tensors_tests.cpp
@@ -810,9 +810,8 @@ TEMPLATE_TEST_CASE("fk::vector utilities", "[tensors]", double, float, int)
     std::string golden_string, golden_string_v, golden_string_cv;
     if constexpr (std::is_floating_point<TestType>::value)
     {
-      golden_string =
-          "golden vector(owner)\n  2.0000e+00  3.0000e+00  "
-          "4.0000e+00  5.0000e+00  6.0000e+00\n";
+      golden_string = "golden vector(owner)\n  2.0000e+00  3.0000e+00  "
+                      "4.0000e+00  5.0000e+00  6.0000e+00\n";
       golden_string_v = "golden vector(view)\n  2.0000e+00  3.0000e+00  "
                         "4.0000e+00  5.0000e+00  6.0000e+00\n";
       golden_string_cv = "golden vector(const view)\n  2.0000e+00  3.0000e+00  "


### PR DESCRIPTION
The ref-counts with `std::shared_ptr` inside the matrix and vector class are used only in an assert statement to make sure the `view` objects have been destroyed before the memory of the `owner` is released. This can be done with a sanitizer and even then the use case is obscure as I have not seen it happen. Nevertheless, the ref-counts were enabled in `Release` mode even when the assertions are disabled, which comes at a cost with absolutely no benefit.

Removing the ref-counts speeds things by about 10% in the `continuity_3` simulation. The number of created and destroyed vectors is still huge, but his helps a tiny bit.