### PR TITLE
Adapt l2 norm

### DIFF
--- a/src/adapt.cpp
+++ b/src/adapt.cpp
@@ -261,7 +261,7 @@ template<typename P>
 fk::vector<P>
 distributed_grid<P>::refine(fk::vector<P> const &x, options const &cli_opts)
 {
-  P const max_elem   = cli_opts.use_l2_nrm ? fm::nrm2(x) : fm::nrminf(x);
+  P const max_elem   = cli_opts.use_linf_nrm ? fm::nrminf(x) : fm::nrm2(x);
   P const global_max = get_global_max<P>(max_elem, this->plan_);
 
   auto const refine_threshold = cli_opts.adapt_threshold * global_max;
@@ -274,7 +274,7 @@ distributed_grid<P>::refine(fk::vector<P> const &x, options const &cli_opts)
       [&cli_opts, refine_threshold](
           int64_t const, fk::vector<P, mem_type::const_view> const &element_x) {
         auto const refined_max_elem =
-            cli_opts.use_l2_nrm ? fm::nrm2(element_x) : fm::nrminf(element_x);
+            cli_opts.use_linf_nrm ? fm::nrminf(element_x) : fm::nrm2(element_x);
         return refined_max_elem >= refine_threshold;
       };
   auto const to_refine = filter_elements(refine_check, x);
@@ -285,8 +285,8 @@ template<typename P>
 fk::vector<P>
 distributed_grid<P>::coarsen(fk::vector<P> const &x, options const &cli_opts)
 {
-  P const max_elem         = cli_opts.use_l2_nrm ? fm::nrm2(x) : fm::nrminf(x);
-  P const global_max       = get_global_max<P>(max_elem, this->plan_);
+  P const max_elem   = cli_opts.use_linf_nrm ? fm::nrminf(x) : fm::nrm2(x);
+  P const global_max = get_global_max<P>(max_elem, this->plan_);
   P const refine_threshold = cli_opts.adapt_threshold * global_max;
   if (refine_threshold <= 0.0)
   {
@@ -300,7 +300,7 @@ distributed_grid<P>::coarsen(fk::vector<P> const &x, options const &cli_opts)
           int64_t const elem_index,
           fk::vector<P, mem_type::const_view> const &element_x) {
         P const coarsened_max_elem =
-            cli_opts.use_l2_nrm ? fm::nrm2(element_x) : fm::nrminf(element_x);
+            cli_opts.use_linf_nrm ? fm::nrminf(element_x) : fm::nrm2(element_x);
         auto const coords    = table.get_coords(elem_index);
         auto const min_level = *std::min_element(
             coords.begin(), coords.begin() + coords.size() / 2);

--- a/src/adapt_tests.cpp
+++ b/src/adapt_tests.cpp
@@ -7,6 +7,8 @@
 
 static auto constexpr adapt_threshold = 1e-4;
 
+static auto const use_linf_nrm = true;
+
 static auto const adapt_base_dir = gold_base_dir / "adapt";
 
 using namespace asgard;
@@ -124,7 +126,7 @@ TEMPLATE_TEST_CASE("adapt - 1d, scattered coarsen/refine", "[adapt]",
   parser parse(pde_choice, fk::vector<int>(std::vector<int>(num_dims, level)),
                degree);
   parser_mod::set(parse, parser_mod::adapt_threshold, adapt_threshold);
-
+  parser_mod::set(parse, parser_mod::use_linf_nrm, use_linf_nrm);
   test_adapt<TestType>(parse, adapt_base_dir / "continuity1_l4_d3_");
 }
 
@@ -141,6 +143,7 @@ TEMPLATE_TEST_CASE("adapt - 2d, all zero", "[adapt]", test_precs)
   parser parse(pde_choice, fk::vector<int>(std::vector<int>(num_dims, level)),
                degree);
   parser_mod::set(parse, parser_mod::adapt_threshold, adapt_threshold);
+  parser_mod::set(parse, parser_mod::use_linf_nrm, use_linf_nrm);
 
   // temporarily disable test for MPI due to table elements < num ranks
   if (get_num_ranks() == 1)
@@ -163,7 +166,7 @@ TEMPLATE_TEST_CASE("adapt - 3d, scattered, contiguous refine/adapt", "[adapt]",
   parser parse(pde_choice, fk::vector<int>(std::vector<int>(num_dims, level)),
                degree);
   parser_mod::set(parse, parser_mod::adapt_threshold, adapt_threshold);
-
+  parser_mod::set(parse, parser_mod::use_linf_nrm, use_linf_nrm);
   test_adapt<TestType>(parse, adapt_base_dir / "continuity3_l4_d4_");
 }
 
@@ -211,6 +214,7 @@ TEMPLATE_TEST_CASE("initial - diffusion 1d", "[adapt]", test_precs)
                degree);
   parser_mod::set(parse, parser_mod::do_adapt, true);
   parser_mod::set(parse, parser_mod::adapt_threshold, adapt_threshold);
+  parser_mod::set(parse, parser_mod::use_linf_nrm, use_linf_nrm);
 
   // don't test this in the MPI case -- too small to split table
   if (get_num_ranks() == 1)
@@ -234,6 +238,7 @@ TEMPLATE_TEST_CASE("initial - diffusion 2d", "[adapt]", test_precs)
                degree);
   parser_mod::set(parse, parser_mod::do_adapt, true);
   parser_mod::set(parse, parser_mod::adapt_threshold, adapt_threshold);
+  parser_mod::set(parse, parser_mod::use_linf_nrm, use_linf_nrm);
 
   test_initial<TestType>(parse,
                          adapt_base_dir / "diffusion2_l2_d3_initial.dat");

--- a/src/fast_math.hpp
+++ b/src/fast_math.hpp
@@ -27,6 +27,15 @@ inline constexpr T two_raised_to(T const exponent)
   return T{1} << exponent;
 }
 
