### PR TITLE
Add moment calculations for 1x3v PDEs

### DIFF
--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -35,7 +35,9 @@ simple_gmres_euler(const P dt, kronmult_matrix<P> const &mat,
       [&](fk::vector<P, mem_type::owner, resrc> const &x_in,
           fk::vector<P, mem_type::owner, resrc> &y, P const alpha,
           P const beta) -> void {
+        auto const apply_id = tools::timer.start("kronmult - implicit");
         mat.template apply<resrc>(-dt * alpha, x_in.data(), beta, y.data());
+        tools::timer.stop(apply_id, mat.flops());
         int one = 1, n = y.size();
         lib_dispatch::axpy<resrc>(n, alpha, x_in.data(), one, y.data(), one);
       },

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -115,6 +115,9 @@ simple_gmres(matrix_replacement mat, fk::vector<P, mem_type::owner, resrc> &x,
     return (norm == 0.0) ? static_cast<P>(1.0) : norm;
   }();
 
+  // controls how often the inner residual print occurs
+  int const print_freq = restart / 3;
+
   fk::vector<P, mem_type::owner, resrc> residual(b);
   auto const compute_residual = [&]() {
     P const alpha = -1.0;
@@ -248,7 +251,7 @@ simple_gmres(matrix_replacement mat, fk::vector<P, mem_type::owner, resrc> &x,
         break; // depart the inner iteration loop
       }
 
-      if (i % 5 == 0)
+      if (i % print_freq == 0)
       {
         std::cout << "   -- GMRES inner iteration " << i << " / " << restart
                   << " w/ residual " << error << std::endl;

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -245,6 +245,12 @@ simple_gmres(matrix_replacement mat, fk::vector<P, mem_type::owner, resrc> &x,
           fm::gemv(m, s_view, x, false, P{1.0}, P{1.0});
         break; // depart the inner iteration loop
       }
+
+      if (i % 5 == 0)
+      {
+        std::cout << "   -- GMRES inner iteration " << i << " / " << restart
+                  << " w/ residual " << error << std::endl;
+      }
     } // end of inner iteration loop
 
     if (error <= tolerance)

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -682,7 +682,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
                    0.5 * (std::pow(u1, 2) + std::pow(u2, 2));
           };
         }
-        else if (pde.num_dims == 4 && pde.moments.size() > 3)
+        else if (pde.num_dims == 4 && pde.moments.size() > 6)
         {
           // Moments for 1X3V case
           // TODO: this will be refactored to replace dimension cases in the
@@ -692,7 +692,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
           // Create moment matrices and realspace moments for all moments in PDE
           for (size_t mom = 2; mom < pde.moments.size(); mom++)
           {
-            // \int f v_{mom} dv
+            // \int f v_x dv
             moments.push_back(
                 fk::vector<P, mem_type::owner, imex_resrc>(dense_size));
             fm::sparse_gemv(pde.moments[mom].get_moment_matrix_dev(), f_in,
@@ -731,8 +731,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
             P const n = param_manager.get_parameter("n")->value(x_v, t);
 
             return (mom4_x + mom5_x + mom6_x) / (3.0 * n) -
-                   (1.0 / 3.0) *
-                       (std::pow(u1, 2) + std::pow(u2, 2) + std::pow(u3, 2));
+                   (1.0 / 3.0) * (u1 * u1 + u2 * u2 + u3 * u3);
           };
         }
         else

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -731,7 +731,8 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
             P const n = param_manager.get_parameter("n")->value(x_v, t);
 
             return (mom4_x + mom5_x + mom6_x) / (3.0 * n) -
-                   0.5 * (std::pow(u1, 2) + std::pow(u2, 2) + std::pow(u3, 2));
+                   (1.0 / 3.0) *
+                       (std::pow(u1, 2) + std::pow(u2, 2) + std::pow(u3, 2));
           };
         }
         else


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

This adds moment calculations for 1x3v PDEs to the IMEX time advance function.

Refactoring `calculate_moments()` inside IMEX is planned and will be done in follow-up work which will combine the different cases for each dimension into a single function.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [ ] Bugfix
- [x] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

Ubuntu 20.04

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
