### PR TITLE
Add initial sparse class for sparse moment matrices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,6 +375,7 @@ if (ASGARD_USE_CUDA)
                            PUBLIC
                            CUDA::cudart
                            CUDA::cublas
+                           CUDA::cusparse
     )
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,6 +275,7 @@ set (components
      quadrature
      solver
      tensors
+     sparse
      time_advance
      tools
      transformations

--- a/src/fast_math.hpp
+++ b/src/fast_math.hpp
@@ -460,12 +460,11 @@ void getrs(fk::matrix<P, amem> const &A, fk::scalapack_matrix_info &ainfo,
 #endif
 
 // sparse gemv - sparse matrix dense vector multiplication
-template<typename P, mem_type amem, mem_type xmem, mem_type ymem,
-         resource resrc>
+template<typename P, mem_type xmem, mem_type ymem, resource resrc>
 fk::vector<P, ymem, resrc> &
-sparse_gemv(fk::sparse<P, amem, resrc> const &A,
-            fk::vector<P, xmem, resrc> const &x, fk::vector<P, ymem, resrc> &y,
-            bool const trans_A = false, P const alpha = 1.0, P const beta = 0.0)
+sparse_gemv(fk::sparse<P, resrc> const &A, fk::vector<P, xmem, resrc> const &x,
+            fk::vector<P, ymem, resrc> &y, bool const trans_A = false,
+            P const alpha = 1.0, P const beta = 0.0)
 {
   int const rows_opA = trans_A ? A.ncols() : A.nrows();
   int const cols_A   = trans_A ? A.nrows() : A.ncols();

--- a/src/fast_math.hpp
+++ b/src/fast_math.hpp
@@ -480,9 +480,8 @@ sparse_gemv(fk::sparse<P, amem, resrc> const &A,
   int n             = A.ncols();
   int nnz           = A.nnz();
 
-  lib_dispatch::sparse_gemv(&transa, &m, &n, &nnz, A.offsets(), A.columns(),
-                            A.data(), &alpha_, x.data(), &beta_, y.data(),
-                            resrc);
+  lib_dispatch::sparse_gemv<resrc>(&transa, &m, &n, &nnz, A.offsets(), A.columns(),
+                            A.data(), &alpha_, x.data(), &beta_, y.data());
 
   return y;
 }

--- a/src/fast_math.hpp
+++ b/src/fast_math.hpp
@@ -480,8 +480,9 @@ sparse_gemv(fk::sparse<P, amem, resrc> const &A,
   int n             = A.ncols();
   int nnz           = A.nnz();
 
-  lib_dispatch::sparse_gemv<resrc>(&transa, &m, &n, &nnz, A.offsets(), A.columns(),
-                            A.data(), &alpha_, x.data(), &beta_, y.data());
+  lib_dispatch::sparse_gemv<resrc>(&transa, &m, &n, &nnz, A.offsets(),
+                                   A.columns(), A.data(), &alpha_, x.data(),
+                                   &beta_, y.data());
 
   return y;
 }

--- a/src/fast_math.hpp
+++ b/src/fast_math.hpp
@@ -467,22 +467,16 @@ sparse_gemv(fk::sparse<P, amem, resrc> const &A,
             fk::vector<P, xmem, resrc> const &x, fk::vector<P, ymem, resrc> &y,
             bool const trans_A = false, P const alpha = 1.0, P const beta = 0.0)
 {
-  int const rows_A = trans_A ? A.ncols() : A.nrows();
-  int const cols_A = trans_A ? A.nrows() : A.ncols();
+  int const rows_opA = trans_A ? A.ncols() : A.nrows();
+  int const cols_A   = trans_A ? A.nrows() : A.ncols();
 
-  expect(rows_A == y.size());
+  expect(rows_opA == y.size());
   expect(cols_A == x.size());
 
-  P alpha_          = alpha;
-  P beta_           = beta;
   char const transa = trans_A ? 't' : 'n';
-  int m             = A.nrows();
-  int n             = A.ncols();
-  int nnz           = A.nnz();
-
-  lib_dispatch::sparse_gemv<resrc>(&transa, &m, &n, &nnz, A.offsets(),
-                                   A.columns(), A.data(), &alpha_, x.data(),
-                                   &beta_, y.data());
+  lib_dispatch::sparse_gemv<resrc>(transa, A.nrows(), A.ncols(), A.nnz(),
+                                   A.offsets(), A.columns(), A.data(), alpha,
+                                   x.data(), beta, y.data());
 
   return y;
 }

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -81,11 +81,14 @@ void generate_initial_moments(
       fk::vector<P, mem_type::view, resource::host>(workspace, dense_size,
                                                     dense_size * 2 - 1)};
 
+  fk::vector<P, mem_type::owner, resource::device> initial_condition_d =
+      initial_condition.clone_onto_device();
   for (size_t i = 0; i < pde.moments.size(); ++i)
   {
-    fk::vector<P> moment_vec(dense_size);
+    fk::vector<P, mem_type::owner, resource::device> moment_vec(dense_size);
     pde.moments[i].createMomentReducedMatrix(pde, adaptive_grid.get_table());
-    fm::gemv(pde.moments[i].get_moment_matrix(), initial_condition, moment_vec);
+    fm::sparse_gemv(pde.moments[i].get_moment_matrix_dev(), initial_condition_d,
+                    moment_vec);
     pde.moments[i].create_realspace_moment(pde_1d, moment_vec,
                                            adaptive_grid_1d.get_table(),
                                            transformer, tmp_workspace);

--- a/src/lib_dispatch.cpp
+++ b/src/lib_dispatch.cpp
@@ -1228,10 +1228,8 @@ void sparse_gemv(char const trans, int rows, int cols, int nnz,
 {
   expect(row_offsets);
   expect(col_indices);
-  expect(alpha);
   expect(vals);
   expect(x);
-  expect(beta);
   expect(y);
   expect(rows >= 0);
   expect(cols >= 0);

--- a/src/lib_dispatch.hpp
+++ b/src/lib_dispatch.hpp
@@ -85,5 +85,11 @@ template<typename P>
 void scalapack_getrs(char *trans, int *n, int *nrhs, P const *A, int *descA,
                      int const *ipiv, P *b, int *descB, int *info);
 #endif
+
+template<typename P>
+void sparse_gemv(char const *trans, int *rows, int *cols, int *nnz,
+                 const int *offsets, const int *columns, const P *A, P *alpha, const P *x, P *beta,
+                 const P *y, resource const resrc = resource::device);
+
 } // namespace lib_dispatch
 } // namespace asgard

--- a/src/lib_dispatch.hpp
+++ b/src/lib_dispatch.hpp
@@ -87,9 +87,9 @@ void scalapack_getrs(char *trans, int *n, int *nrhs, P const *A, int *descA,
 #endif
 
 template<resource resrc = resource::host, typename P>
-void sparse_gemv(char const *trans, int *rows, int *cols, int *nnz,
-                 const int *offsets, const int *columns, const P *A, P *alpha,
-                 const P *x, P *beta, P *y);
+void sparse_gemv(char const trans, int rows, int cols, int nnz,
+                 const int *row_offsets, const int *col_indices, const P *vals,
+                 P alpha, const P *x, P beta, P *y);
 
 } // namespace lib_dispatch
 } // namespace asgard

--- a/src/lib_dispatch.hpp
+++ b/src/lib_dispatch.hpp
@@ -86,10 +86,10 @@ void scalapack_getrs(char *trans, int *n, int *nrhs, P const *A, int *descA,
                      int const *ipiv, P *b, int *descB, int *info);
 #endif
 
-template<typename P>
+template<resource resrc = resource::host, typename P>
 void sparse_gemv(char const *trans, int *rows, int *cols, int *nnz,
-                 const int *offsets, const int *columns, const P *A, P *alpha, const P *x, P *beta,
-                 const P *y, resource const resrc = resource::device);
+                 const int *offsets, const int *columns, const P *A, P *alpha,
+                 const P *x, P *beta, P *y);
 
 } // namespace lib_dispatch
 } // namespace asgard