+template<typename P, mem_type mem>
+P nrminf(fk::vector<P, mem> const &x)
+{
+  return std::abs(
+      *std::max_element(x.begin(), x.end(), [](P const a, P const b) {
+        return (std::abs(a) < std::abs(b));
+      }));
+}
+
 template<typename P, mem_type mem, resource resrc>
 P nrm2(fk::vector<P, mem, resrc> const &x)
 {

--- a/src/fast_math_tests.cpp
+++ b/src/fast_math_tests.cpp
@@ -30,13 +30,13 @@ TEMPLATE_TEST_CASE("floating point norms", "[fast_math]", test_precs)
       2,  3,  4, 5, 6, 6, 5, 4, 3, 2, 10, 10, 10,
       10, 10, 7, 3, 5, 9, 9, 4, 5, 4, 5,  7};
 
-  TestType gold_norm = 4.0 * std::sqrt(66.0);
+  TestType const gold_l2_norm = 4.0 * std::sqrt(66.0);
 
   SECTION("fk::vector: owner, host")
   {
     TestType norm = fm::nrm2(v);
 
-    relaxed_fp_comparison(gold_norm, norm);
+    relaxed_fp_comparison(gold_l2_norm, norm);
   }
 
   SECTION("fk::vector: const view, host")
@@ -46,7 +46,7 @@ TEMPLATE_TEST_CASE("floating point norms", "[fast_math]", test_precs)
 
     TestType norm = fm::nrm2(v_view_host);
 
-    relaxed_fp_comparison(gold_norm, norm);
+    relaxed_fp_comparison(gold_l2_norm, norm);
   }
 
   SECTION("fk::vector: view, host")
@@ -55,7 +55,35 @@ TEMPLATE_TEST_CASE("floating point norms", "[fast_math]", test_precs)
 
     TestType norm = fm::nrm2(v_view_host);
 
-    relaxed_fp_comparison(gold_norm, norm);
+    relaxed_fp_comparison(gold_l2_norm, norm);
+  }
+
+  TestType const gold_inf_norm = v[10];
+
+  SECTION("fk::vector: owner, host")
+  {
+    TestType norm = fm::nrminf(v);
+
+    relaxed_fp_comparison(gold_inf_norm, norm);
+  }
+
+  SECTION("fk::vector: const view, host")
+  {
+    fk::vector<TestType, mem_type::const_view, resource::host> const
+        v_view_host(v);
+
+    TestType norm = fm::nrminf(v_view_host);
+
+    relaxed_fp_comparison(gold_inf_norm, norm);
+  }
+
+  SECTION("fk::vector: view, host")
+  {
+    fk::vector<TestType, mem_type::view, resource::host> const v_view_host(v);
+
+    TestType norm = fm::nrminf(v_view_host);
+
+    relaxed_fp_comparison(gold_inf_norm, norm);
   }
 
   /* matrix Frobenius norm tests */
@@ -72,7 +100,7 @@ TEMPLATE_TEST_CASE("floating point norms", "[fast_math]", test_precs)
   {
     TestType norm = fm::frobenius(m);
 
-    relaxed_fp_comparison(gold_norm, norm);
+    relaxed_fp_comparison(gold_l2_norm, norm);
   }
 
   SECTION("fk::matrix: view, host")
@@ -81,7 +109,7 @@ TEMPLATE_TEST_CASE("floating point norms", "[fast_math]", test_precs)
 
     TestType norm = fm::frobenius(m_view_host);
 
-    relaxed_fp_comparison(gold_norm, norm);
+    relaxed_fp_comparison(gold_l2_norm, norm);
   }
 
   SECTION("fk::matrix submatrix: view, host")
@@ -100,7 +128,7 @@ TEMPLATE_TEST_CASE("floating point norms", "[fast_math]", test_precs)
 
     TestType norm = fm::frobenius(m_view_host);
 
-    relaxed_fp_comparison(gold_norm, norm);
+    relaxed_fp_comparison(gold_l2_norm, norm);
   }
 
   SECTION("fk::matrix submatrix: const view, host")

--- a/src/fast_math_tests.cpp
+++ b/src/fast_math_tests.cpp
@@ -149,7 +149,7 @@ TEMPLATE_TEST_CASE("floating point norms", "[fast_math]", test_precs)
 
     TestType norm = fm::nrm2(v_owner_dev);
 
