### PR TITLE
Only allocate real-space arrays when output is requested.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -147,7 +147,7 @@ int main(int argc, char **argv)
   int dense_size = 0;
   if (cli_input.get_realspace_output_freq() > 0)
   {
-    asgard::dense_space_size(*pde);
+    dense_size = asgard::dense_space_size(*pde);
     expect(dense_size > 0);
   }
   asgard::fk::vector<prec> real_space(dense_size);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -144,7 +144,12 @@ int main(int argc, char **argv)
 
   // realspace solution vector - WARNING this is
   // currently infeasible to form for large problems
-  auto dense_size = asgard::dense_space_size(*pde);
+  int dense_size = 0;
+  if (cli_input.get_realspace_output_freq() > 0)
+  {
+    asgard::dense_space_size(*pde);
+    expect(dense_size > 0);
+  }
   asgard::fk::vector<prec> real_space(dense_size);
 
   // temporary workspaces for the transform

--- a/src/transformations.hpp
+++ b/src/transformations.hpp
@@ -301,22 +301,26 @@ template<typename precision>
 inline int dense_space_size(std::vector<dimension<precision>> const &dims)
 {
   /* determine the length of the realspace solution */
-  return std::accumulate(dims.cbegin(), dims.cend(), int{1},
-                         [](int const size, dimension<precision> const &dim) {
-                           return size * dense_dim_size(dim.get_degree(),
-                                                        dim.get_level());
-                         });
+  int64_t const dense_size = std::accumulate(
+      dims.cbegin(), dims.cend(), int64_t{1},
+      [](int64_t const size, dimension<precision> const &dim) {
+        return size * dense_dim_size(dim.get_degree(), dim.get_level());
+      });
+  expect(dense_size <= std::numeric_limits<int>::max());
+  return static_cast<int>(dense_size);
 }
 
 template<typename precision>
 inline int
 dense_space_size(std::vector<dimension_description<precision>> const &dims)
 {
-  return std::accumulate(
-      dims.cbegin(), dims.cend(), int{1},
-      [](int const size, dimension_description<precision> const &dim) {
+  int64_t const dense_size = std::accumulate(
+      dims.cbegin(), dims.cend(), int64_t{1},
+      [](int64_t const size, dimension_description<precision> const &dim) {
         return size * dense_dim_size(dim.degree, dim.level);
       });
+  expect(dense_size <= std::numeric_limits<int>::max());
+  return static_cast<int>(dense_size);
 }
 
 template<typename P>


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

The size of real-space arrays may be larger than INT_MAX, causing an assertion error. Since these arrays are for an optional output, when it isn't needed we can just set their size to zero.

I also promoted the variable in dense_space_size to int64_t and check its size before returning.

This fixes #654 

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [x] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## What systems has this change been tested on?

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [x] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
