### PR TITLE
gmres: fix array size and move initialization outside of outer loop

### DIFF
--- a/src/asgard_resources_cuda.tpp
+++ b/src/asgard_resources_cuda.tpp
@@ -89,16 +89,13 @@ getCudaMemcpyKind(resource destination, resource source)
   {
     if (source == resource::host)
       return cudaMemcpyHostToHost;
-    else if (source == resource::device)
+    else
       return cudaMemcpyDeviceToHost;
   }
-  else if (destination == resource::device)
-  {
-    if (source == resource::host)
-      return cudaMemcpyHostToDevice;
-    else if (source == resource::device)
-      return cudaMemcpyDeviceToDevice;
-  }
+  if (source == resource::host)
+    return cudaMemcpyHostToDevice;
+  else
+    return cudaMemcpyDeviceToDevice;
 }
 
 template<resource out, resource in, typename P>

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -147,13 +147,14 @@ simple_gmres(matrix_abstraction mat, fk::vector<P, mem_type::view, resrc> x,
   fk::vector<P> krylov_proj(restart * (restart + 1) / 2);
   fk::vector<P> sines(restart + 1);
   fk::vector<P> cosines(restart + 1);
+  fk::vector<P> krylov_sol(restart + 1);
 
-  int total_iterations{0};
-  int outer_iterations{0};
-  int inner_iterations{0};
+  int total_iterations = 0;
+  int outer_iterations = 0;
+  int inner_iterations = 0;
 
-  P inner_res{0.};
-  P outer_res{tolerance + P{1.}};
+  P inner_res = 0.;
+  P outer_res = tolerance + 1.;
   while ((outer_res > tolerance) && (outer_iterations < max_outer_iterations))
   {
     fk::vector<P, mem_type::view, resrc> scaled(basis, 0, 0, basis.nrows() - 1);
@@ -162,7 +163,6 @@ simple_gmres(matrix_abstraction mat, fk::vector<P, mem_type::view, resrc> x,
     precondition(scaled);
     ++total_iterations;
 
-    fk::vector<P> krylov_sol(n + 1);
     inner_res = fm::nrm2(scaled);
     scaled.scale(P{1.} / inner_res);
     krylov_sol[0] = inner_res;
@@ -216,6 +216,7 @@ simple_gmres(matrix_abstraction mat, fk::vector<P, mem_type::view, resrc> x,
 
       if ((inner_res > tolerance) && (inner_iterations < restart))
       {
+        krylov_sol[inner_iterations + 1] = 0.;
         lib_dispatch::rot(1, krylov_sol.data(inner_iterations), 1,
                           krylov_sol.data(inner_iterations + 1), 1,
                           cosines[inner_iterations], sines[inner_iterations]);


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

moved `krylov_sol` out of the outer loop, incrementally zeroing out the next element. Worked around a CUDA warning about no return and removed the uniform initialization Miro dislikes.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [ ] New feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
