### PR TITLE
mixed_group now selects max based on group instead of overall

### DIFF
--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -264,11 +264,7 @@ table::table(options const &opts, std::vector<dimension<P>> const &dims)
     {
       // get maximum level of each group
       fk::vector<int> mixed_max(2);
-      mixed_max[0] = 0;
-      for (int i = 0; i < opts.mixed_grid_group; ++i)
-      {
-        mixed_max[0] = std::max(levels[i], mixed_max[0]);
-      }
+      mixed_max[0] = *std::max_element(std::begin(levels), std::next(std::begin(levels), opts.mixed_grid_group));
       mixed_max[1] = 0;
       for (int i = opts.mixed_grid_group; i < dims.size(); ++i)
       {

--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -261,9 +261,23 @@ table::table(options const &opts, std::vector<dimension<P>> const &dims)
       return permutations::get_max_multi(levels, dims.size(), sort);
 
     if (opts.mixed_grid_group > 0)
-      return permutations::get_mix_leqmax_multi(
-          levels, dims.size(), *std::max_element(levels.begin(), levels.end()),
-          opts.mixed_grid_group, sort);
+    {
+      // get maximum level of each group
+      fk::vector<int> mixed_max(2);
+      mixed_max[0] = 0;
+      for (int i = 0; i < opts.mixed_grid_group; ++i)
+      {
+        mixed_max[0] = std::max(levels[i], mixed_max[0]);
+      }
+      mixed_max[1] = 0;
+      for (int i = opts.mixed_grid_group; i < dims.size(); ++i)
+      {
+        mixed_max[1] = std::max(levels[i], mixed_max[1]);
+      }
+
+      return permutations::get_mix_leqmax_multi(levels, dims.size(), mixed_max,
+                                                opts.mixed_grid_group, sort);
+    }
 
     // default is a simple sparse grid
     return permutations::get_lequal_multi(

--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -265,11 +265,7 @@ table::table(options const &opts, std::vector<dimension<P>> const &dims)
       // get maximum level of each group
       fk::vector<int> mixed_max(2);
       mixed_max[0] = *std::max_element(std::begin(levels), std::next(std::begin(levels), opts.mixed_grid_group));
-      mixed_max[1] = 0;
-      for (int i = opts.mixed_grid_group; i < dims.size(); ++i)
-      {
-        mixed_max[1] = std::max(levels[i], mixed_max[1]);
-      }
+      mixed_max[1] =  *std::max_element(std::next(std::begin(levels), opts.mixed_grid_group), std::end(levels));
 
       return permutations::get_mix_leqmax_multi(levels, dims.size(), mixed_max,
                                                 opts.mixed_grid_group, sort);

--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -264,8 +264,12 @@ table::table(options const &opts, std::vector<dimension<P>> const &dims)
     {
       // get maximum level of each group
       fk::vector<int> mixed_max(2);
-      mixed_max[0] = *std::max_element(std::begin(levels), std::next(std::begin(levels), opts.mixed_grid_group));
-      mixed_max[1] =  *std::max_element(std::next(std::begin(levels), opts.mixed_grid_group), std::end(levels));
+      mixed_max[0] = *std::max_element(
+          std::begin(levels),
+          std::next(std::begin(levels), opts.mixed_grid_group));
+      mixed_max[1] = *std::max_element(
+          std::next(std::begin(levels), opts.mixed_grid_group),
+          std::end(levels));
 
       return permutations::get_mix_leqmax_multi(levels, dims.size(), mixed_max,
                                                 opts.mixed_grid_group, sort);

--- a/src/permutations.cpp
+++ b/src/permutations.cpp
@@ -53,17 +53,20 @@ fk::matrix<int> get_lequal_multi(fk::vector<int> const &levels,
                         });
 }
 
-fk::matrix<int> get_mix_leqmax_multi(fk::vector<int> const &levels,
-                                     int const num_dims, int const limit,
-                                     int const num_first_group,
-                                     bool const increasing_sum_order)
+fk::matrix<int>
+get_mix_leqmax_multi(fk::vector<int> const &levels, int const num_dims,
+                     fk::vector<int> const &mixed_max,
+                     int const num_first_group, bool const increasing_sum_order)
 {
   expect(num_dims > 0);
   expect(levels.size() == num_dims);
-  expect(limit >= 0);
+  expect(mixed_max.size() == 2);
+  expect(mixed_max[0] >= 0);
+  expect(mixed_max[1] >= 0);
 
   return select_indexex(num_dims, true, not increasing_sum_order,
                         [&](std::vector<int> const &index) -> bool {
+                          // check first group
                           int level_g1 = 0;
                           for (int i = 0; i < num_first_group; i++)
                           {
@@ -71,6 +74,9 @@ fk::matrix<int> get_mix_leqmax_multi(fk::vector<int> const &levels,
                               return false;
                             level_g1 += index[i];
                           }
+                          if (level_g1 > mixed_max[0])
+                            return false;
+                          // check second group
                           int level_g2 = 0;
                           for (int i = num_first_group; i < num_dims; i++)
                           {
@@ -78,7 +84,10 @@ fk::matrix<int> get_mix_leqmax_multi(fk::vector<int> const &levels,
                               return false;
                             level_g2 += index[i];
                           }
-                          return (std::max(level_g1, level_g2) <= limit);
+                          if (level_g2 > mixed_max[1])
+                            return false;
+                          // if both groups pass, return true
+                          return true;
                         });
 }
 

--- a/src/permutations.hpp
+++ b/src/permutations.hpp
@@ -254,7 +254,8 @@ fk::matrix<int> get_lequal_multi(fk::vector<int> const &levels,
  * tensored.
  */
 fk::matrix<int> get_mix_leqmax_multi(fk::vector<int> const &levels,
-                                     int const num_dims, int const limit,
+                                     int const num_dims,
+                                     fk::vector<int> const &mixed_max,
                                      int const num_first_group,
                                      bool const increasing_sum_order);
 


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  

Current implementation of `mixed_grid_group` builds both sparse grids with the maximum level of the whole level array.  For example, if we wanted to build a 1x FG tensored with a 3v sparse grid and the level vector is `-l "6 4 4 4`, then the current code builds the `4 4 4` sparse grid using the maximum level of 6.  We should be using a max level of 4 to build the sparse grid for the 3v group. 

This PR builds the sparse grids to each group's max level instead of the entire level set maximum.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [ ] Bugfix
- [ x ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [ x ] No

## What systems has this change been tested on?

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [ x ] this PR is up to date with current the current state of 'develop'
- [ x ] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