--- a/src/moment.cpp
+++ b/src/moment.cpp
@@ -211,7 +211,7 @@ void moment<P>::createMomentReducedMatrix_nd(PDE<P> const &pde,
   std::cout << " -- moment_mat map size = " << moment_mat.size() << "\n";
 
   // create a sparse version of this matrix and put it on the GPU
-  //this->sparse_mat =
+  // this->sparse_mat =
   //    fk::sparse<P, mem_type::owner, resource::host>(this->moment_matrix)
   //        .clone_onto_device();
 

--- a/src/moment.cpp
+++ b/src/moment.cpp
@@ -211,10 +211,6 @@ void moment<P>::createMomentReducedMatrix_nd(PDE<P> const &pde,
   std::cout << " -- moment_mat map size = " << moment_mat.size() << "\n";
 
   // create a sparse version of this matrix and put it on the GPU
-  // this->sparse_mat =
-  //    fk::sparse<P, mem_type::owner, resource::host>(this->moment_matrix)
-  //        .clone_onto_device();
-
   this->sparse_mat =
       fk::sparse<P, mem_type::owner, resource::host>(moment_mat, n, rows)
           .clone_onto_device();

--- a/src/moment.cpp
+++ b/src/moment.cpp
@@ -212,8 +212,7 @@ void moment<P>::createMomentReducedMatrix_nd(PDE<P> const &pde,
 
   // create a sparse version of this matrix and put it on the GPU
   this->sparse_mat =
-      fk::sparse<P, mem_type::owner, resource::host>(moment_mat, n, rows)
-          .clone_onto_device();
+      fk::sparse<P, resource::host>(moment_mat, n, rows).clone_onto_device();
   std::cout << this->sparse_mat.sp_size() << "\n";
 }
 

--- a/src/moment.cpp
+++ b/src/moment.cpp
@@ -179,9 +179,11 @@ void moment<P>::createMomentReducedMatrix_nd(PDE<P> const &pde,
               int const ind_j = i * static_cast<int>(std::pow(deg, 3)) +
                                 j * static_cast<int>(std::pow(deg, 2)) +
                                 deg * vdeg1 + vdeg2;
-              moment_matrix(ind_i, ind_j) =
-                  g_vec_1(elem_indices(1) * deg + vdeg1) *
-                  g_vec_2(elem_indices(2) * deg + vdeg2);
+              moment_mat.insert(
+                  {ind_i,
+                   dense_item<P>{ind_i, ind_j,
+                                 g_vec_1(elem_indices(1) * deg + vdeg1) *
+                                     g_vec_2(elem_indices(2) * deg + vdeg2)}});
             }
             else if (nvdim == 3)
             {
@@ -192,10 +194,12 @@ void moment<P>::createMomentReducedMatrix_nd(PDE<P> const &pde,
                                   j * static_cast<int>(std::pow(deg, 3)) +
                                   static_cast<int>(std::pow(deg, 2)) * vdeg1 +
                                   vdeg2 * deg + vdeg3;
-                moment_matrix(ind_i, ind_j) =
-                    g_vec_1(elem_indices(1) * deg + vdeg1) *
-                    g_vec_2(elem_indices(2) * deg + vdeg2) *
-                    g_vec_3(elem_indices(3) * deg + vdeg3);
+                moment_mat.insert(
+                    {ind_i, dense_item<P>{
+                                ind_i, ind_j,
+                                g_vec_1(elem_indices(1) * deg + vdeg1) *
+                                    g_vec_2(elem_indices(2) * deg + vdeg2) *
+                                    g_vec_3(elem_indices(3) * deg + vdeg3)}});
               }
             }
           }

--- a/src/moment.hpp
+++ b/src/moment.hpp
@@ -10,6 +10,7 @@ class PDE;
 #include "elements.hpp"
 #include "pde/pde_base.hpp"
 #include "program_options.hpp"
+#include "sparse.hpp"
 #include "tensors.hpp"
 #include <vector>
 
@@ -42,6 +43,11 @@ public:
     return fList;
   }
   fk::matrix<P> const &get_moment_matrix() const { return moment_matrix; }