-    relaxed_fp_comparison(gold_norm, norm);
+    relaxed_fp_comparison(gold_l2_norm, norm);
   }
 
   SECTION("fk::vector: const view, device")
@@ -162,7 +162,7 @@ TEMPLATE_TEST_CASE("floating point norms", "[fast_math]", test_precs)
 
     TestType norm = fm::nrm2(v_view_dev);
 
-    relaxed_fp_comparison(gold_norm, norm);
+    relaxed_fp_comparison(gold_l2_norm, norm);
   }
 
   SECTION("fk::vector: view, device")
@@ -175,7 +175,7 @@ TEMPLATE_TEST_CASE("floating point norms", "[fast_math]", test_precs)
 
     TestType norm = fm::nrm2(v_view_dev);
 
-    relaxed_fp_comparison(gold_norm, norm);
+    relaxed_fp_comparison(gold_l2_norm, norm);
   }
 
   SECTION("fk::matrix: owner, device")
@@ -185,7 +185,7 @@ TEMPLATE_TEST_CASE("floating point norms", "[fast_math]", test_precs)
 
     TestType norm = fm::frobenius(m_owner_dev);
 
-    relaxed_fp_comparison(gold_norm, norm);
+    relaxed_fp_comparison(gold_l2_norm, norm);
   }
 
   SECTION("fk::matrix: view, device")
@@ -198,7 +198,7 @@ TEMPLATE_TEST_CASE("floating point norms", "[fast_math]", test_precs)
 
     TestType norm = fm::frobenius(m_view_dev);
 
-    relaxed_fp_comparison(gold_norm, norm);
+    relaxed_fp_comparison(gold_l2_norm, norm);
   }
 
   SECTION("fk::matrix submatrix: view, device")
@@ -223,7 +223,7 @@ TEMPLATE_TEST_CASE("floating point norms", "[fast_math]", test_precs)
 
     TestType norm = fm::frobenius(m_view_dev);
 
-    relaxed_fp_comparison(gold_norm, norm);
+    relaxed_fp_comparison(gold_l2_norm, norm);
   }
 
   SECTION("fk::matrix submatrix: const view, device")

--- a/src/program_options.cpp
+++ b/src/program_options.cpp
@@ -33,6 +33,7 @@ parser::parser(int argc, char const *const *argv)
           "Terms in legendre basis polynomials") |
       clara::detail::Opt(use_full_grid)["-f"]["--full_grid"](
           "Use full grid (vs. sparse grid)") |
+      clara::detail::Opt(use_l2_nrm)["--l_two"]("Use L2 norm (vs. Linf norm)") |
       clara::detail::Opt(use_implicit_stepping)["-i"]["--implicit"](
           "Use implicit time advance (vs. explicit)") |
       clara::detail::Opt(solver_str,
@@ -331,6 +332,11 @@ parser::parser(int argc, char const *const *argv)
               << '\n';
     valid = false;
   }
+  if (use_l2_nrm != DEFAULT_USE_L2_NRM && !do_adapt)
+  {
+    std::cerr << "input adaptivity norm without enabling adaptivity..." << '\n';
+    valid = false;
+  }
 
 #ifndef ASGARD_USE_MATLAB
   if (matlab_name != NO_USER_VALUE_STR)
@@ -458,6 +464,7 @@ parser::parser(int argc, char const *const *argv)
 bool parser::using_implicit() const { return use_implicit_stepping; }
 bool parser::using_imex() const { return use_imex_stepping; }
 bool parser::using_full_grid() const { return use_full_grid; }
+bool parser::using_l2_nrm() const { return use_l2_nrm; }
 bool parser::do_poisson_solve() const { return do_poisson; }
 bool parser::do_adapt_levels() const { return do_adapt; }
 bool parser::do_restart() const { return restart_file != NO_USER_VALUE_STR; }
@@ -551,6 +558,9 @@ void parser_mod::set(parser &p, parser_option_entry entry, bool value)
     break;
   case use_full_grid:
     p.use_full_grid = value;
+    break;
+  case use_l2_nrm:
+    p.use_l2_nrm = value;
     break;
   case do_poisson:
     p.do_poisson = value;

--- a/src/program_options.cpp
+++ b/src/program_options.cpp
@@ -33,7 +33,8 @@ parser::parser(int argc, char const *const *argv)
           "Terms in legendre basis polynomials") |
       clara::detail::Opt(use_full_grid)["-f"]["--full_grid"](
           "Use full grid (vs. sparse grid)") |
-      clara::detail::Opt(use_l2_nrm)["--l_two"]("Use L2 norm (vs. Linf norm)") |
+      clara::detail::Opt(use_linf_nrm)["--l_inf"](
+          "Use Linf norm (vs. L2 norm)") |
       clara::detail::Opt(use_implicit_stepping)["-i"]["--implicit"](
           "Use implicit time advance (vs. explicit)") |
       clara::detail::Opt(solver_str,
@@ -332,7 +333,7 @@ parser::parser(int argc, char const *const *argv)
               << '\n';
     valid = false;
   }
