### PR TITLE
Fix cuda warning

### DIFF
--- a/src/asgard_kronmult_matrix.cpp
+++ b/src/asgard_kronmult_matrix.cpp
@@ -39,7 +39,7 @@ std::vector<int> get_used_terms(PDE<precision> const &pde, options const &opts,
 
     return terms;
   }
-};
+}
 
 template<typename precision>
 kronmult_matrix<precision>

--- a/src/device/asgard_kronmult.cpp
+++ b/src/device/asgard_kronmult.cpp
@@ -43,10 +43,7 @@ constexpr int compute_team_size()
   {
     return ASGARD_GPU_WARP_SIZE;
   }
-  else
-  {
-    return ipow<n, dims>();
-  }
+  return ipow<n, dims>();
 }
 
 //! \brief Helper to instantiate and call the scaling kernel.

--- a/src/device/asgard_kronmult_cycle1.hpp
+++ b/src/device/asgard_kronmult_cycle1.hpp
@@ -268,6 +268,17 @@ cycle1(int const num_batch, int const num_cols, int const num_terms,
       i = num_batch;
   }
 
+#if (CUDART_VERSION < 11070)
+  (void)ix5;
+  (void)ix4;
+  (void)ix3;
+  (void)ix2;
+  (void)ia5;
+  (void)ia4;
+  (void)ia3;
+  (void)ia2;
+#endif
+
   while (i < num_batch)
   {
     int ma = i * num_terms * dims;

--- a/src/device/asgard_kronmult_cycle1.hpp
+++ b/src/device/asgard_kronmult_cycle1.hpp
@@ -124,7 +124,6 @@ __global__ void
 case_d1(int const num_batch, int const num_cols, int const num_terms,
         int const iA[], T const vA[], T const alpha, T const x[], T y[])
 {
-  (void)alpha;
   // if thread teams span more than one warp, we must synchronize
   constexpr manual_sync sync_mode = (team_size > ASGARD_GPU_WARP_SIZE or
                                      ASGARD_GPU_WARP_SIZE % team_size != 0)
@@ -269,6 +268,7 @@ cycle1(int const num_batch, int const num_cols, int const num_terms,
   }
 
 #if (CUDART_VERSION < 11070)
+  (void)alpha;
   (void)ix5;
   (void)ix4;
   (void)ix3;

--- a/src/device/asgard_kronmult_cycle2.hpp
+++ b/src/device/asgard_kronmult_cycle2.hpp
@@ -122,6 +122,25 @@ cycle2(int const num_batch, int const num_cols, int const num_terms,
   int const ix01 = n * ((threadIdx.x + team_size) / n);
   int const ia01 = (threadIdx.x + team_size) % n;
 
+#if (CUDART_VERSION < 11070)
+  (void)ix50;
+  (void)ix40;
+  (void)ix30;
+  (void)ix20;
+  (void)ia50;
+  (void)ia40;
+  (void)ia30;
+  (void)ia20;
+  (void)ix51;
+  (void)ix41;
+  (void)ix31;
+  (void)ix21;
+  (void)ia51;
+  (void)ia41;
+  (void)ia31;
+  (void)ia21;
+#endif
+
   while (i < num_batch)
   {
     T yinc0 = 0;

--- a/src/device/asgard_kronmult_cycle2.hpp
+++ b/src/device/asgard_kronmult_cycle2.hpp
@@ -18,7 +18,6 @@ __global__ void
 cycle2(int const num_batch, int const num_cols, int const num_terms,
        int const iA[], T const vA[], T const alpha, T const x[], T y[])
 {
-  (void)alpha;
   static_assert(dims <= 6, "kernel won't work for more than 6 dimensions");
   static_assert(
       2 * team_size >= int_pow<n, dims>(),
@@ -123,6 +122,7 @@ cycle2(int const num_batch, int const num_cols, int const num_terms,
   int const ia01 = (threadIdx.x + team_size) % n;
 
 #if (CUDART_VERSION < 11070)
+  (void)alpha;
   (void)ix50;
   (void)ix40;
   (void)ix30;

--- a/src/device/asgard_kronmult_cyclex.hpp
+++ b/src/device/asgard_kronmult_cyclex.hpp
@@ -24,7 +24,9 @@ __global__ void
 cyclex(int const num_batch, int const num_cols, int const num_terms,
        int const iA[], T const vA[], T const alpha, T const x[], T y[])
 {
+#if (CUDART_VERSION < 11070)
   (void)alpha;
+#endif
   static_assert(dims <= 6, "kernel won't work for more than 6 dimensions");
   static_assert(num_cycles <= 4, "supporting up to 4 cycles");
   static_assert(num_cycles >= 1,

--- a/src/device/asgard_spkronmult.cpp
+++ b/src/device/asgard_spkronmult.cpp
@@ -43,10 +43,7 @@ constexpr int compute_team_size()
   {
     return ASGARD_GPU_WARP_SIZE;
   }
-  else
-  {
-    return ipow<n, dims>();
-  }
+  return ipow<n, dims>();
 }
 
 //! \brief Helper to instantiate and call the scaling kernel.

--- a/src/device/asgard_spkronmult_cycle1.hpp
+++ b/src/device/asgard_spkronmult_cycle1.hpp
@@ -211,7 +211,6 @@ __global__ void
 cycle1(int const num_batch, int const ix[], int const iy[], int const num_terms,
        int const iA[], T const vA[], T const alpha, T const x[], T y[])
 {
-  (void)alpha;
   // if thread teams span more than one warp, we must synchronize
   constexpr manual_sync sync_mode = (team_size > ASGARD_GPU_WARP_SIZE or
                                      ASGARD_GPU_WARP_SIZE % team_size != 0)
@@ -263,6 +262,7 @@ cycle1(int const num_batch, int const ix[], int const iy[], int const num_terms,
   int const ia0 = threadIdx.x % n;
 
 #if (CUDART_VERSION < 11070)
+  (void)alpha;
   (void)ix5;
   (void)ix4;
   (void)ix3;

--- a/src/device/asgard_spkronmult_cycle1.hpp
+++ b/src/device/asgard_spkronmult_cycle1.hpp
@@ -262,6 +262,17 @@ cycle1(int const num_batch, int const ix[], int const iy[], int const num_terms,
   int const ix0 = n * (threadIdx.x / n);
   int const ia0 = threadIdx.x % n;
 
+#if (CUDART_VERSION < 11070)
+  (void)ix5;
+  (void)ix4;
+  (void)ix3;
+  (void)ix2;
+  (void)ia5;
+  (void)ia4;
+  (void)ia3;
+  (void)ia2;
+#endif
+
   if constexpr (effective_team_size < team_size)
   {
     if (threadIdx.x >= effective_team_size)

--- a/src/device/asgard_spkronmult_cycle2.hpp
+++ b/src/device/asgard_spkronmult_cycle2.hpp
@@ -122,6 +122,25 @@ cycle2(int const num_batch, int const ix[], int const iy[], int const num_terms,
   int const ix01 = n * ((threadIdx.x + team_size) / n);
   int const ia01 = (threadIdx.x + team_size) % n;
 
+#if (CUDART_VERSION < 11070)
+  (void)ix50;
+  (void)ix40;
+  (void)ix30;
+  (void)ix20;
+  (void)ia50;
+  (void)ia40;
+  (void)ia30;
+  (void)ia20;
+  (void)ix51;
+  (void)ix41;
+  (void)ix31;
+  (void)ix21;
+  (void)ia51;
+  (void)ia41;
+  (void)ia31;
+  (void)ia21;
+#endif
+
   while (i < num_batch)
   {
     T yinc0 = 0;

--- a/src/device/asgard_spkronmult_cyclex.hpp
+++ b/src/device/asgard_spkronmult_cyclex.hpp
@@ -24,7 +24,9 @@ __global__ void
 cyclex(int const num_batch, int const ix[], int const iy[], int const num_terms,
        int const iA[], T const vA[], T const alpha, T const x[], T y[])
 {
+#if (CUDART_VERSION < 11070)
   (void)alpha;
+#endif
   static_assert(dims <= 6, "kernel won't work for more than 6 dimensions");
   static_assert(num_cycles <= 4, "supporting up to 4 cycles");
   static_assert(num_cycles >= 1,


### PR DESCRIPTION
Closes #565

Removes the enormous amounts of warnings on older versions of CUDA where you cannot see any relevant messages.