### PR TITLE
Add max level to 1D PDE in IMEX

### DIFF
--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -478,11 +478,13 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   static bool first_time = true;
 
   // create 1D version of PDE and element table for wavelet->realspace mappings
-  PDE pde_1d = PDE(pde, PDE<P>::extract_dim0);
+  PDE pde_1d       = PDE(pde, PDE<P>::extract_dim0);
+  int const degree = pde.get_dimensions()[0].get_degree();
+  int const level  = pde.get_dimensions()[0].get_level();
 
   options const opts_1d = make_options(
-      {"-d 3", "-f",
-       "-l " + std::to_string(pde.get_dimensions()[0].get_level())});
+      {"-d " + std::to_string(degree), "-f", "-l " + std::to_string(level),
+       "-m " + std::to_string(program_opts.max_level)});
   adapt::distributed_grid adaptive_grid_1d(pde_1d, opts_1d);
 
   // Create workspace for wavelet transform
@@ -495,8 +497,6 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
                                                     dense_size * 2 - 1)};
 
   auto const dt        = pde.get_dt();
-  int const degree     = pde.get_dimensions()[0].get_degree();
-  int const level      = pde.get_dimensions()[0].get_level();
   P const min          = pde.get_dimensions()[0].domain_min;
   P const max          = pde.get_dimensions()[0].domain_max;
   int const N_elements = fm::two_raised_to(level);


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

This fixes an issue in IMEX where the 1D PDE created for mapping the realspace moments did not have the `max_level` defined, which defaulted to 8. This adds the `max_level` option when creating this to make IMEX work properly when running with `max_level > 8`.

This also replaces the hard coded `degree = 3` to use the correct degree as well.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
