### PR TITLE
Allow PDE levels to be 1

### DIFF
--- a/src/asgard_dimension.hpp
+++ b/src/asgard_dimension.hpp
@@ -161,7 +161,7 @@ std::vector<dimension_description<precision>> cli_apply_level_degree_correction(
     for (int &l : levels)
     {
       l = cli_input.get_starting_levels()(counter++);
-      expect(l >= 1);
+      expect(l >= 0);
     }
   }
   auto const cli_degree = cli_input.get_degree();
@@ -176,7 +176,7 @@ std::vector<dimension_description<precision>> cli_apply_level_degree_correction(
   for (size_t i = 0; i < dimensions.size(); i++)
   {
     expect(degrees[i] > 0);
-    expect(levels[i] > 1);
+    expect(levels[i] >= 0);
   }
 
   std::vector<dimension_description<precision>> result;

--- a/src/asgard_dimension.hpp
+++ b/src/asgard_dimension.hpp
@@ -161,7 +161,7 @@ std::vector<dimension_description<precision>> cli_apply_level_degree_correction(
     for (int &l : levels)
     {
       l = cli_input.get_starting_levels()(counter++);
-      expect(l > 1);
+      expect(l >= 1);
     }
   }
   auto const cli_degree = cli_input.get_degree();

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -549,7 +549,7 @@ public:
       for (dimension<P> &d : dimensions_)
       {
         auto const num_levels = cli_input.get_starting_levels()(counter++);
-        expect(num_levels >= 1);
+        expect(num_levels >= 0);
         d.set_level(num_levels);
       }
     }
@@ -613,7 +613,7 @@ public:
     for (auto const &d : dimensions_)
     {
       expect(d.get_degree() > 0);
-      expect(d.get_level() >= 1);
+      expect(d.get_level() >= 0);
       expect(d.domain_max > d.domain_min);
     }
 

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -549,7 +549,7 @@ public:
       for (dimension<P> &d : dimensions_)
       {
         auto const num_levels = cli_input.get_starting_levels()(counter++);
-        expect(num_levels > 1);
+        expect(num_levels >= 1);
         d.set_level(num_levels);
       }
     }
@@ -613,7 +613,7 @@ public:
     for (auto const &d : dimensions_)
     {
       expect(d.get_degree() > 0);
-      expect(d.get_level() > 1);
+      expect(d.get_level() >= 1);
       expect(d.domain_max > d.domain_min);
     }
 

--- a/src/program_options.cpp
+++ b/src/program_options.cpp
@@ -171,6 +171,8 @@ parser::parser(int argc, char const *const *argv)
       valid = false;
     }
     starting_levels.resize(starting_lev.size()) = starting_lev;
+    // check that at least one level is greater than 0
+    int lev_sum = 0;
     for (auto const lev : starting_levels)
     {
       if (lev < 0)
@@ -185,6 +187,12 @@ parser::parser(int argc, char const *const *argv)
             << '\n';
         valid = false;
       }
+      lev_sum += lev;
+    }
+    if (lev_sum == 0)
+    {
+      std::cerr << "At least one level must be > 0" << '\n';
+      valid = false;
     }
   }
   if (memory_limit <= 0)

--- a/src/program_options.cpp
+++ b/src/program_options.cpp
@@ -173,9 +173,9 @@ parser::parser(int argc, char const *const *argv)
     starting_levels.resize(starting_lev.size()) = starting_lev;
     for (auto const lev : starting_levels)
     {
-      if (lev < 2)
+      if (lev < 0)
       {
-        std::cerr << "Level must be greater than one" << '\n';
+        std::cerr << "Level must be >= 0" << '\n';
         valid = false;
       }
       if (max_level < lev)
@@ -425,9 +425,9 @@ parser::parser(int argc, char const *const *argv)
     }
     for (int i = 0; i < max_adapt_levels.size(); ++i)
     {
-      if (max_adapt_levels[i] < 2)
+      if (max_adapt_levels[i] <= 0)
       {
-        std::cerr << "Level must be greater than one" << '\n';
+        std::cerr << "Level must be >= 0" << '\n';
         valid = false;
       }
       if (max_adapt_levels[i] < starting_levels[i])

--- a/src/program_options.cpp
+++ b/src/program_options.cpp
@@ -189,7 +189,7 @@ parser::parser(int argc, char const *const *argv)
       }
       lev_sum += lev;
     }
-    if (lev_sum == 0)
+    if (lev_sum == 0 && starting_lev.size() > 1)
     {
       std::cerr << "At least one level must be > 0" << '\n';
       valid = false;

--- a/src/program_options.hpp
+++ b/src/program_options.hpp
@@ -339,6 +339,14 @@ private:
       std::string word;
       number_stream >> word;
       int temp_int;
+
+      // remove any leading or trailing '"'
+      size_t pos = word.find_first_of('\"');
+      if (pos != std::string::npos)
+      {
+        word.erase(word.begin() + pos);
+      }
+
       if (std::stringstream(word) >> temp_int)
       {
         parsed_ints.push_back(temp_int);

--- a/src/program_options_tests.cpp
+++ b/src/program_options_tests.cpp
@@ -155,12 +155,12 @@ TEST_CASE("parser constructor/getters", "[program_options]")
     std::cerr.clear();
     REQUIRE(!p.is_valid());
   }
-  SECTION("out of range level, 2nd entry")
+  SECTION("2d with dim 1 level=0")
   {
     std::cerr.setstate(std::ios_base::failbit);
     parser const p = make_parser({"-l=\"2, 0\""});
     std::cerr.clear();
-    REQUIRE(!p.is_valid());
+    REQUIRE(p.is_valid());
   }
   SECTION("negative degree")
   {

--- a/src/program_options_tests.cpp
+++ b/src/program_options_tests.cpp
@@ -303,4 +303,11 @@ TEST_CASE("parser constructor/getters", "[program_options]")
     std::cerr.clear();
     REQUIRE(!p.is_valid());
   }
+  SECTION("check all levels cannot be 0")
+  {
+    std::cerr.setstate(std::ios_base::failbit);
+    parser const p = make_parser({"-l=\"0, 0\""});
+    std::cerr.clear();
+    REQUIRE(!p.is_valid());
+  }
 }


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

The CLI parser and PDE/dimension classes currently force the level to be > 2. Some problems, such as the relaxation problem, only need level = 1 in the x dimension. Additional problems will need level = 0 in some dimensions, so this allows those cases to pass CLI parsing as well.

This removes the checks for level > 2 and allows the user to set a level to be 1.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

Ubuntu 20.04

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