-  if (use_l2_nrm != DEFAULT_USE_L2_NRM && !do_adapt)
+  if (use_linf_nrm != DEFAULT_USE_LINF_NRM && !do_adapt)
   {
     std::cerr << "input adaptivity norm without enabling adaptivity..." << '\n';
     valid = false;
@@ -464,7 +465,7 @@ parser::parser(int argc, char const *const *argv)
 bool parser::using_implicit() const { return use_implicit_stepping; }
 bool parser::using_imex() const { return use_imex_stepping; }
 bool parser::using_full_grid() const { return use_full_grid; }
-bool parser::using_l2_nrm() const { return use_l2_nrm; }
+bool parser::using_linf_nrm() const { return use_linf_nrm; }
 bool parser::do_poisson_solve() const { return do_poisson; }
 bool parser::do_adapt_levels() const { return do_adapt; }
 bool parser::do_restart() const { return restart_file != NO_USER_VALUE_STR; }
@@ -559,8 +560,8 @@ void parser_mod::set(parser &p, parser_option_entry entry, bool value)
   case use_full_grid:
     p.use_full_grid = value;
     break;
-  case use_l2_nrm:
-    p.use_l2_nrm = value;
+  case use_linf_nrm:
+    p.use_linf_nrm = value;
     break;
   case do_poisson:
     p.do_poisson = value;

--- a/src/program_options.hpp
+++ b/src/program_options.hpp
@@ -218,7 +218,7 @@ public:
   static auto constexpr DEFAULT_USE_IMPLICIT      = false;
   static auto constexpr DEFAULT_USE_IMEX          = false;
   static auto constexpr DEFAULT_USE_FG            = false;
-  static auto constexpr DEFAULT_USE_L2_NRM        = false;
+  static auto constexpr DEFAULT_USE_LINF_NRM      = false;
   static auto constexpr DEFAULT_DO_POISSON        = false;
   static auto constexpr DEFAULT_DO_ADAPT          = false;
   static auto constexpr DEFAULT_PDE_STR           = "continuity_2";
@@ -256,9 +256,9 @@ public:
       int const gmres_outer_iterations_in  = DEFAULT_GMRES_OUTER_ITERATIONS,
       fk::vector<int> const &max_adapt_levels_in = DEFAULT_MAX_ADAPT_LEVELS,
       std::string const restart_file_in          = NO_USER_VALUE_STR,
-      bool const use_l2_nrm_in                   = DEFAULT_USE_L2_NRM)
+      bool const use_linf_nrm_in                 = DEFAULT_USE_LINF_NRM)
       : use_implicit_stepping(use_implicit), use_full_grid(use_full_grid_in),
-        use_l2_nrm(use_l2_nrm_in), do_adapt(do_adapt_levels),
+        use_linf_nrm(use_linf_nrm_in), do_adapt(do_adapt_levels),
         starting_levels(starting_levels_in), degree(degree_in),
         max_level(max_level_in), mixed_grid_group(mixed_grid_group_in),
         num_time_steps(num_steps), cfl(cfl_in),
@@ -289,14 +289,14 @@ public:
       int const gmres_outer_iterations_in  = DEFAULT_GMRES_OUTER_ITERATIONS,
       fk::vector<int> const &max_adapt_levels_in = DEFAULT_MAX_ADAPT_LEVELS,
       std::string const restart_file_in          = NO_USER_VALUE_STR,
-      bool const use_l2_nrm_in                   = DEFAULT_USE_L2_NRM)
+      bool const use_linf_nrm_in                 = DEFAULT_USE_LINF_NRM)
       : parser(pde_mapping.at(pde_choice_in).pde_choice, starting_levels_in,
                degree_in, cfl_in, use_full_grid_in, max_level_in,
                mixed_grid_group_in, num_steps, use_implicit, do_adapt_levels,
                adapt_threshold_in, solver_str_in, use_imex, memory_limit_in,
                kmode_in, gmres_tolerance_in, gmres_inner_iterations_in,
                gmres_outer_iterations_in, max_adapt_levels_in, restart_file_in,
-               use_l2_nrm_in){};
+               use_linf_nrm_in){};
   /*!
    * \brief Simple utility to modify private members of the parser.
    */
@@ -305,7 +305,7 @@ public:
   bool using_implicit() const;
   bool using_imex() const;
   bool using_full_grid() const;
-  bool using_l2_nrm() const;
+  bool using_linf_nrm() const;
   bool do_poisson_solve() const;
   bool do_adapt_levels() const;
   bool do_restart() const;
@@ -393,7 +393,7 @@ private:
   bool use_implicit_stepping =
       DEFAULT_USE_IMPLICIT;            // enable implicit(/explicit) stepping
   bool use_full_grid = DEFAULT_USE_FG; // enable full(/sparse) grid
-  bool use_l2_nrm    = DEFAULT_USE_L2_NRM;
+  bool use_linf_nrm  = DEFAULT_USE_LINF_NRM;
   bool do_poisson = DEFAULT_DO_POISSON; // do poisson solve for electric field
   bool do_adapt   = DEFAULT_DO_ADAPT;   // adapt number of basis levels
 
