### PR TITLE
Remove device fallback to CPU

### DIFF
--- a/src/lib_dispatch_tests.cpp
+++ b/src/lib_dispatch_tests.cpp
@@ -35,10 +35,12 @@ TEMPLATE_TEST_CASE("matrix-matrix multiply (lib_dispatch::gemm)",
     };
   // clang-format on
 
+#ifdef ASGARD_USE_CUDA
   fk::matrix<TestType, mem_type::owner, resource::device> const in1_d(
       in1.clone_onto_device());
   fk::matrix<TestType, mem_type::owner, resource::device> const in2_d(
       in2.clone_onto_device());
+#endif
 
   SECTION("no transpose")
   {
@@ -329,11 +331,15 @@ TEMPLATE_TEST_CASE("matrix-vector multiply (lib_dispatch::gemv)",
      {  8, -1, -8},
      { -9,  9,  8},
     };
-    fk::matrix<TestType, mem_type::owner, resource::device> const A_d(A.clone_onto_device());
     fk::vector<TestType> const x
      {2, 1, -7};
-    fk::vector<TestType, mem_type::owner, resource::device> const x_d(x.clone_onto_device());
   // clang-format on
+#ifdef ASGARD_USE_CUDA
+  fk::matrix<TestType, mem_type::owner, resource::device> const A_d(
+      A.clone_onto_device());
+  fk::vector<TestType, mem_type::owner, resource::device> const x_d(
+      x.clone_onto_device());
+#endif
 
   SECTION("no transpose")
   {
@@ -702,8 +708,10 @@ TEMPLATE_TEST_CASE("scale/accumulate (lib_dispatch::axpy)", "[lib_dispatch]",
                    test_precs)
 {
   fk::vector<TestType> const x = {1, 2, 3, 4, 5};
+#ifdef ASGARD_USE_CUDA
   fk::vector<TestType, mem_type::owner, resource::device> const x_d(
       x.clone_onto_device());
+#endif
 
   TestType const scale            = 3;
   fk::vector<TestType> const gold = {4, 7, 10, 13, 16};
@@ -774,11 +782,13 @@ TEMPLATE_TEST_CASE("dot product (lib_dispatch::dot)", "[lib_dispatch]",
                    test_precs, int)
 {
   fk::vector<TestType> const x = {1, 2, 3, 4, 5};
+  fk::vector<TestType> const y = {2, 4, 6, 8, 10};
+#ifdef ASGARD_USE_CUDA
   fk::vector<TestType, mem_type::owner, resource::device> const x_d(
       x.clone_onto_device());
-  fk::vector<TestType> const y = {2, 4, 6, 8, 10};
   fk::vector<TestType, mem_type::owner, resource::device> const y_d(
       y.clone_onto_device());
+#endif
   TestType const gold = 110;
 
   SECTION("lib_dispatch::dot - inc = 1")

--- a/src/tensors.hpp
+++ b/src/tensors.hpp
@@ -1009,12 +1009,12 @@ fk::vector<P, mem, resrc>::vector(std::initializer_list<P> list)
 {
   if constexpr (resrc == resource::host)
   {
-    data_ = new P[size_]();
+    data_ = new P[size_];
     std::copy(list.begin(), list.end(), data_);
   }
   else
   {
-    allocate_device(data_, size_);
+    allocate_device(data_, size_, false);
     copy_to_device(data_, list.begin(), size_);
   }
 }
@@ -1046,7 +1046,7 @@ fk::vector<P, mem, resrc>::vector(
     }
     else
     {
-      allocate_device(data_, size_);
+      allocate_device(data_, size_, false);
       copy_on_device(data_, mat.data(), mat.size());
     }
   }
@@ -1140,7 +1140,7 @@ fk::vector<P, mem, resrc>::vector(vector<P, mem, resrc> const &a)
     }
     else
     {
-      allocate_device(data_, a.size());
+      allocate_device(data_, a.size(), false);
       copy_on_device(data_, a.data(), a.size());
     }
   }
@@ -1226,7 +1226,7 @@ fk::vector<P, mem, resrc>::vector(vector<P, omem, resrc> const &a)
   }
   else
   {
-    allocate_device(data_, a.size());
+    allocate_device(data_, a.size(), false);
     copy_on_device(data_, a.data(), a.size());
   }
 }
