### PR TITLE
Use LLF in twostream PDE

### DIFF
--- a/src/pde/pde_two_stream.hpp
+++ b/src/pde/pde_two_stream.hpp
@@ -236,7 +236,7 @@ private:
   {
     auto param = param_manager.get_parameter("E");
     expect(param != nullptr);
-    return std::max(P{0.0},param->value(x, time));
+    return std::max(P{0.0}, param->value(x, time));
   }
 
   static P negOne(P const x, P const time = 0)
@@ -275,7 +275,7 @@ private:
   {
     auto param = param_manager.get_parameter("E");
     expect(param != nullptr);
-    return std::min(P{0.0},param->value(x, time));
+    return std::min(P{0.0}, param->value(x, time));
   }
 
   inline static const partial_term<P> pterm_E_mass_x_neg = partial_term<P>(


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

This changes the twostream PDE to use a local Lax-Friedrich flux (LLF) instead of the global Lax-Friedrich flux. This improved stability of the result and matched the original python implementation.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
