### PR TITLE
Reduce memory resizes in element table creation

### DIFF
--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -282,17 +282,14 @@ table::table(options const &opts, std::vector<dimension<P>> const &dims)
   }();
 
   fk::vector<int> dev_table_builder;
-  if (opts.use_full_grid)
+  int64_t dof = 1;
+  for (int lev = 0; lev < dims.size(); lev++)
   {
-    int64_t dof = 1;
-    for (int lev = 0; lev < dims.size(); lev++)
-    {
-      dof *= dims[0].get_degree() * fm::two_raised_to(dims[lev].get_level());
-    }
-
-    // reserve element table data up front
-    dev_table_builder.resize(dof);
+    dof *= dims[0].get_degree() * fm::two_raised_to(dims[lev].get_level());
   }
+
+  // reserve element table data up front
+  dev_table_builder.resize(dof);
 
   int64_t pos = 0;
   for (int row = 0; row < perm_table.nrows(); ++row)

--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -283,7 +283,7 @@ table::table(options const &opts, std::vector<dimension<P>> const &dims)
 
   fk::vector<int> dev_table_builder;
   int64_t dof = 1;
-  for (int lev = 0; lev < dims.size(); lev++)
+  for (size_t lev = 0; lev < dims.size(); lev++)
   {
     dof *= dims[0].get_degree() * fm::two_raised_to(dims[lev].get_level());
   }

--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -289,7 +289,6 @@ table::table(options const &opts, std::vector<dimension<P>> const &dims)
     {
       dof *= dims[0].get_degree() * fm::two_raised_to(dims[lev].get_level());
     }
-    std::cout << "    FG DOF = " << dof << std::endl;
 
     // reserve element table data up front
     dev_table_builder.resize(dof);
@@ -304,8 +303,6 @@ table::table(options const &opts, std::vector<dimension<P>> const &dims)
     // calculate all possible cell indices allowed by this level tuple
     fk::matrix<int> const index_set = get_cell_index_set(level_tuple);
 
-    std::cout << " row " << row << " / " << perm_table.nrows()
-              << " -- index set rows = " << index_set.nrows() << std::endl;
     for (int cell_set = 0; cell_set < index_set.nrows(); ++cell_set)
     {
       auto const cell_indices = fk::vector<int>(
@@ -328,19 +325,13 @@ table::table(options const &opts, std::vector<dimension<P>> const &dims)
       {
         // if this is larger than our pre-allocated size, then start resizing
         dev_table_builder.concat(coords);
-        std::cout << "  flattened table size = " << dev_table_builder.size()
-                  << std::endl;
       }
       pos += coords.size();
     }
   }
 
-  std::cout << " FINISHED CREATING ELEMENT TABLE\n";
-  std::cout << "  TOTAL SIZE = " << dev_table_builder.size()
-            << ", ACTUAL size = " << pos << std::endl;
   if (pos < dev_table_builder.size())
   {
-    std::cout << "   over allocated, shrinking table\n";
     dev_table_builder = dev_table_builder.extract(0, pos - 1);
   }
 

--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -282,10 +282,10 @@ table::table(options const &opts, std::vector<dimension<P>> const &dims)
   }();
 
   fk::vector<int> dev_table_builder;
-  int64_t dof = 1;
+  int64_t dof = std::pow(dims[0].get_degree(), dims.size());
   for (size_t lev = 0; lev < dims.size(); lev++)
   {
-    dof *= dims[0].get_degree() * fm::two_raised_to(dims[lev].get_level());
+    dof *= fm::two_raised_to(dims[lev].get_level());
   }
 
   // reserve element table data up front
@@ -314,7 +314,7 @@ table::table(options const &opts, std::vector<dimension<P>> const &dims)
       id_to_coords_[key].resize(coords.size()) = coords;
 
       // assign into flattened device table builder
-      if (pos + coords.size() < dev_table_builder.size())
+      if (pos + coords.size() - 1 < dev_table_builder.size())
       {
         dev_table_builder.set_subvector(pos, coords);
       }
@@ -333,7 +333,7 @@ table::table(options const &opts, std::vector<dimension<P>> const &dims)
   }
 
   expect(active_element_ids_.size() == id_to_coords_.size());
-  active_table_.resize(dev_table_builder.size()) = dev_table_builder;
+  active_table_ = std::move(dev_table_builder);
 }
 
 // static construction helper


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

This reduces use of `concat` when creating the element table. For large problems with millions of DOF, `concat` was slow due to freeing/reallocating memory for each coordinate pair (~3-4 hrs for ~230 million elements). Instead, this allocates size for the element table upfront and updates portions of the table rather than reallocating for each coordinate. The size allocated initially assumes the FG worst-case, but shrinks afterwards if needed for smaller adaptive grid problems.

This can still be improved, especially with the planned refactor of the element table, but for now this provides a quick workaround for larger high-dimensional problems.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [ ] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

Ubuntu 20.04, wombat

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