@@ -478,7 +478,7 @@ struct parser_mod
     // bool values
     use_implicit_stepping,
     use_full_grid,
-    use_l2_nrm,
+    use_linf_nrm,
     do_poisson,
     do_adapt,
     use_imex_stepping,
@@ -524,7 +524,7 @@ public:
         gmres_outer_iterations(user_vals.get_gmres_outer_iterations()),
         use_implicit_stepping(user_vals.using_implicit()),
         use_full_grid(user_vals.using_full_grid()),
-        use_l2_nrm(user_vals.using_l2_nrm()),
+        use_linf_nrm(user_vals.using_linf_nrm()),
         do_poisson_solve(user_vals.do_poisson_solve()),
         do_adapt_levels(user_vals.do_adapt_levels()),
         solver(user_vals.get_selected_solver()),
@@ -554,7 +554,7 @@ public:
 
   bool const use_implicit_stepping;
   bool const use_full_grid;
-  bool const use_l2_nrm{false};
+  bool const use_linf_nrm{false};
   bool const do_poisson_solve;
   bool const do_adapt_levels;
 

--- a/src/program_options.hpp
+++ b/src/program_options.hpp
@@ -218,6 +218,7 @@ public:
   static auto constexpr DEFAULT_USE_IMPLICIT      = false;
   static auto constexpr DEFAULT_USE_IMEX          = false;
   static auto constexpr DEFAULT_USE_FG            = false;
+  static auto constexpr DEFAULT_USE_L2_NRM        = false;
   static auto constexpr DEFAULT_DO_POISSON        = false;
   static auto constexpr DEFAULT_DO_ADAPT          = false;
   static auto constexpr DEFAULT_PDE_STR           = "continuity_2";
@@ -254,16 +255,17 @@ public:
       int const gmres_inner_iterations_in  = DEFAULT_GMRES_INNER_ITERATIONS,
       int const gmres_outer_iterations_in  = DEFAULT_GMRES_OUTER_ITERATIONS,
       fk::vector<int> const &max_adapt_levels_in = DEFAULT_MAX_ADAPT_LEVELS,
-      std::string const restart_file_in          = NO_USER_VALUE_STR)
+      std::string const restart_file_in          = NO_USER_VALUE_STR,
+      bool const use_l2_nrm_in                   = DEFAULT_USE_L2_NRM)
       : use_implicit_stepping(use_implicit), use_full_grid(use_full_grid_in),
-        do_adapt(do_adapt_levels), starting_levels(starting_levels_in),
-        degree(degree_in), max_level(max_level_in),
-        mixed_grid_group(mixed_grid_group_in), num_time_steps(num_steps),
-        cfl(cfl_in), adapt_threshold(adapt_threshold_in),
-        pde_choice(pde_choice_in), solver_str(solver_str_in),
-        solver(solver_mapping.at(solver_str_in)), use_imex_stepping(use_imex),
-        memory_limit(memory_limit_in), kmode(kmode_in),
-        gmres_tolerance(gmres_tolerance_in),
+        use_l2_nrm(use_l2_nrm_in), do_adapt(do_adapt_levels),
+        starting_levels(starting_levels_in), degree(degree_in),
+        max_level(max_level_in), mixed_grid_group(mixed_grid_group_in),
+        num_time_steps(num_steps), cfl(cfl_in),
+        adapt_threshold(adapt_threshold_in), pde_choice(pde_choice_in),
+        solver_str(solver_str_in), solver(solver_mapping.at(solver_str_in)),
+        use_imex_stepping(use_imex), memory_limit(memory_limit_in),
+        kmode(kmode_in), gmres_tolerance(gmres_tolerance_in),
         gmres_inner_iterations(gmres_inner_iterations_in),
         gmres_outer_iterations(gmres_outer_iterations_in),
         max_adapt_levels(max_adapt_levels_in), restart_file(restart_file_in){};
@@ -286,14 +288,15 @@ public:
       int const gmres_inner_iterations_in  = DEFAULT_GMRES_INNER_ITERATIONS,
       int const gmres_outer_iterations_in  = DEFAULT_GMRES_OUTER_ITERATIONS,
       fk::vector<int> const &max_adapt_levels_in = DEFAULT_MAX_ADAPT_LEVELS,
-      std::string const restart_file_in          = NO_USER_VALUE_STR)
+      std::string const restart_file_in          = NO_USER_VALUE_STR,
+      bool const use_l2_nrm_in                   = DEFAULT_USE_L2_NRM)
       : parser(pde_mapping.at(pde_choice_in).pde_choice, starting_levels_in,
                degree_in, cfl_in, use_full_grid_in, max_level_in,
                mixed_grid_group_in, num_steps, use_implicit, do_adapt_levels,
                adapt_threshold_in, solver_str_in, use_imex, memory_limit_in,
                kmode_in, gmres_tolerance_in, gmres_inner_iterations_in,
-               gmres_outer_iterations_in, max_adapt_levels_in,
-               restart_file_in){};
+               gmres_outer_iterations_in, max_adapt_levels_in, restart_file_in,
+               use_l2_nrm_in){};
   /*!
    * \brief Simple utility to modify private members of the parser.
    */
