### PR TITLE
Refactor IMEX moment calculation and add moments for 1x2v

### DIFF
--- a/src/adapt.cpp
+++ b/src/adapt.cpp
@@ -142,7 +142,9 @@ fk::vector<P> distributed_grid<P>::get_initial_condition(
 {
   // get unrefined condition
 
-  auto const num_md_funcs = dims.front().initial_condition.size();
+  // TODO: this needs to be refactored to allow dimensions to have different
+  // number of md_funcs
+  auto const num_md_funcs = dims.back().initial_condition.size();
   std::vector<std::vector<vector_func<P>>> v_functions;
   for (auto const &dim : dims)
   {

--- a/src/distribution.cpp
+++ b/src/distribution.cpp
@@ -286,8 +286,9 @@ find_column_dependencies(std::vector<int> const &row_boundaries,
   return column_dependencies;
 }
 
-template<typename P>
-void reduce_results(fk::vector<P> const &source, fk::vector<P> &dest,
+template<typename P, mem_type src_mem, mem_type dst_mem, resource resrc>
+void reduce_results(fk::vector<P, src_mem, resrc> const &source,
+                    fk::vector<P, dst_mem, resrc> &dest,
                     distribution_plan const &plan, int const my_rank)
 {
   expect(source.size() == dest.size());
@@ -563,8 +564,9 @@ static void dispatch_message(fk::vector<P> const &source, fk::vector<P> &dest,
 #endif
 }
 
-template<typename P>
-void exchange_results(fk::vector<P> const &source, fk::vector<P> &dest,
+template<typename P, mem_type src_mem, mem_type dst_mem, resource resrc>
+void exchange_results(fk::vector<P, src_mem, resrc> const &source,
+                      fk::vector<P, dst_mem, resrc> &dest,
                       int const segment_size, distribution_plan const &plan,
                       int const my_rank)
 {
@@ -1238,13 +1240,28 @@ void scatter_matrix(P const *A, int const *descA, P *A_distr,
 #endif
 
 #ifdef ASGARD_ENABLE_DOUBLE
-template void reduce_results(fk::vector<double> const &source,
-                             fk::vector<double> &dest,
-                             distribution_plan const &plan, int const my_rank);
-template void exchange_results(fk::vector<double> const &source,
-                               fk::vector<double> &dest, int const segment_size,
-                               distribution_plan const &plan,
-                               int const my_rank);
+
+template void reduce_results(
+    fk::vector<double, mem_type::owner, resource::host> const &source,
+    fk::vector<double, mem_type::owner, resource::host> &dest,
+    distribution_plan const &plan, int const my_rank);
+
+template void exchange_results(
+    fk::vector<double, mem_type::owner, resource::host> const &source,
+    fk::vector<double, mem_type::owner, resource::host> &dest,
+    int const segment_size, distribution_plan const &plan, int const my_rank);
+
+//#ifdef ASGARD_USE_CUDA
+template void reduce_results(
+    fk::vector<double, mem_type::owner, resource::device> const &source,
+    fk::vector<double, mem_type::owner, resource::device> &dest,
+    distribution_plan const &plan, int const my_rank);
+
+template void exchange_results(
+    fk::vector<double, mem_type::owner, resource::device> const &source,
+    fk::vector<double, mem_type::owner, resource::device> &dest,
+    int const segment_size, distribution_plan const &plan, int const my_rank);
+//#endif
 
 template std::array<fk::vector<double>, 2>
 gather_errors(double const root_mean_squared, double const relative);
@@ -1279,13 +1296,28 @@ template void scatter_matrix<double>(double const *A, int const *descA,
 #endif
 
 #ifdef ASGARD_ENABLE_FLOAT
-template void reduce_results(fk::vector<float> const &source,
-                             fk::vector<float> &dest,
-                             distribution_plan const &plan, int const my_rank);
-template void exchange_results(fk::vector<float> const &source,
-                               fk::vector<float> &dest, int const segment_size,
-                               distribution_plan const &plan,
-                               int const my_rank);
+
+template void
+reduce_results(fk::vector<float, mem_type::owner, resource::host> const &source,
+               fk::vector<float, mem_type::owner, resource::host> &dest,
+               distribution_plan const &plan, int const my_rank);
+
+template void exchange_results(
+    fk::vector<float, mem_type::owner, resource::host> const &source,
+    fk::vector<float, mem_type::owner, resource::host> &dest,
+    int const segment_size, distribution_plan const &plan, int const my_rank);
+
+//#ifdef ASGARD_USE_CUDA
+template void reduce_results(
+    fk::vector<float, mem_type::owner, resource::device> const &source,
+    fk::vector<float, mem_type::owner, resource::device> &dest,
+    distribution_plan const &plan, int const my_rank);
+
+template void exchange_results(
+    fk::vector<float, mem_type::owner, resource::device> const &source,
+    fk::vector<float, mem_type::owner, resource::device> &dest,
+    int const segment_size, distribution_plan const &plan, int const my_rank);
+//#endif
 
 template std::array<fk::vector<float>, 2>
 gather_errors(float const root_mean_squared, float const relative);

--- a/src/distribution.cpp
+++ b/src/distribution.cpp
@@ -1251,7 +1251,7 @@ template void exchange_results(
     fk::vector<double, mem_type::owner, resource::host> &dest,
     int const segment_size, distribution_plan const &plan, int const my_rank);
 
-//#ifdef ASGARD_USE_CUDA
+#ifdef ASGARD_USE_CUDA
 template void reduce_results(
     fk::vector<double, mem_type::owner, resource::device> const &source,
     fk::vector<double, mem_type::owner, resource::device> &dest,
@@ -1261,7 +1261,7 @@ template void exchange_results(
     fk::vector<double, mem_type::owner, resource::device> const &source,
     fk::vector<double, mem_type::owner, resource::device> &dest,
     int const segment_size, distribution_plan const &plan, int const my_rank);
-//#endif
+#endif
 
 template std::array<fk::vector<double>, 2>
 gather_errors(double const root_mean_squared, double const relative);
@@ -1307,7 +1307,7 @@ template void exchange_results(
     fk::vector<float, mem_type::owner, resource::host> &dest,
     int const segment_size, distribution_plan const &plan, int const my_rank);
 
-//#ifdef ASGARD_USE_CUDA
+#ifdef ASGARD_USE_CUDA
 template void reduce_results(
     fk::vector<float, mem_type::owner, resource::device> const &source,
     fk::vector<float, mem_type::owner, resource::device> &dest,
@@ -1317,7 +1317,7 @@ template void exchange_results(
     fk::vector<float, mem_type::owner, resource::device> const &source,
     fk::vector<float, mem_type::owner, resource::device> &dest,
     int const segment_size, distribution_plan const &plan, int const my_rank);
-//#endif
+#endif
 
 template std::array<fk::vector<float>, 2>
 gather_errors(float const root_mean_squared, float const relative);

--- a/src/distribution.hpp
+++ b/src/distribution.hpp
@@ -234,8 +234,9 @@ struct message
 };
 
 // reduce the results of a subgrid row
-template<typename P>
-void reduce_results(fk::vector<P> const &source, fk::vector<P> &dest,
+template<typename P, mem_type src_mem, mem_type dst_mem, resource resrc>
+void reduce_results(fk::vector<P, src_mem, resrc> const &source,
+                    fk::vector<P, dst_mem, resrc> &dest,
                     distribution_plan const &plan, int const my_rank);
 
 // generate a message list for each rank for exchange_results function;
@@ -244,8 +245,9 @@ std::vector<std::vector<message>> const
 generate_messages(distribution_plan const &plan);
 
 // exchange results between subgrid rows
-template<typename P>
-void exchange_results(fk::vector<P> const &source, fk::vector<P> &dest,
+template<typename P, mem_type src_mem, mem_type dst_mem, resource resrc>
+void exchange_results(fk::vector<P, src_mem, resrc> const &source,
+                      fk::vector<P, dst_mem, resrc> &dest,
                       int const segment_size, distribution_plan const &plan,
                       int const my_rank);
 

--- a/src/moment.cpp
+++ b/src/moment.cpp
@@ -94,6 +94,7 @@ template<typename P>
 void moment<P>::createMomentReducedMatrix(PDE<P> const &pde,
                                           elements::table const &hash_table)
 {
+  tools::timer.start("createMomentMatrix");
   switch (pde.num_dims)
   {
   case 2:
@@ -109,6 +110,7 @@ void moment<P>::createMomentReducedMatrix(PDE<P> const &pde,
     throw std::runtime_error(
         "unsupported number of dimensions with createMomentReducedMatrix");
   }
+  tools::timer.stop("createMomentMatrix");
 }
 
 template<typename P>

--- a/src/moment.cpp
+++ b/src/moment.cpp
@@ -130,10 +130,12 @@ void moment<P>::createMomentReducedMatrix_nd(PDE<P> const &pde,
   fk::vector<P> g_vec_2, g_vec_3;
   if (nvdim >= 2)
   {
-    g_vec_2 = this->fList[moment_idx][2];
+    g_vec_2.resize(this->fList[moment_idx][2].size()) =
+        this->fList[moment_idx][2];
     if (nvdim >= 3)
     {
-      g_vec_3 = this->fList[moment_idx][3];
+      g_vec_3.resize(this->fList[moment_idx][3].size()) =
+          this->fList[moment_idx][3];
     }
   }
 

--- a/src/moment.hpp
+++ b/src/moment.hpp
@@ -84,7 +84,6 @@ private:
   std::vector<std::vector<fk::vector<P>>> fList;
   fk::vector<P> vector;
   fk::matrix<P> moment_matrix;
-  fk::matrix<P, mem_type::owner, resource::device> moment_matrix_dev;
   fk::vector<P> realspace;
   fk::sparse<P, sparse_resrc> sparse_mat;
   // moment_fval_integral;

--- a/src/moment.hpp
+++ b/src/moment.hpp
@@ -84,6 +84,7 @@ private:
   std::vector<std::vector<fk::vector<P>>> fList;
   fk::vector<P> vector;
   fk::matrix<P> moment_matrix;
+  fk::matrix<P, mem_type::owner, resource::device> moment_matrix_dev;
   fk::vector<P> realspace;
   fk::sparse<P, sparse_resrc> sparse_mat;
   // moment_fval_integral;

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -733,11 +733,11 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   tools::timer.stop(apply_id,
                     operator_matrices[matrix_entry::imex_explicit].flops());
 
-  if constexpr (imex_resrc == resource::device)
+  if constexpr (imex_resrc == resource::host)
   {
     reduce_results(fx, reduced_fx, plan, get_rank());
 
-    fk::vector<P, mem_type::owner, resource::device> f_2s(x_orig.size());
+    fk::vector<P, mem_type::owner, resource::host> f_2s(x_orig.size());
     exchange_results(reduced_fx, f_2s, elem_size, plan, get_rank());
     fm::axpy(f_2s, x, dt); // x here is f(1)
   }
@@ -817,11 +817,11 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   }
   tools::timer.stop(apply_id,
                     operator_matrices[matrix_entry::imex_explicit].flops());
-  if constexpr (imex_resrc == resource::device)
+  if constexpr (imex_resrc == resource::host)
   {
     reduce_results(fx, reduced_fx, plan, get_rank());
 
-    fk::vector<P, mem_type::owner, resource::device> t_f2(x_orig.size());
+    fk::vector<P, mem_type::owner, resource::host> t_f2(x_orig.size());
     exchange_results(reduced_fx, t_f2, elem_size, plan, get_rank());
     fm::axpy(t_f2, f_2, dt); // f_2 here is now f3 = f_2 + dt*T(f2)
   }


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

This refactors the moment calculation in IMEX to be a single lambda function `calculate_moments` rather than having two copies of the same code in IMEX.

This also adds initial support for calculating moments for 1x2v PDEs.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [ ] Bugfix
- [x] New feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

Ubuntu 20.04

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