@@ -1596,11 +1596,14 @@ fk::vector<P, mem, resrc>::resize(int const new_size)
 
   if constexpr (resrc == resource::host)
   {
-    data_ = new P[new_size]();
+    data_ = new P[new_size];
     if (size() > 0 && new_size > 0)
     {
       if (size() < new_size)
+      {
         std::memcpy(data_, old_data, size() * sizeof(P));
+        std::fill(data_ + size(), data_ + new_size, P{0});
+      }
       else
         std::memcpy(data_, old_data, new_size * sizeof(P));
     }
@@ -1631,7 +1634,7 @@ fk::vector<P, mem, resrc>::concat(vector<P, omem> const &right)
   int const old_size = this->size();
   int const new_size = this->size() + right.size();
   P *old_data{data_};
-  data_ = new P[new_size]();
+  data_ = new P[new_size];
   std::memcpy(data_, old_data, old_size * sizeof(P));
   std::memcpy(data(old_size), right.data(), right.size() * sizeof(P));
   size_ = new_size;

--- a/src/tensors_tests.cpp
+++ b/src/tensors_tests.cpp
@@ -77,10 +77,12 @@ TEMPLATE_TEST_CASE("fk::vector interface: constructors, copy/move", "[tensors]",
     REQUIRE(test_empty.size() == 0);
 
     // enable on device...
+#ifdef ASGARD_USE_CUDA
     fk::matrix<TestType, mem_type::owner, resource::device> const mat_d(
         mat.clone_onto_device());
     fk::vector<TestType, mem_type::owner, resource::device> const vect_d(mat_d);
     REQUIRE(vect_d.clone_onto_host() == gold);
+#endif
   }
 
   SECTION("construct view from owner")
@@ -901,6 +903,7 @@ TEMPLATE_TEST_CASE("fk::vector device functions", "[tensors]", test_precs, int)
 
   SECTION("ctors")
   {
+#ifdef ASGARD_USE_CUDA
     // default
     {
       fk::vector<TestType, mem_type::owner, resource::device> const vect;
@@ -963,7 +966,7 @@ TEMPLATE_TEST_CASE("fk::vector device functions", "[tensors]", test_precs, int)
           copy.clone_onto_host());
       REQUIRE(vect_h == gold);
     }
-
+#endif
     SECTION("views from matrix constructor")
     {
       fk::matrix<TestType> base{{0, 1, 2}, {3, 4, 5}, {6, 7, 8}};
@@ -1033,7 +1036,7 @@ TEMPLATE_TEST_CASE("fk::vector device functions", "[tensors]", test_precs, int)
           std::move(view_2));
     }
   }
-
+#ifdef ASGARD_USE_CUDA
   SECTION("copy and move")
   {
     // copy owner
@@ -1122,7 +1125,6 @@ TEMPLATE_TEST_CASE("fk::vector device functions", "[tensors]", test_precs, int)
       REQUIRE(moved_h == gold);
     }
   }
-
   SECTION("transfer copies and assignments")
   {
     // owner device to owner host
@@ -1434,6 +1436,7 @@ TEMPLATE_TEST_CASE("fk::vector device functions", "[tensors]", test_precs, int)
       }
     }
   }
+#endif
 }
 
 TEMPLATE_TEST_CASE("fk::matrix interface: constructors, copy/move", "[tensors]",
@@ -2903,7 +2906,7 @@ TEMPLATE_TEST_CASE("fk::matrix utilities", "[tensors]", test_precs, int)
     REQUIRE(std::accumulate(test_v_p.begin(), test_v_p.end(), 0) == sum_p);
   }
 } // end fk::matrix utilities
-
+#ifdef ASGARD_USE_CUDA
 TEMPLATE_TEST_CASE("fk::matrix device transfer functions", "[tensors]",
                    test_precs, int)
 {
@@ -3445,7 +3448,7 @@ TEMPLATE_TEST_CASE("fk::matrix device transfer functions", "[tensors]",
     REQUIRE(mat_h == gold_view);
   }
 }
-
+#endif
 TEMPLATE_TEST_CASE("fk::matrix transpose", "[tensors]", test_precs)
 {
   fk::matrix<TestType> const m_0 = {{0, 4, 8, 12, 16, 20, 24, 28},


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

This PR removes a confusing and unused feature that would allocate "device" vectors and matrices on the host CPU if CUDA isn't enabled. This feature is only used in a handful of tests.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [ ] Bugfix
- [ ] New feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [x] Yes
- [ ] No

This removes a CPU fallback that appears to only be used in test code. 

## What systems has this change been tested on?

my laptop, Ubuntu 20.04

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