@@ -302,6 +305,7 @@ public:
   bool using_implicit() const;
   bool using_imex() const;
   bool using_full_grid() const;
+  bool using_l2_nrm() const;
   bool do_poisson_solve() const;
   bool do_adapt_levels() const;
   bool do_restart() const;
@@ -387,8 +391,9 @@ private:
   }
 
   bool use_implicit_stepping =
-      DEFAULT_USE_IMPLICIT;             // enable implicit(/explicit) stepping
-  bool use_full_grid = DEFAULT_USE_FG;  // enable full(/sparse) grid
+      DEFAULT_USE_IMPLICIT;            // enable implicit(/explicit) stepping
+  bool use_full_grid = DEFAULT_USE_FG; // enable full(/sparse) grid
+  bool use_l2_nrm    = DEFAULT_USE_L2_NRM;
   bool do_poisson = DEFAULT_DO_POISSON; // do poisson solve for electric field
   bool do_adapt   = DEFAULT_DO_ADAPT;   // adapt number of basis levels
 
@@ -473,6 +478,7 @@ struct parser_mod
     // bool values
     use_implicit_stepping,
     use_full_grid,
+    use_l2_nrm,
     do_poisson,
     do_adapt,
     use_imex_stepping,
@@ -518,6 +524,7 @@ public:
         gmres_outer_iterations(user_vals.get_gmres_outer_iterations()),
         use_implicit_stepping(user_vals.using_implicit()),
         use_full_grid(user_vals.using_full_grid()),
+        use_l2_nrm(user_vals.using_l2_nrm()),
         do_poisson_solve(user_vals.do_poisson_solve()),
         do_adapt_levels(user_vals.do_adapt_levels()),
         solver(user_vals.get_selected_solver()),
@@ -547,6 +554,7 @@ public:
 
   bool const use_implicit_stepping;
   bool const use_full_grid;
+  bool const use_l2_nrm{false};
   bool const do_poisson_solve;
   bool const do_adapt_levels;
 

--- a/src/program_options_tests.cpp
+++ b/src/program_options_tests.cpp
@@ -105,6 +105,8 @@ TEST_CASE("parser constructor/getters", "[program_options]")
 
     auto const def_restart = parser::NO_USER_VALUE_STR;
 
+    auto const def_use_l2_nrm = parser::DEFAULT_USE_L2_NRM;
+
     auto const p = make_parser({});
 
     REQUIRE(p.get_degree() == def_degree);
@@ -130,6 +132,7 @@ TEST_CASE("parser constructor/getters", "[program_options]")
     REQUIRE(p.get_gmres_outer_iterations() == def_outer_iterations);
     REQUIRE(p.get_max_adapt_levels() == def_max_adapt_levels);
     REQUIRE(p.get_restart_file() == def_restart);
+    REQUIRE(p.using_l2_nrm() == def_use_l2_nrm);
     REQUIRE(p.is_valid());
   }
 
@@ -201,6 +204,13 @@ TEST_CASE("parser constructor/getters", "[program_options]")
   {
     std::cerr.setstate(std::ios_base::failbit);
     parser const p = make_parser({"--thresh=-0.2"});
+    std::cerr.clear();
+    REQUIRE(!p.is_valid());
+  }
+  SECTION("providing use_l2_nrm but disabled adapt")
+  {
+    std::cerr.setstate(std::ios_base::failbit);
+    parser const p = make_parser({"--l_two"});
     std::cerr.clear();
     REQUIRE(!p.is_valid());
   }

--- a/src/program_options_tests.cpp
+++ b/src/program_options_tests.cpp
@@ -105,7 +105,7 @@ TEST_CASE("parser constructor/getters", "[program_options]")
 
     auto const def_restart = parser::NO_USER_VALUE_STR;
 
-    auto const def_use_l2_nrm = parser::DEFAULT_USE_L2_NRM;
+    auto const def_use_linf_nrm = parser::DEFAULT_USE_LINF_NRM;
 
     auto const p = make_parser({});
 
@@ -132,7 +132,7 @@ TEST_CASE("parser constructor/getters", "[program_options]")
     REQUIRE(p.get_gmres_outer_iterations() == def_outer_iterations);
     REQUIRE(p.get_max_adapt_levels() == def_max_adapt_levels);
     REQUIRE(p.get_restart_file() == def_restart);
-    REQUIRE(p.using_l2_nrm() == def_use_l2_nrm);
+    REQUIRE(p.using_linf_nrm() == def_use_linf_nrm);
     REQUIRE(p.is_valid());
   }
 
@@ -207,10 +207,10 @@ TEST_CASE("parser constructor/getters", "[program_options]")
     std::cerr.clear();
     REQUIRE(!p.is_valid());
   }
-  SECTION("providing use_l2_nrm but disabled adapt")
+  SECTION("providing use_linf_nrm but disabled adapt")
   {
     std::cerr.setstate(std::ios_base::failbit);
-    parser const p = make_parser({"--l_two"});
+    parser const p = make_parser({"--l_inf"});
     std::cerr.clear();
     REQUIRE(!p.is_valid());
   }