+  fk::sparse<P, mem_type::owner, resource::device> const &
+  get_moment_matrix_dev() const
+  {
+    return sparse_mat;
+  }
 
   void createMomentReducedMatrix(PDE<P> const &pde,
                                  elements::table const &hash_table);
@@ -57,6 +63,13 @@ public:
       asgard::basis::wavelet_transform<P, resource::host> const &transformer,
       std::array<fk::vector<P, mem_type::view, resource::host>, 2> &workspace);
 
+  fk::vector<P> &create_realspace_moment(
+      PDE<P> const &pde_1d,
+      fk::vector<P, mem_type::owner, resource::device> &wave,
+      elements::table const &table,
+      basis::wavelet_transform<P, resource::host> const &transformer,
+      std::array<fk::vector<P, mem_type::view, resource::host>, 2> &workspace);
+
 private:
   template<int nvdim>
   void createMomentReducedMatrix_nd(PDE<P> const &pde,
@@ -67,6 +80,7 @@ private:
   fk::vector<P> vector;
   fk::matrix<P> moment_matrix;
   fk::vector<P> realspace;
+  fk::sparse<P, mem_type::owner, resource::device> sparse_mat;
   // moment_fval_integral;
   // moment_analytic_integral;
 };

--- a/src/moment.hpp
+++ b/src/moment.hpp
@@ -43,8 +43,7 @@ public:
     return fList;
   }
   fk::matrix<P> const &get_moment_matrix() const { return moment_matrix; }
-  fk::sparse<P, mem_type::owner, resource::device> const &
-  get_moment_matrix_dev() const
+  fk::sparse<P, resource::device> const &get_moment_matrix_dev() const
   {
     return sparse_mat;
   }
@@ -80,7 +79,7 @@ private:
   fk::vector<P> vector;
   fk::matrix<P> moment_matrix;
   fk::vector<P> realspace;
-  fk::sparse<P, mem_type::owner, resource::device> sparse_mat;
+  fk::sparse<P, resource::device> sparse_mat;
   // moment_fval_integral;
   // moment_analytic_integral;
 };

--- a/src/moment.hpp
+++ b/src/moment.hpp
@@ -27,6 +27,12 @@ template<typename P, resource resrc>
 class wavelet_transform;
 }
 
+#ifdef ASGARD_USE_CUDA
+static constexpr resource sparse_resrc = resource::device;
+#else
+static constexpr resource sparse_resrc = resource::host;
+#endif
+
 template<typename P>
 class moment
 {
@@ -43,7 +49,7 @@ public:
     return fList;
   }
   fk::matrix<P> const &get_moment_matrix() const { return moment_matrix; }
-  fk::sparse<P, resource::device> const &get_moment_matrix_dev() const
+  fk::sparse<P, sparse_resrc> const &get_moment_matrix_dev() const
   {
     return sparse_mat;
   }
@@ -79,7 +85,7 @@ private:
   fk::vector<P> vector;
   fk::matrix<P> moment_matrix;
   fk::vector<P> realspace;
-  fk::sparse<P, resource::device> sparse_mat;
+  fk::sparse<P, sparse_resrc> sparse_mat;
   // moment_fval_integral;
   // moment_analytic_integral;
 };

--- a/src/moment_tests.cpp
+++ b/src/moment_tests.cpp
@@ -96,9 +96,14 @@ TEMPLATE_TEST_CASE("CreateMomentReducedMatrix", "[moments]", test_precs)
     auto const gold_moment_matrix =
         read_matrix_from_txt_file<TestType>(gold_filename);
 
+#ifdef ASGARD_USE_CUDA
     rmse_comparison(
         gold_moment_matrix,
         moments[i].get_moment_matrix_dev().clone_onto_host().to_dense(),
         tol_factor);
+#else
+    rmse_comparison(gold_moment_matrix,
+                    moments[i].get_moment_matrix_dev().to_dense(), tol_factor);
+#endif
   }
 }

--- a/src/moment_tests.cpp
+++ b/src/moment_tests.cpp
@@ -96,7 +96,9 @@ TEMPLATE_TEST_CASE("CreateMomentReducedMatrix", "[moments]", test_precs)
     auto const gold_moment_matrix =
         read_matrix_from_txt_file<TestType>(gold_filename);
 
-    rmse_comparison(gold_moment_matrix, moments[i].get_moment_matrix(),
-                    tol_factor);
+    rmse_comparison(
+        gold_moment_matrix,
+        moments[i].get_moment_matrix_dev().clone_onto_host().to_dense(),
+        tol_factor);
   }
 }

--- a/src/sparse.hpp
+++ b/src/sparse.hpp
@@ -65,7 +65,7 @@ public:
   template<resource r_ = resrc, typename = enable_for_host<r_>, mem_type mem>
   sparse(fk::matrix<P, mem, resrc> const &m)
   {
-    P constexpr tol = 1.0e-10;
+    P constexpr tol = std::is_floating_point_v<P> ? 1.0e-10 : 0;
     // P constexpr tol = 2.0 * std::numeric_limits<P>::epsilon();
 
     ncols_ = m.ncols();
@@ -110,7 +110,7 @@ public:
   // create sparse matrix from multimap
   sparse(std::multimap<int, dense_item<P>> const &items, int ncols, int nrows)
   {
-    P constexpr tol = 1.0e-10;
+    P constexpr tol = std::is_floating_point_v<P> ? 1.0e-10 : 0;
     // P constexpr tol = 2.0 * std::numeric_limits<P>::epsilon();
 
     ncols_ = ncols;

--- a/src/sparse.hpp
+++ b/src/sparse.hpp
@@ -162,16 +162,6 @@ public:
     }
   }
 
-  // template<mem_type m_ = mem, typename = enable_for_owner<m_>,
-  //          resource r_ = resrc, typename = enable_for_host<r_>>
-  /*
-  explicit sparse(sparse<P, mem, resrc> const &a)
-      : ncols_{a.ncols_}, nrows_{a.nrows_}, nnz_{a.nnz_},
-        row_offsets_{a.row_offsets_}, col_indices_{a.col_indices_},
-        values_{a.values_}
-  {}
-  */
-
   // copy constructor
   sparse(fk::sparse<P, mem, resrc> const &other)
       : ncols_{other.ncols_}, nrows_{other.nrows_}, nnz_{other.nnz_},

