### PR TITLE
Fixed logic in max_adapt_levels command line checks

### DIFF
--- a/src/program_options.cpp
+++ b/src/program_options.cpp
@@ -433,7 +433,7 @@ parser::parser(int argc, char const *const *argv)
     }
     for (int i = 0; i < max_adapt_levels.size(); ++i)
     {
-      if (max_adapt_levels[i] <= 0)
+      if (max_adapt_levels[i] < 0)
       {
         std::cerr << "Level must be >= 0" << '\n';
         valid = false;

--- a/src/program_options.cpp
+++ b/src/program_options.cpp
@@ -424,7 +424,7 @@ parser::parser(int argc, char const *const *argv)
           << '\n';
       valid = false;
     }
-    if (!(max_adapt_levels.empty() && do_adapt))
+    if (!max_adapt_levels.empty() && !do_adapt)
     {
       std::cerr
           << "input maximum adaptivity levels without enabling adaptivity..."


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Bug in logic for CLI with `max_adapt_levels`.  We want to throw an error if `--max_adapt_levels` was specified (so non-empty) and adaptivity is not enabled.  

Also allowed `--max_adapt_levels` to be set to 0 in some dimensions.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [X] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [X] No

## What systems has this change been tested on?

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [X] this PR is up to date with current the current state of 'develop'
- [X] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