--- a/src/time_advance_tests.cpp
+++ b/src/time_advance_tests.cpp
@@ -401,6 +401,29 @@ TEST_CASE("adaptive time advance")
     time_advance_test(parse, gold_base, tol_factor);
   }
 
+  SECTION("continuity 2 explicit, l2 norm")
+  {
+    // Gold data was calculated with L^{\infty} norm
+    auto const tol_factor        = 0.00001;
+    std::string const pde_choice = "continuity_2";
+    auto const degree            = 4;
+    fk::vector<int> const levels{3, 3};
+    auto const gold_base = time_advance_base_dir / "continuity2_ad_sg_l3_d4_t";
+
+    auto const full_grid       = false;
+    auto const use_implicit    = parser::DEFAULT_USE_IMPLICIT;
+    auto const do_adapt_levels = true;
+    auto const use_l2_nrm      = true;
+    auto const adapt_threshold = 1e-3;
+
+    parser parse =
+        make_basic_parser(pde_choice, levels, degree, cfl, full_grid, num_steps,
+                          use_implicit, do_adapt_levels, adapt_threshold);
+    parser_mod::set(parse, parser_mod::use_l2_nrm, use_l2_nrm);
+
+    time_advance_test(parse, gold_base, tol_factor);
+  }
+
   SECTION("continuity 2 explicit")
   {
     auto const tol_factor        = get_tolerance<default_precision>(100);

--- a/src/time_advance_tests.cpp
+++ b/src/time_advance_tests.cpp
@@ -163,12 +163,15 @@ parser make_basic_parser(std::string const &pde_choice,
                          fk::vector<int> starting_levels, int const degree,
                          double const cfl, bool full_grid,
                          int const num_time_steps, bool use_implicit,
-                         bool do_adapt_levels, double adapt_threshold)
+                         bool do_adapt_levels, double adapt_threshold,
+                         bool use_linf_nrm)
 {
   parser parse = make_basic_parser(pde_choice, starting_levels, degree, cfl,
                                    full_grid, num_time_steps, use_implicit);
   parser_mod::set(parse, parser_mod::do_adapt, do_adapt_levels);
   parser_mod::set(parse, parser_mod::adapt_threshold, adapt_threshold);
+  parser_mod::set(parse, parser_mod::use_linf_nrm, use_linf_nrm);
+
   return parse;
 }
 parser make_basic_parser(std::string const &pde_choice,
@@ -176,11 +179,11 @@ parser make_basic_parser(std::string const &pde_choice,
                          double const cfl, bool full_grid,
                          int const num_time_steps, bool use_implicit,
                          bool do_adapt_levels, double adapt_threshold,
-                         std::string const &solver_str)
+                         bool use_linf_nrm, std::string const &solver_str)
 {
-  parser parse = make_basic_parser(pde_choice, starting_levels, degree, cfl,
-                                   full_grid, num_time_steps, use_implicit,
-                                   do_adapt_levels, adapt_threshold);
+  parser parse = make_basic_parser(
+      pde_choice, starting_levels, degree, cfl, full_grid, num_time_steps,
+      use_implicit, do_adapt_levels, adapt_threshold, use_linf_nrm);
   parser_mod::set(parse, parser_mod::solver_str, solver_str);
   return parse;
 }
@@ -284,10 +287,11 @@ TEST_CASE("adaptive time advance")
     auto const use_implicit    = true;
     auto const do_adapt_levels = true;
     auto const adapt_threshold = 0.5e-1;
+    auto const use_linf_nrm    = true;
 
-    parser const parse =
-        make_basic_parser(pde_choice, levels, degree, cfl, full_grid, num_steps,
-                          use_implicit, do_adapt_levels, adapt_threshold);
+    parser const parse = make_basic_parser(
+        pde_choice, levels, degree, cfl, full_grid, num_steps, use_implicit,
+        do_adapt_levels, adapt_threshold, use_linf_nrm);
 
     // temporarily disable test for MPI due to table elements < num ranks
     if (get_num_ranks() == 1)
@@ -299,7 +303,7 @@ TEST_CASE("adaptive time advance")
 
     parser const parse_scalapack = make_basic_parser(
         pde_choice, levels, degree, cfl, full_grid, num_steps, use_implicit,
-        do_adapt_levels, adapt_threshold, solver_str);
+        do_adapt_levels, adapt_threshold, use_linf_nrm, solver_str);
 
     // temporarily disable test for MPI due to table elements < num ranks
     if (get_num_ranks() == 1)
@@ -320,10 +324,11 @@ TEST_CASE("adaptive time advance")
     auto const use_implicit    = parser::DEFAULT_USE_IMPLICIT;
     auto const do_adapt_levels = true;
     auto const adapt_threshold = 0.5e-1;
+    auto const use_linf_nrm    = true;
 
