### PR TITLE
fk::vector: eliminate host-only restriction on dot product

### DIFF
--- a/src/tensors.hpp
+++ b/src/tensors.hpp
@@ -372,8 +372,8 @@ public:
    *  \param right elements on rhs for dot product.
    *  \return scalar result of dot product.
    */
-  template<mem_type omem, resource r_ = resrc, typename = enable_for_host<r_>>
-  P operator*(vector<P, omem> const &) const;
+  template<mem_type omem>
+  P operator*(vector<P, omem, resrc> const &) const;
   /*! vector*matrix product
    *  \param right Matrix on RHS.
    *  \return result of vector*matrix multiplication .
@@ -1284,15 +1284,13 @@ fk::vector<P, mem, resrc>::operator-(vector<P, omem> const &right) const
 // vector*vector multiplication operator
 //
 template<typename P, mem_type mem, resource resrc>
-template<mem_type omem, resource, typename>
-P fk::vector<P, mem, resrc>::operator*(vector<P, omem> const &right) const
+template<mem_type omem>
+P fk::vector<P, mem, resrc>::operator*(
+    vector<P, omem, resrc> const &right) const
 {
   expect(size() == right.size());
-  int n           = size();
-  int one         = 1;
   vector const &X = (*this);
-
-  return lib_dispatch::dot(n, X.data(), one, right.data(), one);
+  return lib_dispatch::dot<resrc>(size(), X.data(), 1, right.data(), 1);
 }
 
 //

--- a/src/tensors_tests.cpp
+++ b/src/tensors_tests.cpp
@@ -484,7 +484,34 @@ TEMPLATE_TEST_CASE("fk::vector operators", "[tensors]", test_precs, int)
     REQUIRE((in1_cv - in2_v) == gold);
     REQUIRE((in1_cv - in2_cv) == gold);
   }
+#ifdef ASGARD_USE_CUDA
+  SECTION("vector*vector operator - device")
+  {
+    if constexpr (std::is_floating_point_v<TestType>)
+    {
+      fk::vector<TestType, mem_type::owner, resource::device> gold_d(
+          gold.clone_onto_device());
+      fk::vector<TestType, mem_type::view, resource::device> const gold_v_d(
+          gold_d);
+      fk::vector<TestType, mem_type::const_view, resource::device> const
+          gold_cv_d(gold_d);
 
+      TestType const inner_prod = 90;
+
+      REQUIRE((gold_d * gold_d) == inner_prod);
+      REQUIRE((gold_d * gold_v_d) == inner_prod);
+      REQUIRE((gold_d * gold_cv_d) == inner_prod);
+
+      REQUIRE((gold_v_d * gold_d) == inner_prod);
+      REQUIRE((gold_v_d * gold_v_d) == inner_prod);
+      REQUIRE((gold_v_d * gold_cv_d) == inner_prod);
+
+      REQUIRE((gold_cv_d * gold_d) == inner_prod);
+      REQUIRE((gold_cv_d * gold_v_d) == inner_prod);
+      REQUIRE((gold_cv_d * gold_cv_d) == inner_prod);
+    }
+  }
+#endif
   SECTION("vector*vector operator")
   {
     fk::vector<TestType> gold_copy(gold);


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Eliminates the unnecessary restriction that the dot product can only be calculated on "host" vectors.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [ ] Bugfix
- [x] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [x] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