--- a/src/sparse.hpp
+++ b/src/sparse.hpp
@@ -18,7 +18,6 @@
 
 namespace asgard
 {
-
 template<typename P>
 struct dense_item
 {

--- a/src/sparse.hpp
+++ b/src/sparse.hpp
@@ -293,8 +293,9 @@ public:
     expect(col >= 0);
     expect(col < ncols_);
 
-    for (int i = col_indices_[row_offsets_[row]];
-         i < col_indices_[row_offsets_[row + 1]]; i++)
+    int col_index_offset = col_indices_[row_offsets_[row]];
+    int num_in_row       = row_offsets_[row + 1] - row_offsets_[row];
+    for (int i = col_index_offset; i < col_index_offset + num_in_row; i++)
     {
       if (i == col)
       {

--- a/src/sparse.hpp
+++ b/src/sparse.hpp
@@ -187,6 +187,29 @@ public:
         nrows_, ncols_, nnz_, offsets_host, col_host, val_host);
   }
 
+  // convert this sparse matrix back to a dense matrix
+  fk::matrix<P, mem, resrc> to_dense() const
+  {
+    // create dense, filled with 0 initially
+    fk::matrix<P, mem, resrc> dense(nrows_, ncols_);
+
+    // populate entries of the dense matrix
+    int col_index_offset = 0;
+    for (int row = 0; row < nrows_; row++)
+    {
+      int num_in_row = row_offsets_[row + 1] - row_offsets_[row];
+      for (int col = 0; col < num_in_row; col++)
+      {
+        int index                       = col_index_offset + col;
+        dense(row, col_indices_[index]) = values_[index];
+      }
+
+      col_index_offset += num_in_row;
+    }
+
+    return dense;
+  }
+
   //
   // basic queries to private data
   //

--- a/src/sparse.hpp
+++ b/src/sparse.hpp
@@ -286,7 +286,7 @@ public:
   }
 
   // checks if the dense element at (row, col) exists in the sparse matrix
-  bool exists(int const row, int const col)
+  bool exists(int const row, int const col) const
   {
     expect(row >= 0);
     expect(row < nrows_);
@@ -323,6 +323,40 @@ public:
   bool operator!=(sparse<P, omem> const &other) const
   {
     return !(*this == other);
+  }
+
+  template<resource r_ = resrc, typename = enable_for_host<r_>>
+  void print(std::string const label = "") const
+  {
+    if constexpr (mem == mem_type::owner)
+      std::cout << label << "(owner)" << '\n';
+    else
+      expect(false); // above cases cover all implemented mem types
+
+    //  Print these out as row major even though stored in memory as column
+    //  major.
+    for (auto i = 0; i < nrows(); ++i)
+    {
+      for (auto j = 0; j < ncols(); ++j)
+      {
+        if (exists(i, j))
+        {
+          std::cout << "(" << std::setw(2) << i << ", " << std::setw(2) << j
+                    << ") ";
+          P const val = values_[col_indices_[row_offsets_[i]]];
+          if constexpr (std::is_floating_point<P>::value)
+          {
+            std::cout << std::setw(12) << std::setprecision(4)
+                      << std::scientific << std::right << val;
+          }
+          else
+          {
+            std::cout << val << " ";
+          }
+          std::cout << '\n';
+        }
+      }
+    }
   }
 
   //

--- a/src/sparse.hpp
+++ b/src/sparse.hpp
@@ -303,29 +303,26 @@ public:
   template<resource r_ = resrc, typename = enable_for_host<r_>>
   void print(std::string const label = "") const
   {
-    std::cout << label << "(owner)" << '\n';
+    std::cout << label << "(owner, nnz = " << nnz() << ")" << '\n';
     //  Print these out as row major even though stored in memory as column
     //  major.
-    for (auto i = 0; i < nrows(); ++i)
+    for (int row = 0; row < nrows_; row++)
     {
-      for (auto j = 0; j < ncols(); ++j)
+      for (int col = row_offsets_[row]; col < row_offsets_[row + 1]; col++)
       {
-        if (exists(i, j))
+        std::cout << "(" << std::setw(2) << row << ", " << std::setw(2) << col
+                  << ") ";
+        P const val = values_[col];
+        if constexpr (std::is_floating_point<P>::value)
         {
-          std::cout << "(" << std::setw(2) << i << ", " << std::setw(2) << j
-                    << ") ";
-          P const val = values_[col_indices_[row_offsets_[i]]];
-          if constexpr (std::is_floating_point<P>::value)
-          {
-            std::cout << std::setw(12) << std::setprecision(4)
-                      << std::scientific << std::right << val;
-          }
-          else
-          {
-            std::cout << val << " ";
-          }
-          std::cout << '\n';
+          std::cout << std::setw(12) << std::setprecision(4) << std::scientific
+                    << std::right << val;
         }
+        else
+        {
+          std::cout << val << " ";
+        }
+        std::cout << '\n';
       }
     }
   }

--- a/src/sparse.hpp
+++ b/src/sparse.hpp
@@ -295,6 +295,7 @@ public:
   template<resource r_ = resrc, typename = enable_for_host<r_>>
   void print(std::string const label = "") const
   {
+    std::cout << label << "(owner)" << '\n';
     //  Print these out as row major even though stored in memory as column
     //  major.
     for (auto i = 0; i < nrows(); ++i)

--- a/src/sparse.hpp
+++ b/src/sparse.hpp
@@ -1,0 +1,172 @@
+#pragma once
+#include "build_info.hpp"
+
+#ifdef ASGARD_USE_CUDA
+#include <cuda_runtime.h>
+#include <cusparse.h>
+#endif
+
+#include "lib_dispatch.hpp"
+#include "tensors.hpp"
+#include "tools.hpp"
+
+#include <filesystem>
+#include <memory>
+#include <new>
+#include <string>
+#include <vector>
+
+namespace asgard
+{
+namespace fk
+{
+template<typename P, mem_type mem, resource resrc>
+class sparse
+{
+  template<typename, mem_type, resource>
+  friend class sparse;
+
+public:
+  template<mem_type m_ = mem, typename = enable_for_owner<m_>>
+  sparse()
+  {}
+
+  explicit sparse(int nrows, int ncols, int nnz,
+                  fk::vector<int, mem, resrc> &row_offsets,
+                  fk::vector<int, mem, resrc> &col_indices,
+                  fk::vector<P, mem, resrc> &values)
+      : ncols_{ncols}, nrows_{nrows}, nnz_{nnz}, row_offsets_{row_offsets},
+        col_indices_{col_indices}, values_{values}
+  {}
+
+  ~sparse() {}
+
+  // create sparse matrix from dense matrix
+  sparse(fk::matrix<P, mem, resrc> const &m)
+  {
+    P constexpr tol = 1.0e-10;
+    // P constexpr tol = 2.0 * std::numeric_limits<P>::epsilon();
+
+    ncols_ = m.ncols();
+    nrows_ = m.nrows();
+    nz_    = 0;
+
+    row_offsets_.resize(nrows_ + 1);
+    row_offsets_[0] = 0;
+
+    std::vector<P> values;
+    std::vector<int> col_indices_tmp;
+
+    values.reserve(nrows_);
+    for (int row = 0; row < nrows_; row++)
+    {
+      size_t n_start = values.size();
+      for (int col = 0; col < ncols_; col++)
+      {
+        if (std::abs(m(row, col)) > tol)
+        {
+          col_indices_tmp.push_back(col);
+          values.push_back(m(row, col));
+        }
+        else
+        {
+          nz_ += 1;
+        }
+      }
+      size_t n_end = values.size();
+
+      row_offsets_[row + 1] = row_offsets_[row] + (n_end - n_start);
+    }
+
+    col_indices_ = fk::vector<int, mem, resrc>(col_indices_tmp);
+
+    values_ = fk::vector<P>(values);
+    nnz_    = values_.size();
+
+    expect(m.size() == values_.size() + nz_);
+  }
+
+  explicit sparse(sparse<P, mem, resrc> const &a)
+      : ncols_{a.ncols_}, nrows_{a.nrows_}, nnz_{a.nnz_},
+        row_offsets_{a.row_offsets_},
+        col_indices_{a.col_indices_}, values_{a.values_}
+  {}
+
+  // move assignment
+  sparse<P, mem, resrc> &operator=(fk::sparse<P, mem, resrc> &&a)
+  {
+    static_assert(mem != mem_type::const_view,
+                  "cannot move assign into const_view!");
+
+    if (&a == this)
+      return *this;
+
+    this->ncols_ = a.ncols_;
+    this->nrows_ = a.nrows_;
+    this->nnz_   = a.nnz_;
+
+    this->row_offsets_ = std::move(a.get_offsets());
+    this->col_indices_ = std::move(a.get_columns());
+    this->values_      = std::move(a.get_values());
+
+    return *this;
+  }
+
+  // transfer functions
+  // host->dev, new matrix
+  template<resource r_ = resrc, typename = enable_for_host<r_>>
+  sparse<P, mem_type::owner, resource::device> clone_onto_device() const
+  {
+    auto offsets_dev = row_offsets_.clone_onto_device();
+    auto col_dev     = col_indices_.clone_onto_device();
+    auto val_dev     = values_.clone_onto_device();
+    return sparse<P, mem_type::owner, resource::device>(
+        nrows_, ncols_, nnz_, offsets_dev, col_dev, val_dev);
+  }
+
+  // transfer functions
+  // dev->host, new matrix
+  template<resource r_ = resrc, typename = enable_for_device<r_>>
+  sparse<P, mem_type::owner, resource::host> clone_onto_host() const
+  {
+    auto offsets_host = row_offsets_.clone_onto_host();
+    auto col_host     = col_indices_.clone_onto_host();
+    auto val_host     = values_.clone_onto_host();
+    return sparse<P, mem_type::owner, resource::host>(
+        nrows_, ncols_, nnz_, offsets_host, col_host, val_host);
+  }
+
+  //
+  // basic queries to private data
+  //
+  int nrows() const { return nrows_; }
+  int ncols() const { return ncols_; }
+  int nnz() const { return nnz_; }
+  int64_t size() const { return int64_t{nrows()} * ncols(); }
+  int64_t sp_size() const { return int64_t{values_.size()}; }
+
+  const P *data() const { return values_.data(); }
+
+  const int *offsets() const { return row_offsets_.data(); }
+
+  const int *columns() const { return col_indices_.data(); }
+
+  fk::vector<int, mem, resrc> &get_offsets() { return row_offsets_; }
+  fk::vector<int, mem, resrc> &get_columns() { return col_indices_; }
+  fk::vector<P, mem, resrc> &get_values() { return values_; }
+
+private:
+  int ncols_;
+  int nrows_;
+  int nnz_;
+  int nz_;
+
+  // CSR format
+  fk::vector<int, mem, resrc> row_offsets_;
+  fk::vector<int, mem, resrc> col_indices_;
+
+  fk::vector<P, mem, resrc> values_;
+};
+
+} // namespace fk
+} // namespace asgard

--- a/src/sparse.hpp
+++ b/src/sparse.hpp
@@ -139,7 +139,7 @@ public:
     values_ = fk::vector<P>(values);
     nnz_    = values_.size();
 
-    expect(col_indices_tmp.size() == values_.size());
+    expect(col_indices_tmp.size() == static_cast<size_t>(values_.size()));
   }
 
   // create sparse matrix from a vector, filling elements on the diagonal

--- a/src/sparse_tests.cpp
+++ b/src/sparse_tests.cpp
@@ -63,7 +63,7 @@ TEMPLATE_TEST_CASE("fk::sparse interface: constructors, copy/move", "[sparse]",
 
 #ifdef ASGARD_USE_CUDA
     // create device sparse matrix from host
-    fk::sparse<TestType, mem_type::owner, resource::device> const sp_mat_d(
+    fk::sparse<TestType, resource::device> const sp_mat_d(
         sp_mat.clone_onto_device());
 
     REQUIRE((sp_mat_d.nrows() == nrows));
@@ -75,7 +75,7 @@ TEMPLATE_TEST_CASE("fk::sparse interface: constructors, copy/move", "[sparse]",
     REQUIRE((sp_mat_d.get_values().clone_onto_host() == values));
 
     // clone device sparse matrix back to host
-    fk::sparse<TestType, mem_type::owner, resource::host> const sp_host =
+    fk::sparse<TestType, resource::host> const sp_host =
         sp_mat_d.clone_onto_host();
     REQUIRE((sp_host.nrows() == nrows));
     REQUIRE((sp_host.ncols() == ncols));
@@ -153,8 +153,8 @@ TEMPLATE_TEST_CASE("fk::sparse interface: constructors, copy/move", "[sparse]",
     fk::sparse<TestType> test;
     TestType *const test_data = test.data();
     test                      = std::move(moved);
-    REQUIRE(test.data() == data);
-    REQUIRE(moved.data() == test_data);
-    REQUIRE(test == sp_mat_gold);
+    REQUIRE((test.data() == data));
+    REQUIRE((moved.data() == test_data));
+    REQUIRE((test == sp_mat_gold));
   }
 } // end fk::sparse constructors, copy/move

--- a/src/sparse_tests.cpp
+++ b/src/sparse_tests.cpp
@@ -1,0 +1,160 @@
+#include "fast_math.hpp"
+#include "sparse.hpp"
+#include "tests_general.hpp"
+
+using namespace asgard;
+
+TEMPLATE_TEST_CASE("fk::sparse interface: constructors, copy/move", "[sparse]",
+                   test_precs, int)
+{
+  // test 4x6 CSR sparse matrix
+  int nrows                         = 4;
+  int ncols                         = 6;
+  int sp_size                       = 8;
+  int size                          = nrows * ncols;
+  fk::vector<int> const col_indices = {0, 1, 1, 3, 2, 3, 4, 5};
+  fk::vector<int> const row_offsets = {0, 2, 4, 7, 8};
+
+  // explicit types for testing converting copy operations
+  fk::vector<int> const goldi{10, 20, 30, 40, 50, 60, 70, 80};
+  fk::vector<float> const goldf{10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0};
+  fk::vector<float> const goldd{10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0};
+
+  SECTION("default constructor")
+  {
+    fk::sparse<TestType> const test;
+    REQUIRE(test.empty());
+  }
+
+  SECTION("constructor")
+  {
+    fk::vector<TestType> const values{10, 20, 30, 40, 50, 60, 70, 80};
+    fk::sparse<TestType> const sp_mat(nrows, ncols, sp_size, row_offsets,
+                                      col_indices, values);
+    REQUIRE((sp_mat.nrows() == nrows));
+    REQUIRE((sp_mat.ncols() == ncols));
+    REQUIRE((sp_mat.size() == size));
+    REQUIRE((sp_mat.sp_size() == sp_size));
+    REQUIRE((sp_mat.get_offsets() == row_offsets));
+    REQUIRE((sp_mat.get_columns() == col_indices));
+    REQUIRE((sp_mat.get_values() == values));
+  }
+
+  SECTION("construct from an fk::matrix")
+  {
+    // dense matrix
+    fk::matrix<TestType> const mat{{10, 20, 0, 0, 0, 0},
+                                   {0, 30, 0, 40, 0, 0},
+                                   {0, 0, 50, 60, 70, 0},
+                                   {0, 0, 0, 0, 0, 80}};
+    fk::vector<TestType> const values{10, 20, 30, 40, 50, 60, 70, 80};
+
+    fk::sparse<TestType> const sp_mat(mat);
+    REQUIRE((sp_mat.nrows() == nrows));
+    REQUIRE((sp_mat.ncols() == ncols));
+    REQUIRE((sp_mat.size() == size));
+    REQUIRE((sp_mat.sp_size() == sp_size));
+    REQUIRE((sp_mat.get_offsets() == row_offsets));
+    REQUIRE((sp_mat.get_columns() == col_indices));
+    REQUIRE((sp_mat.get_values() == values));
+
+    // transfer back to dense form
+    REQUIRE((sp_mat.to_dense() == mat));
+
+#ifdef ASGARD_USE_CUDA
+    // create device sparse matrix from host
+    fk::sparse<TestType, mem_type::owner, resource::device> const sp_mat_d(
+        sp_mat.clone_onto_device());
+
+    REQUIRE((sp_mat_d.nrows() == nrows));
+    REQUIRE((sp_mat_d.ncols() == ncols));
+    REQUIRE((sp_mat_d.size() == size));
+    REQUIRE((sp_mat_d.sp_size() == sp_size));
+    REQUIRE((sp_mat_d.get_offsets().clone_onto_host() == row_offsets));
+    REQUIRE((sp_mat_d.get_columns().clone_onto_host() == col_indices));
+    REQUIRE((sp_mat_d.get_values().clone_onto_host() == values));
+
+    // clone device sparse matrix back to host
+    fk::sparse<TestType, mem_type::owner, resource::host> const sp_host =
+        sp_mat_d.clone_onto_host();
+    REQUIRE((sp_host.nrows() == nrows));
+    REQUIRE((sp_host.ncols() == ncols));
+    REQUIRE((sp_host.size() == size));
+    REQUIRE((sp_host.sp_size() == sp_size));
+    REQUIRE((sp_host.get_offsets() == row_offsets));
+    REQUIRE((sp_host.get_columns() == col_indices));
+    REQUIRE((sp_host.get_values() == values));
+#endif
+  }
+
+  SECTION("construct diagonally from a fk::vector")
+  {
+    // create a sparse matrix from a vector along diagonal elements
+    fk::vector<TestType> const diag{10, 20, 30, 40};
+
+    // dense matrix
+    fk::matrix<TestType> const mat{
+        {10, 0, 0, 0}, {0, 20, 0, 0}, {0, 0, 30, 0}, {0, 0, 0, 40}};
+    fk::vector<int> const indices = {0, 1, 2, 3};
+    fk::vector<int> const offsets = {0, 1, 2, 3, 4};
+
+    fk::sparse<TestType> const sp_mat(diag);
+    REQUIRE((sp_mat.nrows() == diag.size()));
+    REQUIRE((sp_mat.ncols() == diag.size()));
+    REQUIRE((sp_mat.sp_size() == diag.size()));
+    REQUIRE((sp_mat.get_offsets() == offsets));
+    REQUIRE((sp_mat.get_columns() == indices));
+    REQUIRE((sp_mat.to_dense() == mat));
+  }
+
+  SECTION("copy construction")
+  {
+    fk::vector<TestType> const values{10, 20, 30, 40, 50, 60, 70, 80};
+    fk::sparse<TestType> const sp_mat_gold(nrows, ncols, sp_size, row_offsets,
+                                           col_indices, values);
+
+    fk::sparse<TestType> test(sp_mat_gold);
+    REQUIRE((test == sp_mat_gold));
+  }
+
+  SECTION("copy assignment")
+  {
+    fk::vector<TestType> const values{10, 20, 30, 40, 50, 60, 70, 80};
+    fk::sparse<TestType> sp_mat_gold(nrows, ncols, sp_size, row_offsets,
+                                     col_indices, values);
+
+    fk::sparse<TestType> test;
+    test = sp_mat_gold;
+    REQUIRE((test == sp_mat_gold));
+  }
+
+  SECTION("move construction")
+  {
+    fk::vector<TestType> const values{10, 20, 30, 40, 50, 60, 70, 80};
+    fk::sparse<TestType> sp_mat_gold(nrows, ncols, sp_size, row_offsets,
+                                     col_indices, values);
+
+    // owners
+    fk::sparse<TestType> moved(sp_mat_gold);
+    fk::sparse<TestType> test(std::move(moved));
+    REQUIRE((moved.data() == nullptr));
+    REQUIRE((test == sp_mat_gold));
+  }
+
+  SECTION("move assignment")
+  {
+    // owners
+    fk::vector<TestType> const values{10, 20, 30, 40, 50, 60, 70, 80};
+    fk::sparse<TestType> sp_mat_gold(nrows, ncols, sp_size, row_offsets,
+                                     col_indices, values);
+
+    fk::sparse<TestType> moved(sp_mat_gold);
+    TestType *const data = moved.data();
+    fk::sparse<TestType> test;
+    TestType *const test_data = test.data();
+    test                      = std::move(moved);
+    REQUIRE(test.data() == data);
+    REQUIRE(moved.data() == test_data);
+    REQUIRE(test == sp_mat_gold);
+  }
+} // end fk::sparse constructors, copy/move

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -495,12 +495,13 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   // function in x
   if (first_time || update_system)
   {
+    asgard::tools::timer.start("update_system");
     std::cout << " dim0 lev = " << level << "\n";
     std::cout << " dim1 lev = " << pde.get_dimensions()[1].get_level() << "\n";
     for (auto &m : pde.moments)
     {
       m.createMomentReducedMatrix(pde, adaptive_grid.get_table());
-      expect(m.get_moment_matrix().nrows() > 0);
+      // expect(m.get_moment_matrix().nrows() > 0);
     }
 
     if (pde.do_poisson_solve)
@@ -515,6 +516,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
     pde.E_source.resize(dense_size);
 
     first_time = false;
+    asgard::tools::timer.stop("update_system");
   }
 
   auto do_poisson_update = [&](fk::vector<P> const &f_in) {

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -523,7 +523,8 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
     tools::timer.start("poisson_update");
     // Get 0th moment
     fk::vector<P, mem_type::owner, resource::device> mom0(dense_size);
-    fm::sparse_gemv(pde.moments[0].get_moment_matrix_dev(), f_in.clone_onto_device(), mom0);
+    fm::sparse_gemv(pde.moments[0].get_moment_matrix_dev(),
+                    f_in.clone_onto_device(), mom0);
     fk::vector<P> &mom0_real = pde.moments[0].create_realspace_moment(
         pde_1d, mom0, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
     param_manager.get_parameter("n")->value = [&](P const x_v,
@@ -611,7 +612,8 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   tools::timer.stop("explicit_1");
   tools::timer.start("implicit_1");
 
-  fk::vector<P, mem_type::owner, resource::device> x_dev = x.clone_onto_device();
+  fk::vector<P, mem_type::owner, resource::device> x_dev =
+      x.clone_onto_device();
   // Create rho_2s
   fk::vector<P, mem_type::owner, resource::device> mom0(dense_size);
   fm::sparse_gemv(pde.moments[0].get_moment_matrix_dev(), x_dev, mom0);

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -588,7 +588,14 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
 
   if (pde.do_poisson_solve)
   {
-    do_poisson_update(x);
+    if constexpr (imex_resrc == resource::device)
+    {
+      do_poisson_update(x.clone_onto_device());
+    }
+    else
+    {
+      do_poisson_update(x);
+    }
   }
 
   operator_matrices.reset_coefficients(matrix_entry::imex_explicit, pde,
@@ -690,7 +697,14 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
 
   if (pde.do_poisson_solve)
   {
-    do_poisson_update(f_2);
+    if constexpr (imex_resrc == resource::device)
+    {
+      do_poisson_update(f_2.clone_onto_device());
+    }
+    else
+    {
+      do_poisson_update(f_2);
+    }
   }
 
   operator_matrices.reset_coefficients(matrix_entry::imex_explicit, pde,

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -619,7 +619,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   }
   else
   {
-    x_dev = x;
+    x_dev = fk::vector(x);
   }
   // Create rho_2s
   fk::vector<P, mem_type::owner, imex_resrc> mom0(dense_size);

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -520,8 +520,8 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   auto do_poisson_update = [&](fk::vector<P> const &f_in) {
     tools::timer.start("poisson_update");
     // Get 0th moment
-    fk::vector<P> mom0(dense_size);
-    fm::gemv(pde.moments[0].get_moment_matrix(), f_in, mom0);
+    fk::vector<P, mem_type::owner, resource::device> mom0(dense_size);
+    fm::sparse_gemv(pde.moments[0].get_moment_matrix_dev(), f_in.clone_onto_device(), mom0);
     fk::vector<P> &mom0_real = pde.moments[0].create_realspace_moment(
         pde_1d, mom0, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
     param_manager.get_parameter("n")->value = [&](P const x_v,
@@ -608,9 +608,11 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
 
   tools::timer.stop("explicit_1");
   tools::timer.start("implicit_1");
+
+  fk::vector<P, mem_type::owner, resource::device> x_dev = x.clone_onto_device();
   // Create rho_2s
-  fk::vector<P> mom0(dense_size);
-  fm::gemv(pde.moments[0].get_moment_matrix(), x, mom0);
+  fk::vector<P, mem_type::owner, resource::device> mom0(dense_size);
+  fm::sparse_gemv(pde.moments[0].get_moment_matrix_dev(), x_dev, mom0);
 
   fk::vector<P> &mom0_real = pde.moments[0].create_realspace_moment(
       pde_1d, mom0, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
@@ -621,8 +623,8 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   };
 
   // TODO: refactor into more generic function
-  fk::vector<P> mom1(dense_size);
-  fm::gemv(pde.moments[1].get_moment_matrix(), x, mom1);
+  fk::vector<P, mem_type::owner, resource::device> mom1(dense_size);
+  fm::sparse_gemv(pde.moments[1].get_moment_matrix_dev(), x_dev, mom1);
   fk::vector<P> &mom1_real = pde.moments[1].create_realspace_moment(
       pde_1d, mom1, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
   param_manager.get_parameter("u")->value = [&](P const x_v,
@@ -631,8 +633,8 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
            param_manager.get_parameter("n")->value(x_v, t);
   };
 
-  fk::vector<P> mom2(dense_size);
-  fm::gemv(pde.moments[2].get_moment_matrix(), x, mom2);
+  fk::vector<P, mem_type::owner, resource::device> mom2(dense_size);
+  fm::sparse_gemv(pde.moments[2].get_moment_matrix_dev(), x_dev, mom2);
   fk::vector<P> &mom2_real = pde.moments[2].create_realspace_moment(
       pde_1d, mom2, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
   param_manager.get_parameter("theta")->value = [&](P const x_v,
@@ -704,7 +706,8 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   tools::timer.start("implicit_2_mom");
   // Create rho_3s
   // TODO: refactor into more generic function
-  fm::gemv(pde.moments[0].get_moment_matrix(), x, mom0);
+  x_dev.transfer_from(x);
+  fm::sparse_gemv(pde.moments[0].get_moment_matrix_dev(), x_dev, mom0);
   mom0_real = pde.moments[0].create_realspace_moment(
       pde_1d, mom0, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
   param_manager.get_parameter("n")->value = [&](P const x_v,
@@ -713,7 +716,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
     return interp1(nodes, mom0_real, {x_v})[0];
   };
 
-  fm::gemv(pde.moments[1].get_moment_matrix(), x, mom1);
+  fm::sparse_gemv(pde.moments[1].get_moment_matrix_dev(), x_dev, mom1);
   mom1_real = pde.moments[1].create_realspace_moment(
       pde_1d, mom1, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
   param_manager.get_parameter("u")->value = [&](P const x_v,
@@ -722,7 +725,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
            param_manager.get_parameter("n")->value(x_v, t);
   };
 
-  fm::gemv(pde.moments[2].get_moment_matrix(), x, mom2);
+  fm::sparse_gemv(pde.moments[2].get_moment_matrix_dev(), x_dev, mom2);
   mom2_real = pde.moments[2].create_realspace_moment(
       pde_1d, mom2, adaptive_grid_1d.get_table(), transformer, tmp_workspace);
   param_manager.get_parameter("theta")->value = [&](P const x_v,

--- a/src/time_advance.hpp
+++ b/src/time_advance.hpp
@@ -14,6 +14,12 @@ enum class method
   imex
 };
 
+#ifdef ASGARD_USE_CUDA
+static constexpr resource imex_resrc = resource::device;
+#else
+static constexpr resource imex_resrc = resource::host;
+#endif
+
 // take an adaptivity-enabled timestep
 // make require many "pseudosteps" to refine
 template<typename P>

--- a/src/time_advance_tests.cpp
+++ b/src/time_advance_tests.cpp
@@ -1263,7 +1263,7 @@ TEMPLATE_TEST_CASE("implicit time advance - continuity 2", "[time_advance]",
   }
 }
 
-TEMPLATE_TEST_CASE("IMEX time advance - landau", "[imex]", double)
+TEMPLATE_TEST_CASE("IMEX time advance - landau", "[imex]", test_precs)
 {
   // Disable test for MPI - IMEX needs to be tested further with MPI
   if (!is_active() || get_num_ranks() > 1)

--- a/src/time_advance_tests.cpp
+++ b/src/time_advance_tests.cpp
@@ -1263,7 +1263,7 @@ TEMPLATE_TEST_CASE("implicit time advance - continuity 2", "[time_advance]",
   }
 }
 
-TEMPLATE_TEST_CASE("IMEX time advance - landau", "[imex]", test_precs)
+TEMPLATE_TEST_CASE("IMEX time advance - landau", "[imex]", double)
 {
   // Disable test for MPI - IMEX needs to be tested further with MPI
   if (!is_active() || get_num_ranks() > 1)


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

This adds a `sparse` class for basic storage of sparse matrices in CSR format. The class currently makes use of the existing vector/matrix classes for reuse of storage/functionality and compatibility with existing code. Functionality is limited and should be extended more in future PRs.

Currently this is only being used in the `moment` class to store the moment matrices for use in IMEX. This is necessary for PDEs beyond 1x1v. `gemv` routines wrapping cuSPARSE are added to `fast_math` and `lib_dispatch` to calculate moments in IMEX. A very basic CPU implementation is also added for support with non-CUDA builds but is not optimized. Test coverage is limited and needs to be extended as well.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [ ] Bugfix
- [x] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

Ubuntu 20.04

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
