### PR TITLE
Fix issue if analytical time function not defined

### DIFF
--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -511,7 +511,8 @@ public:
         num_terms(get_num_terms(cli_input, max_num_terms)),
         max_level(get_max_level(cli_input, dimensions)), sources(sources_in),
         exact_vector_funcs(exact_vector_funcs_in), moments(moments_in),
-        exact_time(exact_time_in), do_poisson_solve(do_poisson_solve_in),
+        exact_time(check_exact_time(exact_time_in)),
+        do_poisson_solve(do_poisson_solve_in),
         do_collision_operator(do_collision_operator_in),
         has_analytic_soln(has_analytic_soln_in), dimensions_(dimensions),
         terms_(terms)
@@ -892,6 +893,22 @@ private:
                        })
                        ->get_level()
                  : *std::max_element(levels.begin(), levels.end());
+    }
+  }
+
+  scalar_func<P> check_exact_time(scalar_func<P> const &exact_time_func)
+  {
+    // check if the PDE exact time function was defined, or return an empty one
+    if (!exact_time_func)
+    {
+      return [](P const t) {
+        ignore(t);
+        return P{1.0};
+      };
+    }
+    else
+    {
+      return exact_time_func;
     }
   }
 


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

If a PDE with analytical solutions did not define an exact time function, then asgard would crash. This fixes the issue by adding a default analytical time function if a PDE does not provide one.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

## Checklist

Ubuntu 20.04

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