-    parser const parse =
-        make_basic_parser(pde_choice, levels, degree, cfl, full_grid, num_steps,
-                          use_implicit, do_adapt_levels, adapt_threshold);
+    parser const parse = make_basic_parser(
+        pde_choice, levels, degree, cfl, full_grid, num_steps, use_implicit,
+        do_adapt_levels, adapt_threshold, use_linf_nrm);
     // temporarily disable test for MPI due to table elements < num ranks
     if (get_num_ranks() == 1)
     {
@@ -344,10 +349,11 @@ TEST_CASE("adaptive time advance")
     auto const use_implicit    = parser::DEFAULT_USE_IMPLICIT;
     auto const do_adapt_levels = true;
     auto const adapt_threshold = 1e-4;
+    auto const use_linf_nrm    = true;
 
-    parser const parse =
-        make_basic_parser(pde_choice, levels, degree, cfl, full_grid, num_steps,
-                          use_implicit, do_adapt_levels, adapt_threshold);
+    parser const parse = make_basic_parser(
+        pde_choice, levels, degree, cfl, full_grid, num_steps, use_implicit,
+        do_adapt_levels, adapt_threshold, use_linf_nrm);
 
     // we do not gracefully handle coarsening below number of active ranks yet
     if (get_num_ranks() == 1)
@@ -369,10 +375,11 @@ TEST_CASE("adaptive time advance")
     auto const use_implicit    = parser::DEFAULT_USE_IMPLICIT;
     auto const do_adapt_levels = true;
     auto const adapt_threshold = 1e-4;
+    auto const use_linf_nrm    = true;
 
-    parser const parse =
-        make_basic_parser(pde_choice, levels, degree, cfl, full_grid, num_steps,
-                          use_implicit, do_adapt_levels, adapt_threshold);
+    parser const parse = make_basic_parser(
+        pde_choice, levels, degree, cfl, full_grid, num_steps, use_implicit,
+        do_adapt_levels, adapt_threshold, use_linf_nrm);
 
     // we do not gracefully handle coarsening below number of active ranks yet
     if (get_num_ranks() == 1)
@@ -393,10 +400,11 @@ TEST_CASE("adaptive time advance")
     auto const use_implicit    = parser::DEFAULT_USE_IMPLICIT;
     auto const do_adapt_levels = true;
     auto const adapt_threshold = 1e-3;
+    auto const use_linf_nrm    = true;
 
-    parser const parse =
-        make_basic_parser(pde_choice, levels, degree, cfl, full_grid, num_steps,
-                          use_implicit, do_adapt_levels, adapt_threshold);
+    parser const parse = make_basic_parser(
+        pde_choice, levels, degree, cfl, full_grid, num_steps, use_implicit,
+        do_adapt_levels, adapt_threshold, use_linf_nrm);
 
     time_advance_test(parse, gold_base, tol_factor);
   }
@@ -413,13 +421,12 @@ TEST_CASE("adaptive time advance")
     auto const full_grid       = false;
     auto const use_implicit    = parser::DEFAULT_USE_IMPLICIT;
     auto const do_adapt_levels = true;
-    auto const use_l2_nrm      = true;
+    auto const use_linf_nrm    = false;
     auto const adapt_threshold = 1e-3;
 
-    parser parse =
-        make_basic_parser(pde_choice, levels, degree, cfl, full_grid, num_steps,
-                          use_implicit, do_adapt_levels, adapt_threshold);
-    parser_mod::set(parse, parser_mod::use_l2_nrm, use_l2_nrm);
+    parser parse = make_basic_parser(pde_choice, levels, degree, cfl, full_grid,
+                                     num_steps, use_implicit, do_adapt_levels,
+                                     adapt_threshold, use_linf_nrm);
 
     time_advance_test(parse, gold_base, tol_factor);
   }
@@ -436,12 +443,16 @@ TEST_CASE("adaptive time advance")
     auto const use_implicit    = parser::DEFAULT_USE_IMPLICIT;
     auto const do_adapt_levels = true;
     auto const adapt_threshold = 1e-3;
+    auto const use_linf_nrm    = true;
+
     fk::vector<int> max_adapt_level{6, 8};
 
-    parser parse =
-        make_basic_parser(pde_choice, levels, degree, cfl, full_grid, num_steps,
-                          use_implicit, do_adapt_levels, adapt_threshold);
+    parser parse = make_basic_parser(pde_choice, levels, degree, cfl, full_grid,
+                                     num_steps, use_implicit, do_adapt_levels,
+                                     adapt_threshold, use_linf_nrm);
     parser_mod::set(parse, parser_mod::max_adapt_level, max_adapt_level);
+    parser_mod::set(parse, parser_mod::use_linf_nrm, use_linf_nrm);
+
     time_advance_test(parse, gold_base, tol_factor);
   }
 }


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

This adds the command-line option `--l_inf` to use the L\infty instead of the L2 adaptivity to determine whether to coarsen/refine.

This fixed #648 

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [ ] Bugfix
- [x] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [x] Yes
- [] No

Switched default from L\infty to L2.

## What systems has this change been tested on?

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [x] this PR is up to date with current the current state of 'develop'
- [x] code added or changed in the PR has been clang-formatted
- [x] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
