### PR TITLE
Fix saving degree to H5 when not specified

### DIFF
--- a/src/io.hpp
+++ b/src/io.hpp
@@ -151,15 +151,15 @@ void write_output(PDE<P> const &pde, parser const &cli_input,
   plist.add(HighFive::Chunking(hsize_t{64}));
   plist.add(HighFive::Deflate(9));
 
+  auto const dims = pde.get_dimensions();
   H5Easy::dump(file, "pde", cli_input.get_pde_string());
-  H5Easy::dump(file, "degree", cli_input.get_degree());
-  H5Easy::dump(file, "dt", cli_input.get_dt());
+  H5Easy::dump(file, "degree", dims[0].get_degree());
+  H5Easy::dump(file, "dt", pde.get_dt());
   H5Easy::dump(file, "time", time);
   H5Easy::dump(file, "ndims", pde.num_dims);
   H5Easy::dump(file, "max_level", pde.max_level);
   H5Easy::dump(file, "dof", dof);
   H5Easy::dump(file, "cli", cli_input.cli_opts);
-  auto const dims = pde.get_dimensions();
   for (size_t dim = 0; dim < dims.size(); ++dim)
   {
     auto const nodes =
@@ -324,8 +324,6 @@ void write_output(PDE<P> const &pde, parser const &cli_input,
 
   file.flush();
   tools::timer.stop("write_output");
-
-  std::cout << " DONE FILE WRITE" << std::endl;
 }
 
 template<typename P>


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Fixes the issue where degree would be saved to file as -1 if not specified with `-d` in the command line.

Fixes #607.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
