### PR TITLE
Cusparse mats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,6 +336,7 @@ target_sources (libasgard
                 $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/device/asgard_spkronmult.cpp>
                 $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/device/asgard_spkronmult_cpu.cpp>
                 $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/device/asgard_glkronmult_cpu.cpp>
+                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/device/asgard_glkronmult_gpu.cpp>
                 $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/device/asgard_gpu_preconditioner.cpp>
 )
 target_precompile_headers (libasgard

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,6 +382,7 @@ target_compile_definitions (libasgard
 if (ASGARD_USE_CUDA)
     set_source_files_properties (${CMAKE_CURRENT_SOURCE_DIR}/src/device/asgard_kronmult.cpp
                                  ${CMAKE_CURRENT_SOURCE_DIR}/src/device/asgard_spkronmult.cpp
+                                 ${CMAKE_CURRENT_SOURCE_DIR}/src/device/asgard_glkronmult_gpu.cpp
                                  ${CMAKE_CURRENT_SOURCE_DIR}/src/device/asgard_gpu_preconditioner.cpp
                                  PROPERTIES LANGUAGE CUDA)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,10 +120,6 @@ if (ASGARD_USE_MPI AND KRON_MODE_GLOBAL)
   message (FATAL_ERROR "Global Kronecker is not yet implemented for MPI")
 endif()
 
-if (KRON_MODE_GLOBAL AND ASGARD_USE_CUDA)
-  option (ASGARD_USE_PINNED_MEMORY "Selects the use of pinned memory for some  asynchronous I/O operations" ON)
-endif()
-
 if (ASGARD_RECOMMENDED_DEFAULTS)
   # add compiler flags we always want to use
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wshadow")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ else()
   option (KRON_MODE_GLOBAL "Global or local Kronecker products" ON)
 endif()
 if (ASGARD_USE_MPI AND KRON_MODE_GLOBAL)
-  message(FATAL_ERROR "Global Kronecker is not yet implemented for MPI")
+  message (FATAL_ERROR "Global Kronecker is not yet implemented for MPI")
 endif()
 
 if (KRON_MODE_GLOBAL AND ASGARD_USE_CUDA)

--- a/src/asgard_kronmult_matrix.cpp
+++ b/src/asgard_kronmult_matrix.cpp
@@ -1449,13 +1449,12 @@ void set_specific_mode(PDE<precision> const &pde,
   }
 
   int64_t gflops = 0; // flops for global component
+
+  for (auto t : used_terms)
+    for (int d = 0; d < num_dimensions; d++)
 #ifdef ASGARD_USE_CUDA
-  for (auto t : used_terms)
-    for (int d = 0; d < num_dimensions; d++)
-      gflops += mat.gvals_[3 * t * num_dimensions + d].size();
+      gflops += mat.gvals_[3 * t * num_dimensions + 3 * d].size();
 #else
-  for (auto t : used_terms)
-    for (int d = 0; d < num_dimensions; d++)
       gflops += mat.gvals_[t * num_dimensions + d].size();
 #endif
 

--- a/src/asgard_kronmult_matrix.cpp
+++ b/src/asgard_kronmult_matrix.cpp
@@ -1326,7 +1326,7 @@ void set_specific_mode(PDE<precision> const &pde,
         }
 #else
         std::vector<precision> &gvals = mat.gvals_[t * num_dimensions + d];
-        std::vector<int> &givals      = mat.givals_[d];
+        std::vector<int> &givals = mat.givals_[d];
 
         int64_t num_entries = static_cast<int64_t>(mat.gindx_[d].size());
 
@@ -1498,7 +1498,7 @@ void set_specific_mode(PDE<precision> const &pde,
 #ifdef ASGARD_USE_CUDA
 template<typename precision>
 void global_kron_matrix<precision>::
-preset_gpu_gkron(gpu::sparse_handle const &hndl, imex_flag const imex)
+    preset_gpu_gkron(gpu::sparse_handle const &hndl, imex_flag const imex)
 {
   int const imex_indx = global_kron_matrix<precision>::flag2int(imex);
 
@@ -1554,7 +1554,7 @@ void update_matrix_coefficients(PDE<precision> const &pde,
       fk::matrix<precision> const &ops = pde.get_coefficients(t, d);
 #ifdef ASGARD_USE_CUDA
       if (mat.gvals_[3 * (t * num_dimensions + d)].empty()) // identity term
-          continue;
+        continue;
 
       int const num_mats = (d == 0) ? 1 : 3;
       for (int k = 0; k < num_mats; k++)
@@ -1578,10 +1578,10 @@ void update_matrix_coefficients(PDE<precision> const &pde,
       }
 #else
       std::vector<precision> &vals = mat.gvals_[t * num_dimensions + d];
-      std::vector<int> &ivals      = mat.givals_[d];
+      std::vector<int> &ivals = mat.givals_[d];
 
       if (mat.gvals_[t * num_dimensions + d].empty()) // identity term
-          continue;
+        continue;
 
       int64_t num_entries = static_cast<int64_t>(mat.gindx_[d].size());
 

--- a/src/asgard_kronmult_matrix.cpp
+++ b/src/asgard_kronmult_matrix.cpp
@@ -1259,7 +1259,7 @@ make_global_kron_matrix(PDE<precision> const &pde,
   }
 
   return global_kron_matrix<precision>(
-      std::move(dof_pattern), std::move(ilist), num_active_dof, std::move(permutations),
+      num_dimensions, num_active_dof, ilist.num_strips(), std::move(permutations),
       std::move(global_pntr), std::move(global_indx), std::move(global_diag),
       std::move(global_ivals),
       porder, connect_1d(max_level), std::move(lpntr), std::move(lindx));

--- a/src/asgard_kronmult_matrix.cpp
+++ b/src/asgard_kronmult_matrix.cpp
@@ -1473,9 +1473,11 @@ void set_specific_mode(PDE<precision> const &pde,
   {
     num_cints += mat.gpntr_[d].size();
     num_cints += mat.gindx_[d].size();
-    num_cints += mat.gdiag_[d].size();
     num_cints += mat.givals_[d].size();
   }
+  for (auto const &ddiag : mat.gdiag_)
+    num_cints += ddiag.size();
+
   for (auto t : used_terms)
     for (int d = 0; d < num_dimensions; d++)
       num_cfps += mat.gvals_[t * num_dimensions + d].size();

--- a/src/asgard_kronmult_matrix.cpp
+++ b/src/asgard_kronmult_matrix.cpp
@@ -1644,8 +1644,8 @@ void global_kron_matrix<precision>::apply(
 
   if constexpr (rec == resource::host)
   {
-    fk::copy_to_device<precision>(gpux, x, num_active_);
-    fk::copy_to_device<precision>(gpuy, y, num_active_);
+    fk::copy_to_device<precision>(get_buffer<workspace::dev_x>(), x, num_active_);
+    fk::copy_to_device<precision>(get_buffer<workspace::dev_y>(), y, num_active_);
   }
 
   kronmult::gpu_sparse(num_dimensions_, porder_ + 1, num_active_, local_cols_.size(),

--- a/src/asgard_kronmult_matrix.cpp
+++ b/src/asgard_kronmult_matrix.cpp
@@ -1043,6 +1043,28 @@ void split_pattern(std::vector<int> const &pntr, std::vector<int> const &indx,
   }
   lpntr.push_back(static_cast<int>(lindx.size()));
   upntr.push_back(static_cast<int>(uindx.size()));
+
+  std::cout << " sizes = " << lpntr.size() << "  " << upntr.size() << "\n";
+  for(size_t r=0; r<pntr.size() - 1; r++){
+    for (int j = pntr[r]; j < pntr[r + 1]; j++)
+      std::cout << indx[j] << "  ";
+    std::cout << "\n";
+  }
+  for(auto d : diag) std::cout << d << "  "; std::cout << "\n";
+  std::cout << "  lower \n";
+  for(size_t r=0; r<lpntr.size() - 1; r++){
+    for (int j = lpntr[r]; j < lpntr[r + 1]; j++)
+      std::cout << lindx[j] << "  ";
+    std::cout << "\n";
+  }
+  std::cout << "  upper \n";
+  for(size_t r=0; r<upntr.size() - 1; r++){
+    for (int j = upntr[r]; j < upntr[r + 1]; j++)
+      std::cout << uindx[j] << "  ";
+    std::cout << "\n";
+  }
+  std::cout << "  -----------------------------------  \n";
+
 }
 
 template<typename precision>
@@ -1672,6 +1694,19 @@ void global_kron_matrix<precision>::apply(matrix_entry etype, precision alpha, p
                                          get_buffer<workspace::pad_y>(), 1,
                                          get_buffer<workspace::dev_y>(), 1);
 
+    std::vector<precision> cpuy = (*work_)[1];
+    //fk::copy_to_host(cpuy.data(), y, num_active_);
+    //for(auto y : cpuy) std::cout << y << " ";
+    //std::cout << "\n";
+    for(auto t : used_terms){
+        std::cout << " term = " << t << "\n";
+        for(int d=0; d<3 * num_dimensions_; d++){
+            std::vector<precision> cpu = gpu_global[imex].gvals_[3 * t * num_dimensions_ + d];
+            for(auto y : cpu) std::cout << y << " ";
+            std::cout << "\n";
+        }
+    }
+
     fk::copy_to_host<precision>(y, get_buffer<workspace::dev_y>(), num_active_);
 #else
     kronmult::cpu_sparse(num_dimensions_, porder_ + 1, local_pntr_.size() - 1,
@@ -1690,6 +1725,19 @@ void global_kron_matrix<precision>::apply(matrix_entry etype, precision alpha, p
                          get_buffer<workspace::pad_y>(),
                          get_buffer<workspace::stage1>(),
                          get_buffer<workspace::stage2>());
+
+    //std::vector<precision> cpuy = (*work_)[1];
+    //fk::copy_to_host(cpuy.data(), y, num_active_);
+    //for(auto y : cpuy) std::cout << y << " ";
+    //std::cout << "\n";
+    for(auto t : used_terms){
+        std::cout << " term = " << t << "\n";
+        for(int d=0; d<num_dimensions_; d++){
+            std::vector<precision> cpu = gvals_[t * num_dimensions_ + d];
+            for(auto y : cpu) std::cout << y << " ";
+            std::cout << "\n";
+        }
+    }
 
     precision *py = get_buffer<workspace::pad_y>();
 #pragma omp parallel for

--- a/src/asgard_kronmult_matrix.hpp
+++ b/src/asgard_kronmult_matrix.hpp
@@ -836,13 +836,13 @@ public:
   }
 
 #ifdef ASGARD_USE_CUDA
-  void preset_gpu_gkron(sparse_handle const &hndl, imex_flag const imex)
+  void preset_gpu_gkron(gpu::sparse_handle const &hndl, imex_flag const imex)
   {
     int const imex_indx = global_kron_matrix<precision>::flag2int(imex);
 
     gpu_global[imex_indx] = kronmult::global_gpu_operations<precision>(
         hndl, num_dimensions_, perms_, gpntr_, gindx_, gvals_,
-        mat.term_groups[imex_indx], pad_x, pad_y, scratch1, scratch2); 
+        term_groups[imex_indx], pad_x, pad_y, scratch1, scratch2);
   }
   size_t get_gpu_gkron_workspace(imex_flag const imex) const
   {
@@ -910,7 +910,7 @@ public:
 #ifdef ASGARD_USE_CUDA
     // zero out the a-vector (maybe run a kernel here)
     std::vector<precision> tmp(four_workspace_buffers_size(), precision{0});
-    copy_on_device(a, tmp.data(), four_workspace_buffers_size());
+    fk::copy_on_device(a, tmp.data(), four_workspace_buffers_size());
 #else
     std::fill_n(a, ilist_.num_strips(), precision{0});
 #endif
@@ -1127,9 +1127,9 @@ struct matrix_list
     {
       set_specific_mode(pde, grid, opts, imex(entry), kglobal);
 #ifdef ASGARD_USE_CUDA
-      kglobal.preset_gpu_gkron(sp_handle, imex(entire));
-      size_t bsize = kglobal.get_gpu_gkron_workspace(imex(entire));
-      if (gpu_sparse_buffer.size() < bsize)
+      kglobal.preset_gpu_gkron(sp_handle, imex(entry));
+      size_t bsize = kglobal.get_gpu_gkron_workspace(imex(entry));
+      if (gpu_sparse_buffer.size() < static_cast<int64_t>(bsize))
         gpu_sparse_buffer.resize(bsize);
       kglobal.set_gk_buffer(gpu_sparse_buffer.data());
 #endif

--- a/src/asgard_kronmult_matrix.hpp
+++ b/src/asgard_kronmult_matrix.hpp
@@ -778,17 +778,18 @@ class global_kron_matrix
 {
 public:
   //! \brief Several workspaces are needed
-  enum class workspace {
-      pad_x = 0, // padded entries for x/y
-      pad_y,
-      stage1,    // global kron workspace (stages)
-      stage2,
+  enum class workspace
+  {
+    pad_x = 0, // padded entries for x/y
+    pad_y,
+    stage1, // global kron workspace (stages)
+    stage2,
 #ifdef ASGARD_USE_CUDA
-      dev_x,     // move CPU data to the GPU
-      dev_y,
-      gsparse,   // cusparse workspace
+    dev_x, // move CPU data to the GPU
+    dev_y,
+    gsparse, // cusparse workspace
 #endif
-      num_spaces
+    num_spaces
   };
 
 #ifdef ASGARD_USE_CUDA
@@ -817,7 +818,7 @@ public:
                      std::vector<std::vector<int>> givals,
                      int porder, connect_1d edges,
                      default_vector<int> local_pntr, default_vector<int> local_indx)
-    :   num_dimensions_(num_dimensions), num_active_(num_active),
+      : num_dimensions_(num_dimensions), num_active_(num_active),
         num_padded_(num_padded), perms_(std::move(perms)), flops_({0, 0, 0}),
         gpntr_(std::move(gpntr)), gindx_(std::move(gindx)),
         gdiag_(std::move(gdiag)), givals_(std::move(givals)),
@@ -946,14 +947,12 @@ protected:
   //! \brief Convert the imex flag to an index of the arrays.
   static int flag2int(imex_flag imex)
   {
-    return (imex == imex_flag::imex_implicit) ? 2 :
-           ((imex == imex_flag::imex_explicit) ? 1 : 0);
+    return (imex == imex_flag::imex_implicit) ? 2 : ((imex == imex_flag::imex_explicit) ? 1 : 0);
   }
   //! \brief Convert the matrix entry to an index of the arrays.
   static int flag2int(matrix_entry imex)
   {
-    return (imex == matrix_entry::imex_implicit) ? 2 :
-           ((imex == matrix_entry::imex_explicit) ? 1 : 0);
+    return (imex == matrix_entry::imex_implicit) ? 2 : ((imex == matrix_entry::imex_explicit) ? 1 : 0);
   }
   // the workspace is kept externally to minimize allocations
   mutable workspace_type *work_;
@@ -977,7 +976,7 @@ protected:
     {
       w.resize(min_size);
       // x must always be padded by zeros
-      if constexpr(wid == workspace::pad_x)
+      if constexpr (wid == workspace::pad_x)
       {
 #ifdef ASGARD_USE_CUDA
         // zero out the a-vector (maybe run a kernel here)

--- a/src/asgard_kronmult_matrix_tests.cpp
+++ b/src/asgard_kronmult_matrix_tests.cpp
@@ -430,9 +430,11 @@ TEMPLATE_TEST_CASE("testing simple 1d", "[global kron]", test_precs)
     asgard::dimension_sort dsort(ilist);
 
     std::vector<TestType> y(x.size(), TestType{0});
-    std::vector<TestType> w(2 * y.size(), TestType{0});
+    std::vector<TestType> w1(y.size(), TestType{0});
+    std::vector<TestType> w2(y.size(), TestType{0});
     asgard::kronmult::global_cpu(perms, ilist, dsort, conn, {0}, vals,
-                                 TestType{1}, x.data(), y.data(), w.data());
+                                 TestType{1}, x.data(), y.data(),
+                                 w1.data(), w1.data());
 
     test_almost_equal(y, y_ref);
   }
@@ -512,9 +514,11 @@ void test_global_kron(int num_dimensions, int level)
   asgard::dimension_sort dsort(ilist);
 
   std::vector<precision> y(y_ref.size(), precision{0});
-  std::vector<precision> w(2 * y.size(), precision{0});
+  std::vector<precision> w1(y.size(), precision{0});
+  std::vector<precision> w2(y.size(), precision{0});
   asgard::kronmult::global_cpu(perms, ilist, dsort, conn, {0}, vals,
-                               precision{1}, x.data(), y.data(), w.data());
+                               precision{1}, x.data(), y.data(),
+                               w1.data(), w2.data());
 
   test_almost_equal(y, y_ref);
 }

--- a/src/asgard_kronmult_matrix_tests.cpp
+++ b/src/asgard_kronmult_matrix_tests.cpp
@@ -111,7 +111,7 @@ void test_kronmult_sparse(int dimensions, int n, int num_rows, int num_terms,
 
   test_almost_equal(data->output_y, data->reference_y, 100);
 }
-/*
+
 template<typename P, asgard::resource rec = asgard::resource::host>
 void test_kronmult_dense(int dimensions, int n, int num_terms,
                          int num_1d_blocks)
@@ -381,9 +381,7 @@ TEMPLATE_TEST_CASE("testing kronmult gpu 6d", "[gpu_dense 6d]", test_precs)
   int n = GENERATE(1, 2, 3); // TODO: n = 4
   test_kronmult_dense<TestType, asgard::resource::host>(6, n, 2, 1);
 }
-
 #endif
-*/
 
 #ifdef KRON_MODE_GLOBAL
 
@@ -557,15 +555,15 @@ TEMPLATE_TEST_CASE("testing cusparse functionality", "[cusparse]", test_precs)
   std::vector<int> indx      = {0, 1, 0, 1, 2, 1, 2, 3, 2, 3};
   std::vector<TestType> vals = {-2.0, 1.0, 1.0, -2.0, 1.0, 1.0, -2.0, 1.0, 1.0, -2.0};
 
-  std::vector<TestType> x     = {1.0, 2.0, 3.0, 4.0};
+  std::vector<TestType> x = {1.0, 2.0, 3.0, 4.0};
   std::vector<TestType> y_ref(pntr.size() - 1, TestType{0});
 
   for (size_t r = 0; r < pntr.size() - 1; r++)
     for (int j = pntr[r]; j < pntr[r + 1]; j++)
       y_ref[r] += x[indx[j]] * vals[j];
 
-  asgard::gpu::vector<int>      gpntr = pntr;
-  asgard::gpu::vector<int>      gindx = indx;
+  asgard::gpu::vector<int> gpntr      = pntr;
+  asgard::gpu::vector<int> gindx      = indx;
   asgard::gpu::vector<TestType> gvals = vals;
   asgard::gpu::vector<TestType> gx    = x;
 

--- a/src/asgard_kronmult_matrix_tests.cpp
+++ b/src/asgard_kronmult_matrix_tests.cpp
@@ -583,6 +583,19 @@ TEMPLATE_TEST_CASE("testing cusparse functionality", "[cusparse]", test_precs)
 
   std::vector<TestType> y = gy;
   test_almost_equal(y, y_ref);
+
+  // change the values without changing the matrix object
+  vals = {2.0, 0.5, 1.0, 2.0, 1.0, 0.5, -2.0, 1.0, 1.0, -2.0};
+  std::fill(y_ref.begin(), y_ref.end(), TestType{0});
+
+  for (size_t r = 0; r < pntr.size() - 1; r++)
+    for (int j = pntr[r]; j < pntr[r + 1]; j++)
+      y_ref[r] += x[indx[j]] * vals[j]; // recompute y_ref
+
+  asgard::fk::copy_to_device(gvals.data(), vals.data(), vals.size());
+  mat.apply(cusparse, work.data());
+  y = gy;
+  test_almost_equal(y, y_ref);
 }
 #endif
 #endif

--- a/src/asgard_kronmult_matrix_tests.cpp
+++ b/src/asgard_kronmult_matrix_tests.cpp
@@ -111,7 +111,7 @@ void test_kronmult_sparse(int dimensions, int n, int num_rows, int num_terms,
 
   test_almost_equal(data->output_y, data->reference_y, 100);
 }
-
+/*
 template<typename P, asgard::resource rec = asgard::resource::host>
 void test_kronmult_dense(int dimensions, int n, int num_terms,
                          int num_1d_blocks)
@@ -383,6 +383,7 @@ TEMPLATE_TEST_CASE("testing kronmult gpu 6d", "[gpu_dense 6d]", test_precs)
 }
 
 #endif
+*/
 
 #ifdef KRON_MODE_GLOBAL
 
@@ -547,4 +548,10 @@ TEMPLATE_TEST_CASE("testing global kron 5d, constant basis", "[gkron 5d]", test_
   test_global_kron<TestType>(5, l);
 }
 
+#ifdef ASGARD_USE_CUDA
+TEMPLATE_TEST_CASE("testing cusparse functionality", "[cusparse]", test_precs)
+{
+  asgard::gpu::sparse_handle cusparse;
+}
+#endif
 #endif

--- a/src/build_info.hpp.in
+++ b/src/build_info.hpp.in
@@ -22,14 +22,4 @@
 
 #define ASGARD_NUM_QUADRATURE @ASGARD_NUM_QUADRATURE@
 
-// both KRON_MODE_GLOBAL and ASGARD_USE_PINNED_MEMORY are temporary while kronmult is improving
 #cmakedefine KRON_MODE_GLOBAL
-#cmakedefine ASGARD_USE_PINNED_MEMORY
-
-// pinned memory works only with both cuda and global kronmult
-#ifndef ASGARD_USE_CUDA
-#undef ASGARD_USE_PINNED_MEMORY
-#endif
-#ifndef KRON_MODE_GLOBAL
-#undef ASGARD_USE_PINNED_MEMORY
-#endif

--- a/src/device/asgard_cusparse.hpp
+++ b/src/device/asgard_cusparse.hpp
@@ -136,6 +136,7 @@ struct sparse_matrix
     auto status = cusparseSpMV(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, scale_factors_.data(),
                                desc_, x_, scale_factors_.data() + 1, y_, cusparse_dtype<T>::value,
                                CUSPARSE_SPMV_CSR_ALG1, workspace);
+    expect(status == CUSPARSE_STATUS_SUCCESS);
   }
 
   cusparseSpMatDescr_t desc_;

--- a/src/device/asgard_cusparse.hpp
+++ b/src/device/asgard_cusparse.hpp
@@ -1,0 +1,145 @@
+#pragma once
+
+#ifdef ASGARD_USE_CUDA
+
+#include <iostream>
+#include <vector>
+
+#include "build_info.hpp"
+
+#include "asgard_vector.hpp"
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <sm_60_atomic_functions.h>
+
+#include <cusparse.h>
+
+namespace asgard::gpu
+{
+
+struct sparse_handle
+{
+  sparse_handle()
+  {
+    auto status = cusparseCreate(&handle_);
+    expect(status == CUSPARSE_STATUS_SUCCESS);
+  }
+  ~sparse_handle()
+  {
+    if (handle_ != nullptr)
+    {
+      auto status = cusparseDestroy(handle_);
+      expect(status == CUSPARSE_STATUS_SUCCESS);
+    }
+  }
+
+  sparse_handle(sparse_handle &&other)
+    : handle_(std::exchange(other.handle_, nullptr))
+  {}
+
+  sparse_handle& operator =(sparse_handle &&other)
+  {
+    sparse_handle tmp(std::move(other));
+    std::swap(handle_, tmp.handle_);
+    return *this;
+  }
+
+  sparse_handle(sparse_handle const &other) = delete;
+  sparse_handle& operator =(sparse_handle &other) = delete;
+
+  operator cusparseHandle_t() { return handle_; }
+
+  mutable cusparseHandle_t handle_;
+};
+
+template<typename T>
+struct cusparse_dtype
+{};
+
+template<> struct cusparse_dtype<float>
+{
+  static const cudaDataType value = CUDA_R_32F;
+};
+template<> struct cusparse_dtype<double>
+{
+  static const cudaDataType value = CUDA_R_64F;
+};
+
+template<typename T>
+struct sparse_matrix
+{
+  sparse_matrix(int64_t num_rows, int64_t num_cols, int64_t nnz,
+                int *pntr, int *indx, T *vals)
+  {
+    auto status = cusparseCreateCsr(&desc_, num_rows, num_cols, nnz,
+                                    pntr, indx, vals,
+                                    CUSPARSE_INDEX_32I, CUSPARSE_INDEX_32I,
+                                    CUSPARSE_INDEX_BASE_ZERO,
+                                    cusparse_dtype<T>::value);
+    expect(status == CUSPARSE_STATUS_SUCCESS);
+  }
+  sparse_matrix(sparse_matrix<T> &&other)
+    : desc_(std::exchange(other.desc_, nullptr)),
+      x_(std::exchange(other.x_, nullptr)),
+      y_(std::exchange(other.y_, nullptr))
+  {}
+
+  sparse_matrix<T>& operator =(sparse_matrix<T> &&other)
+  {
+    sparse_matrix<T> tmp(std::move(other));
+    std::swap(desc_, tmp.desc_);
+    std::swap(x_, tmp.x_);
+    std::swap(y_, tmp.y_);
+    return *this;
+  }
+
+  sparse_matrix(sparse_matrix<T> const &other) = delete;
+  sparse_matrix<T>& operator =(sparse_matrix<T> const &other) = delete;
+
+  ~sparse_matrix()
+  {
+    if (desc_ != nullptr)
+      cusparseDestroySpMat(desc_);
+    if (x_ != nullptr)
+      cusparseDestroyDnVec(x_);
+    if (y_ != nullptr)
+      cusparseDestroyDnVec(y_);
+  }
+
+  void set_vectors(int64_t n, T alpha, T *x, T beta, T *y)
+  {
+    auto status = cusparseCreateDnVec(&x_, n, x, cusparse_dtype<T>::value);
+    expect(status == CUSPARSE_STATUS_SUCCESS);
+    status = cusparseCreateDnVec(&y_, n, y, cusparse_dtype<T>::value);
+    expect(status == CUSPARSE_STATUS_SUCCESS);
+
+    scale_factors_ = std::vector<T>{alpha, beta};
+  }
+
+  size_t size_workspace(cusparseHandle_t handle) const
+  {
+    size_t buffer_size = 0;
+
+    auto status = cusparseSpMV_bufferSize(
+        handle, CUSPARSE_OPERATION_NON_TRANSPOSE, &scale_factors_[0], desc_, x_,
+        &scale_factors_[1], y_, cusparse_dtype<T>::value, CUSPARSE_SPMV_CSR_ALG1,
+        &buffer_size);
+    expect(status == CUSPARSE_STATUS_SUCCESS);
+    return buffer_size;
+  }
+
+  void apply(cusparseHandle_t handle, T *workspace)
+  {
+    auto status = cusparseSpMV(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, &scale_factors_[0],
+                               desc_, x_, &scale_factors_[1], y_, cusparse_dtype<T>::value,
+                               CUSPARSE_SPMV_CSR_ALG1, workspace);
+  }
+
+  cusparseSpMatDescr_t desc_;
+  cusparseDnVecDescr_t x_, y_;
+  gpu::vector<T> scale_factors_;
+};
+
+} // namespace asgard::gpu::sparse
+#endif

--- a/src/device/asgard_cusparse.hpp
+++ b/src/device/asgard_cusparse.hpp
@@ -131,7 +131,7 @@ struct sparse_matrix
     return buffer_size;
   }
 
-  void apply(cusparseHandle_t handle, T *workspace)
+  void apply(cusparseHandle_t handle, void *workspace)
   {
     auto status = cusparseSpMV(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, scale_factors_.data(),
                                desc_, x_, scale_factors_.data() + 1, y_, cusparse_dtype<T>::value,

--- a/src/device/asgard_cusparse.hpp
+++ b/src/device/asgard_cusparse.hpp
@@ -48,7 +48,7 @@ struct sparse_handle
   sparse_handle(sparse_handle const &other) = delete;
   sparse_handle& operator =(sparse_handle &other) = delete;
 
-  operator cusparseHandle_t() { return handle_; }
+  operator cusparseHandle_t() const { return handle_; }
 
   mutable cusparseHandle_t handle_;
 };

--- a/src/device/asgard_cusparse.hpp
+++ b/src/device/asgard_cusparse.hpp
@@ -50,6 +50,8 @@ struct sparse_handle
 
   operator cusparseHandle_t() const { return handle_; }
 
+  using htype = cusparseHandle_t;
+
   mutable cusparseHandle_t handle_;
 };
 
@@ -85,7 +87,7 @@ struct sparse_matrix
       y_(std::exchange(other.y_, nullptr))
   {}
 
-  sparse_matrix<T>& operator =(sparse_matrix<T> &&other)
+  sparse_matrix<T> &operator =(sparse_matrix<T> &&other)
   {
     sparse_matrix<T> tmp(std::move(other));
     std::swap(desc_, tmp.desc_);
@@ -95,7 +97,7 @@ struct sparse_matrix
   }
 
   sparse_matrix(sparse_matrix<T> const &other) = delete;
-  sparse_matrix<T>& operator =(sparse_matrix<T> const &other) = delete;
+  sparse_matrix<T> &operator =(sparse_matrix<T> const &other) = delete;
 
   ~sparse_matrix()
   {
@@ -122,8 +124,8 @@ struct sparse_matrix
     size_t buffer_size = 0;
 
     auto status = cusparseSpMV_bufferSize(
-        handle, CUSPARSE_OPERATION_NON_TRANSPOSE, &scale_factors_[0], desc_, x_,
-        &scale_factors_[1], y_, cusparse_dtype<T>::value, CUSPARSE_SPMV_CSR_ALG1,
+        handle, CUSPARSE_OPERATION_NON_TRANSPOSE, scale_factors_.data(), desc_, x_,
+        scale_factors_.data() + 1, y_, cusparse_dtype<T>::value, CUSPARSE_SPMV_CSR_ALG1,
         &buffer_size);
     expect(status == CUSPARSE_STATUS_SUCCESS);
     return buffer_size;
@@ -131,8 +133,8 @@ struct sparse_matrix
 
   void apply(cusparseHandle_t handle, T *workspace)
   {
-    auto status = cusparseSpMV(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, &scale_factors_[0],
-                               desc_, x_, &scale_factors_[1], y_, cusparse_dtype<T>::value,
+    auto status = cusparseSpMV(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, scale_factors_.data(),
+                               desc_, x_, scale_factors_.data() + 1, y_, cusparse_dtype<T>::value,
                                CUSPARSE_SPMV_CSR_ALG1, workspace);
   }
 

--- a/src/device/asgard_cusparse.hpp
+++ b/src/device/asgard_cusparse.hpp
@@ -17,9 +17,17 @@
 
 namespace asgard::gpu
 {
-
+/*!
+ * \brief RAII wrapper around the cusparse handle
+ *
+ * Unlike the global structure that holds a single cusparse handle,
+ * this one allows for more granular management of resource.
+ * In the future, this will allow us to handle multiple streams
+ * and multiple devices with multiple handles.
+ */
 struct sparse_handle
 {
+  //! \brief Constructor, creates the handle and sets the pointers to device mode
   sparse_handle()
   {
     auto status = cusparseCreate(&handle_);
@@ -27,6 +35,7 @@ struct sparse_handle
     status = cusparseSetPointerMode(handle_, CUSPARSE_POINTER_MODE_DEVICE);
     expect(status == CUSPARSE_STATUS_SUCCESS);
   }
+  //! \brief Free the handle
   ~sparse_handle()
   {
     if (handle_ != nullptr)
@@ -35,11 +44,11 @@ struct sparse_handle
       expect(status == CUSPARSE_STATUS_SUCCESS);
     }
   }
-
+  //! \brief The handle can be moved, via constructor or assignment
   sparse_handle(sparse_handle &&other)
     : handle_(std::exchange(other.handle_, nullptr))
   {}
-
+  //! \brief The handle can be moved, via constructor or assignment
   sparse_handle& operator =(sparse_handle &&other)
   {
     sparse_handle tmp(std::move(other));
@@ -47,32 +56,103 @@ struct sparse_handle
     return *this;
   }
 
+  //! \brief The handle cannot be copied, will lose unique ownership
   sparse_handle(sparse_handle const &other) = delete;
+  //! \brief The handle cannot be copied, will lose unique ownership
   sparse_handle& operator =(sparse_handle &other) = delete;
 
+  //! \brief Automatically converts to the cusparse handle
   operator cusparseHandle_t() const { return handle_; }
-
+  //! \brief Declare the internal type, will have a rocSparse mode in the future
   using htype = cusparseHandle_t;
 
+  //! \brief The handle variable
   mutable cusparseHandle_t handle_;
 };
 
+/*!
+ * \brief Helper template, converts float/double to CUDA_R_32F/64F
+ */
 template<typename T>
 struct cusparse_dtype
 {};
 
+//! \brief Float specialization for CUDA_R_32F
 template<> struct cusparse_dtype<float>
 {
+  //! \brief The corresponding cuda type
   static const cudaDataType value = CUDA_R_32F;
 };
+//! \brief Float specialization for CUDA_R_64F
 template<> struct cusparse_dtype<double>
 {
+  //! \brief The corresponding cuda type
   static const cudaDataType value = CUDA_R_64F;
 };
 
+/*!
+ * \brief Wrapper around cusparse matrix
+ *
+ * Inside the cusparse library, a simple matrix vector product is associated
+ * with multiple dynamically allocated data-structures.
+ * In addition to the cusparse handle, we also have a structure describing
+ * the sparse matrix, two structures describing the y/x vectors,
+ * and a raw pointer that is a scratch space buffer.
+ * During repeated calls to the same matrix vector operation, it is redundant
+ * to keep allocating/deallocating the same opaque structures, so we put them
+ * all in a single RAII container.
+ *
+ * The constructor will initialize the matrix structure with the compressed
+ * row storage format. Then a call to set_vectors() is needed to set the x/y
+ * vectors and the scalars for the matrix-vector product.
+ * This structure will hold aliases to the x/y pointers and the scalars
+ * will be pushed onto the GPU device, so they can be used directly from
+ * GPU memory with less synchronization.
+ * The vectors and scalars can be changed with a new call to set_vectors();
+ * however, this can affect the size of the buffer.
+ *
+ * After the vectors have been set, a call to size_workspace() will return
+ * the size of the workspace buffer. Note: that a change to the scalars in
+ * the multiplication can change the size of the buffer.
+ * The returned size is in units of <T>, e.g., the buffer can be allocated
+ * by directly giving the number to the constructor of gpu::vector<T>.
+ *
+ * Finally, the actual matrix-vector operation is computed with the apply()
+ * method, where we can pass a different handle (if using different streams
+ * on the same device) and we have to pass in the scratch buffer,
+ * that can be held externally and shared between multiple matrices.
+ *
+ * Here the input and the result appear as side-effects of the call.
+ * This is the unfortunate behavior of the cuSparse library, conversely
+ * if we accept x/y vectors during the call to apply() we will have to allocate
+ * and free multiple temporary variables.
+ *
+ * The "proper" usage of the sparse_matrix class is to be wrapped in a higher
+ * level structure, which in turn manages the input/output/scratch buffers
+ * and the arrays with indexes and values.
+ * This plays nicely with the global Kronecker approach, where we need to do
+ * multiple matrix-vector products per term for each global kron operation.
+ * Also, since the input and output have to be padded to complete
+ * the hierarchical structure of the sparse grid multi-index set,
+ * we are using the same input/output buffers for every sequence of calls
+ * The external wrapper can also hold aliases (or more appropriately own)
+ * the values array, which allow for the vals (i.e., matrix coefficients)
+ * to be overwritten between calls to apply.
+ *
+ * Example usage:
+ * \code
+ *   sparse_handle cusp;
+ *   sparse_matrix<double> sp_mat( ... );
+ *   sp_mat.set_vectors( ... );
+ *   gpu::vector<T> buffer( sp_mat.size_workspace(cusp) );
+ *   sp_mat.apply( cusp, buffer.data() );
+ * \endcode
+ */
 template<typename T>
-struct sparse_matrix
+class sparse_matrix
 {
+public:
+  //! \brief Constructor, initialize the matrix portion of the container
   sparse_matrix(int64_t num_rows, int64_t num_cols, int64_t nnz,
                 int *pntr, int *indx, T *vals)
     : desc_(nullptr), x_(nullptr), y_(nullptr)
@@ -84,13 +164,14 @@ struct sparse_matrix
                                     cusparse_dtype<T>::value);
     expect(status == CUSPARSE_STATUS_SUCCESS);
   }
+  //! \brief Container is movable, via constructor or assignment
   sparse_matrix(sparse_matrix<T> &&other)
     : desc_(std::exchange(other.desc_, nullptr)),
       x_(std::exchange(other.x_, nullptr)),
       y_(std::exchange(other.y_, nullptr)),
       scale_factors_(std::move(other.scale_factors_))
   {}
-
+  //! \brief Container is movable, via constructor or assignment
   sparse_matrix<T> &operator =(sparse_matrix<T> &&other)
   {
     sparse_matrix<T> tmp(std::move(other));
@@ -100,10 +181,11 @@ struct sparse_matrix
     std::swap(scale_factors_, tmp.scale_factors_);
     return *this;
   }
-
+  //! \brief The handle cannot be copied, will lose unique ownership
   sparse_matrix(sparse_matrix<T> const &other) = delete;
+  //! \brief The handle cannot be copied, will lose unique ownership
   sparse_matrix<T> &operator =(sparse_matrix<T> const &other) = delete;
-
+  //! \brief Destructor, frees the resources
   ~sparse_matrix()
   {
     if (desc_ != nullptr)
@@ -114,8 +196,14 @@ struct sparse_matrix
       cusparseDestroyDnVec(y_);
   }
 
+  //! \brief Sets the vectors and scalars for y = alpha * A * x + beta * y
   void set_vectors(int64_t n, T alpha, T *x, T beta, T *y)
   {
+    if (x_ != nullptr)
+      cusparseDestroyDnVec(x_);
+    if (y_ != nullptr)
+      cusparseDestroyDnVec(y_);
+
     auto status = cusparseCreateDnVec(&x_, n, x, cusparse_dtype<T>::value);
     expect(status == CUSPARSE_STATUS_SUCCESS);
     status = cusparseCreateDnVec(&y_, n, y, cusparse_dtype<T>::value);
@@ -130,25 +218,30 @@ struct sparse_matrix
     size_t buffer_size = 0;
 
     auto status = cusparseSpMV_bufferSize(
-        handle, CUSPARSE_OPERATION_NON_TRANSPOSE, scale_factors_.data(), desc_, x_,
-        scale_factors_.data() + 1, y_, cusparse_dtype<T>::value, CUSPARSE_SPMV_CSR_ALG1,
-        &buffer_size);
+        handle, CUSPARSE_OPERATION_NON_TRANSPOSE, scale_factors_.data(), desc_,
+        x_, scale_factors_.data() + 1, y_, cusparse_dtype<T>::value,
+        CUSPARSE_SPMV_CSR_ALG1, &buffer_size);
     expect(status == CUSPARSE_STATUS_SUCCESS);
     return 1 + buffer_size / sizeof(T);
   }
-
+  //! \brief Computes the matrix vector product with x/y as defined in set_vectors()
   void apply(cusparseHandle_t handle, void *workspace)
   {
-    auto status = cusparseSpMV(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, scale_factors_.data(),
-                               desc_, x_, scale_factors_.data() + 1, y_, cusparse_dtype<T>::value,
-                               CUSPARSE_SPMV_CSR_ALG1, workspace);
+    auto status = cusparseSpMV(
+        handle, CUSPARSE_OPERATION_NON_TRANSPOSE, scale_factors_.data(), desc_,
+        x_, scale_factors_.data() + 1, y_, cusparse_dtype<T>::value,
+        CUSPARSE_SPMV_CSR_ALG1, workspace);
     expect(status == CUSPARSE_STATUS_SUCCESS);
   }
 
+private:
+  //! \brief The matrix description
   cusparseSpMatDescr_t desc_;
+  //! \brief The cuda versions of the x/y vectors
   cusparseDnVecDescr_t x_, y_;
+  //! \brief Hold the scalars for the matrix-vector product
   gpu::vector<T> scale_factors_;
 };
 
-} // namespace asgard::gpu::sparse
+} // namespace asgard::gpu
 #endif

--- a/src/device/asgard_glkronmult_cpu.cpp
+++ b/src/device/asgard_glkronmult_cpu.cpp
@@ -72,7 +72,7 @@ void global_cpu(permutes const &perms,
                 connect_1d const &conn, std::vector<int> const &terms,
                 std::vector<std::vector<precision>> const &vals,
                 precision alpha, precision const *x, precision *y,
-                precision *worspace)
+                precision *w1, precision *w2)
 {
   int const num_dimensions = ilist.stride();
   if (num_dimensions == 1) // no need to split anything
@@ -80,15 +80,12 @@ void global_cpu(permutes const &perms,
     for (int t : terms)
     {
       global_cpu_one(ilist, dsort, 0, permutes::matrix_fill::both, conn,
-                     vals[t].data(), x, worspace);
-      lib_dispatch::axpy<resource::host>(ilist.num_strips(), alpha, worspace, 1, y, 1);
+                     vals[t].data(), x, w1);
+      lib_dispatch::axpy<resource::host>(ilist.num_strips(), alpha, w1, 1, y, 1);
     }
   }
   else
   {
-    precision *w1 = worspace;
-    precision *w2 = worspace + ilist.num_strips();
-
     for (int t : terms)
     {
       for (size_t i = 0; i < perms.fill.size(); i++)
@@ -158,12 +155,9 @@ void global_cpu(int num_dimensions,
                 std::vector<std::vector<int>> const &gdiag,
                 std::vector<std::vector<precision>> const &gvals,
                 std::vector<int> const &terms, precision const *x, precision *y,
-                precision *workspace)
+                precision *w1, precision *w2)
 {
   int64_t const num_rows = static_cast<int64_t>(gpntr.front().size() - 1);
-
-  precision *w1 = workspace;
-  precision *w2 = workspace + num_rows;
 
   for (int t : terms)
   {
@@ -200,14 +194,14 @@ template void global_cpu(int, std::vector<permutes> const &,
                          std::vector<std::vector<int>> const &,
                          std::vector<std::vector<double>> const &,
                          std::vector<int> const &, double const *, double *,
-                         double *workspace);
+                         double *, double *);
 
 template void global_cpu(permutes const &perms,
                          vector2d<int> const &ilist, dimension_sort const &dsort,
                          connect_1d const &conn, std::vector<int> const &terms,
                          std::vector<std::vector<double>> const &vals,
                          double alpha, double const *x, double *y,
-                         double *worspace);
+                         double *, double *);
 #endif
 #ifdef ASGARD_ENABLE_FLOAT
 template void global_cpu(int, std::vector<permutes> const &,
@@ -216,13 +210,13 @@ template void global_cpu(int, std::vector<permutes> const &,
                          std::vector<std::vector<int>> const &,
                          std::vector<std::vector<float>> const &,
                          std::vector<int> const &, float const *, float *,
-                         float *workspace);
+                         float *, float *);
 template void global_cpu(permutes const &perms,
                          vector2d<int> const &ilist, dimension_sort const &dsort,
                          connect_1d const &conn, std::vector<int> const &terms,
                          std::vector<std::vector<float>> const &vals,
                          float alpha, float const *x, float *y,
-                         float *worspace);
+                         float *, float *);
 #endif
 
 #endif

--- a/src/device/asgard_glkronmult_gpu.cpp
+++ b/src/device/asgard_glkronmult_gpu.cpp
@@ -62,9 +62,11 @@ global_gpu_operations<precision>
         if (gvals_[vid].empty())
           gvals_[vid] = gvals[vid];
 
-        mats_.push_back(gpu::sparse_matrix<precision>(num_rows, num_rows, gindx_[pid].size(),
-                                                      gpntr_[pid].data(), gindx_[pid].data(),
-                                                      gvals_[vid].data()));
+        mats_.emplace_back(
+            gpu::sparse_matrix<precision>(num_rows, num_rows, gindx_[pid].size(),
+                                          gpntr_[pid].data(), gindx_[pid].data(),
+                                          gvals_[vid].data())
+        );
 
         if (d == 0 and d == dims - 1) // only one matrix
         {

--- a/src/device/asgard_glkronmult_gpu.cpp
+++ b/src/device/asgard_glkronmult_gpu.cpp
@@ -123,10 +123,19 @@ global_gpu_operations(gpu::sparse_handle const &hndl, int num_dimensions,
 }
 
 #ifdef ASGARD_ENABLE_DOUBLE
-template class global_gpu_operations<double>;
+template struct global_gpu_operations<double>;
+
+template global_gpu_operations<double>::global_gpu_operations(gpu::sparse_handle const &hndl, int num_dimensions,
+                      std::vector<permutes> const &perms,
+                      std::vector<std::vector<int>> const &gpntr,
+                      std::vector<std::vector<int>> const &gindx,
+                      std::vector<std::vector<precision>> const &gvals,
+                      std::vector<int> const &terms,
+                      precision const *x, precision *y,
+                      precision *work1, precision *work2);
 #endif
 #ifdef ASGARD_ENABLE_FLOAT
-template class global_gpu_operations<float>;
+template struct global_gpu_operations<float>;
 #endif
 
 #endif

--- a/src/device/asgard_glkronmult_gpu.cpp
+++ b/src/device/asgard_glkronmult_gpu.cpp
@@ -1,0 +1,126 @@
+
+#include "asgard_kronmult.hpp"
+
+namespace asgard::kronmult
+{
+#ifdef KRON_MODE_GLOBAL
+#ifdef ASGARD_USE_CUDA
+
+template<typename precision>
+void split_pattern(std::vector<int> const &pntr, std::vector<int> const &indx,
+                   std::vector<int> const &diag, std::vector<precision> const &vals,
+                   permutes::matrix_fill mode,
+                   gpu::vector<int> &gpntr, gpu::vector<int> &gindx,
+                   gpu::vector<int> &gvals)
+{
+  if (mode == permutes::matrix_fill::both)
+  {
+    if (gpntr.empty())
+      gpntr = pntr;
+    if (gindx.empty())
+      gindx = indx;
+    gvals = vals;
+  }
+
+  // copy the lower/upper part of the pattern into the vectors prefixed with "a"
+  std::vector<int> apntr(pntr.size());
+  std::vector<int> aindx;
+  aindx.reserve(indx.size());
+  std::vector<precision> avals;
+  avals.reserve(avals.size());
+
+  for (size_t r = 0; r < apntr.size(); r++)
+  {
+    apntr[r] = static_cast<int>(aindx.size());
+    if (mode == permutes::matrix_fill::lower)
+      for (int j = pntr[r]; r < diag[r]; r++)
+      {
+        aindx.push_back(indx[j]);
+        avals.push_back(vals[j]);
+      }
+    else
+      for (int j = diag[r]; r < pntr[r + 1]; r++)
+      {
+        aindx.push_back(indx[j]);
+        avals.push_back(vals[j]);
+      }
+  }
+  apntr.back() = static_cast<int>(aindx.size());
+
+  // send the result to the gpu
+  if (gpntr.empty())
+    gpntr = apntr;
+  if (gindx.empty())
+    gindx = aindx;
+  gvals = avals;
+}
+
+template<typename precision>
+global_gpu_operations::
+global_gpu_operations(cusparseHandle_t cuh, int num_dimensions,
+                      std::vector<permutes> const &perms,
+                      std::vector<std::vector<int>> const &gpntr,
+                      std::vector<std::vector<int>> const &gindx,
+                      std::vector<std::vector<int>> const &gdiag,
+                      std::vector<std::vector<precision>> const &gvals,
+                      std::vector<int> const &terms,
+                      precision const *x, precision *y,
+                      precision *work1, precision *work2)
+    // each matrix has 3 potential variants (both, lower, upper)
+  : gpntr_(3 * gpntr.size()), gindx_(3 * gindx.size()), gvals_(3 * gvals.size()),
+{
+  int64_t const num_rows = static_cast<int64_t>(gpntr.front().size() - 1);
+
+  mats_.reserve(terms.size() * num_dimensions) // max possible number of matrices
+
+  for (int t : terms)
+  {
+    // terms can have different effective dimension, since some of them are identity
+    permutes const &perm = perms[t];
+    int const dims       = perm.num_dimensions();
+    if (dims == 0)
+      continue;
+
+    for (size_t i = 0; i < perm.fill.size(); i++)
+    {
+      precision *w1 = work1;
+      precision *w2 = work2;
+
+      precision ybeta = (i == 0) ? 0 : 1; // first one zeros out y, then we increment
+
+      for (int d = 0; d < dims; d++)
+      {
+        int dir                    = perm.direction[i][d];
+        permutes::matrix_fill mode = perm.fill[i][d];
+        int const mode_id          = (mode == permutes::matrix_fill::both) ? 0 : ((mode == permutes::matrix_fill::lower) ? 1 : 0);
+
+        int const pid = 3 * dir + mode_id;
+        int const vid = 3 * (t * num_dimensions + dir) + mode_id;
+
+        if (gvals_[vid].empty()) // must build and load this pattern
+        {
+          split_pattern(gpntr[dir], gindx[dir], gdiag[dir], gvals[t * num_dimensions + dir],
+                        mode, gpntr_[pid], gindx_[pid], gvals_[vid]);
+        }
+
+        mats_.push_back(gpu::sparse_matrix(num_rows, num_rows, gindx_[pid].size(),
+                                           gpntr_[pid].data(), gindx_[pid].data(), gvals_[vid].data());
+
+        if (d == 0 and d == dims - 1) // only one matrix
+          mats_.back().set_vectors(num_rows, precision{1}, x, ybeta, y);
+        else if (d == 0)
+          mats_.back().set_vectors(num_rows, precision{1}, x, precision{0}, w2);
+        else if (d == dims - 1)
+          mats_.back().set_vectors(num_rows, precision{1}, w1, ybeta, y);
+        else
+          mats_.back().set_vectors(num_rows, precision{1}, w1, precision{0}, w2);
+
+        std::swap(w1, w2);
+      }
+    }
+  }
+}
+
+#endif
+#endif
+} // namespace asgard::kronmult

--- a/src/device/asgard_glkronmult_gpu.cpp
+++ b/src/device/asgard_glkronmult_gpu.cpp
@@ -57,7 +57,7 @@ void split_pattern(std::vector<int> const &pntr, std::vector<int> const &indx,
 
 template<typename precision>
 global_gpu_operations::
-global_gpu_operations(cusparseHandle_t cuh, int num_dimensions,
+global_gpu_operations(gpu::sparse_handle const &cuh, int num_dimensions,
                       std::vector<permutes> const &perms,
                       std::vector<std::vector<int>> const &gpntr,
                       std::vector<std::vector<int>> const &gindx,

--- a/src/device/asgard_glkronmult_gpu.cpp
+++ b/src/device/asgard_glkronmult_gpu.cpp
@@ -56,17 +56,18 @@ void split_pattern(std::vector<int> const &pntr, std::vector<int> const &indx,
 }
 
 template<typename precision>
-global_gpu_operations::
-global_gpu_operations(gpu::sparse_handle const &hndl, int num_dimensions,
-                      std::vector<permutes> const &perms,
-                      std::vector<std::vector<int>> const &gpntr,
-                      std::vector<std::vector<int>> const &gindx,
-                      std::vector<std::vector<precision>> const &gvals,
-                      std::vector<int> const &terms,
-                      precision const *x, precision *y,
-                      precision *work1, precision *work2)
+global_gpu_operations<precision>
+::global_gpu_operations(gpu::sparse_handle const &hndl, int num_dimensions,
+                        std::vector<permutes> const &perms,
+                        std::vector<std::vector<int>> const &gpntr,
+                        std::vector<std::vector<int>> const &gindx,
+                        std::vector<std::vector<precision>> const &gvals,
+                        std::vector<int> const &terms,
+                        precision *x, precision *y,
+                        precision *work1, precision *work2)
     // each matrix has 3 potential variants (both, lower, upper)
-  : hndl(hndl_), gpntr_(gpntr.size()), gindx_(gindx.size()), gvals_(gvals.size())
+  : hndl_(hndl), gpntr_(gpntr.size()), gindx_(gindx.size()), gvals_(gvals.size()),
+    buffer_(nullptr)
 {
   int64_t const num_rows = static_cast<int64_t>(gpntr.front().size() - 1);
 
@@ -125,14 +126,14 @@ global_gpu_operations(gpu::sparse_handle const &hndl, int num_dimensions,
 #ifdef ASGARD_ENABLE_DOUBLE
 template struct global_gpu_operations<double>;
 
-template global_gpu_operations<double>::global_gpu_operations(gpu::sparse_handle const &hndl, int num_dimensions,
-                      std::vector<permutes> const &perms,
-                      std::vector<std::vector<int>> const &gpntr,
-                      std::vector<std::vector<int>> const &gindx,
-                      std::vector<std::vector<precision>> const &gvals,
-                      std::vector<int> const &terms,
-                      precision const *x, precision *y,
-                      precision *work1, precision *work2);
+// template global_gpu_operations<double>::global_gpu_operations(gpu::sparse_handle const &hndl, int num_dimensions,
+//                       std::vector<permutes> const &perms,
+//                       std::vector<std::vector<int>> const &gpntr,
+//                       std::vector<std::vector<int>> const &gindx,
+//                       std::vector<std::vector<precision>> const &gvals,
+//                       std::vector<int> const &terms,
+//                       precision const *x, precision *y,
+//                       precision *work1, precision *work2);
 #endif
 #ifdef ASGARD_ENABLE_FLOAT
 template struct global_gpu_operations<float>;

--- a/src/device/asgard_glkronmult_gpu.cpp
+++ b/src/device/asgard_glkronmult_gpu.cpp
@@ -123,17 +123,14 @@ global_gpu_operations<precision>
   }
 }
 
+template<typename precision>
+void global_gpu_operations<precision>::update_vals()
+{
+  //
+}
+
 #ifdef ASGARD_ENABLE_DOUBLE
 template struct global_gpu_operations<double>;
-
-// template global_gpu_operations<double>::global_gpu_operations(gpu::sparse_handle const &hndl, int num_dimensions,
-//                       std::vector<permutes> const &perms,
-//                       std::vector<std::vector<int>> const &gpntr,
-//                       std::vector<std::vector<int>> const &gindx,
-//                       std::vector<std::vector<precision>> const &gvals,
-//                       std::vector<int> const &terms,
-//                       precision const *x, precision *y,
-//                       precision *work1, precision *work2);
 #endif
 #ifdef ASGARD_ENABLE_FLOAT
 template struct global_gpu_operations<float>;

--- a/src/device/asgard_glkronmult_gpu.cpp
+++ b/src/device/asgard_glkronmult_gpu.cpp
@@ -62,11 +62,9 @@ global_gpu_operations<precision>
         if (gvals_[vid].empty())
           gvals_[vid] = gvals[vid];
 
-        mats_.emplace_back(
-            gpu::sparse_matrix<precision>(num_rows, num_rows, gindx_[pid].size(),
+        mats_.emplace_back(num_rows, num_rows, gindx_[pid].size(),
                                           gpntr_[pid].data(), gindx_[pid].data(),
-                                          gvals_[vid].data())
-        );
+                                          gvals_[vid].data());
 
         if (d == 0 and d == dims - 1) // only one matrix
         {

--- a/src/device/asgard_kronmult.hpp
+++ b/src/device/asgard_kronmult.hpp
@@ -294,6 +294,9 @@ public:
                         precision *x, precision *y,
                         precision *work1, precision *work2);
 
+  //! \brief Update the values of the sparse matrices
+  void update_vals();
+
   //! \brief Returns the maximum size of the workspace
   int64_t workspace_size() const
   {
@@ -311,6 +314,8 @@ public:
     for(auto &m : mats_)
       m.apply(hndl_, buffer_);
   }
+  //! \brief Checks if the operation has been set
+  operator bool() const { return (not gpntr_.empty()); }
 
 private:
   gpu::sparse_handle::htype hndl_;

--- a/src/device/asgard_kronmult.hpp
+++ b/src/device/asgard_kronmult.hpp
@@ -281,29 +281,35 @@ void global_cpu(int num_dimensions,
 template<typename precision>
 struct global_gpu_operations
 {
-  global_gpu_operations() : cuh_(nullptr), buffer(nullptr)
+  global_gpu_operations() : hndl_(nullptr), buffer(nullptr)
   {}
 
-  global_gpu_operations(gpu::sparse_handle const &cuh, int num_dimensions,
+  global_gpu_operations(gpu::sparse_handle const &hndl_, int num_dimensions,
                         std::vector<permutes> const &perms,
                         std::vector<std::vector<int>> const &gpntr,
                         std::vector<std::vector<int>> const &gindx,
-                        std::vector<std::vector<int>> const &gdiag,
                         std::vector<std::vector<precision>> const &gvals,
                         std::vector<int> const &terms,
                         precision const *x, precision *y,
                         precision *work1, precision *work2);
 
   //! \brief Returns the maximum size of the workspace
-  int64_t workspace_size(gpu::sparse_handle const &handle) const
+  int64_t workspace_size() const
   {
     size_t num = 0;
     for(auto const &m : mats_)
-      num = std::max(num, m.size_workspace(handle));
+      num = std::max(num, m.size_workspace(hndl_));
     return static_cast<int64_t>(num);
   }
 
-  cusparseHandle_t cuh_;
+  //! \brief Perform the global kron operation
+  void execute() const
+  {
+    for(auto const &m : mats_)
+      m.apply(hndl_, buffer);
+  }
+
+  gpu::sparse_handle::htype hndl_;
   std::vector<gpu::vector<int>> gpntr_;
   std::vector<gpu::vector<int>> gindx_;
   std::vector<gpu::vector<precision>> gvals_;

--- a/src/device/asgard_kronmult.hpp
+++ b/src/device/asgard_kronmult.hpp
@@ -276,6 +276,33 @@ void global_cpu(int num_dimensions,
                 std::vector<std::vector<precision>> const &gvals,
                 std::vector<int> const &terms, precision const *x, precision *y,
                 precision *worspace);
+
+#ifdef ASGARD_USE_CUDA
+template<typename precision>
+struct global_gpu_operations
+{
+  global_gpu_operations() : cuh_(nullptr), buffer(nullptr)
+  {}
+
+  global_gpu_operations(cusparseHandle_t cuh, int num_dimensions,
+                        std::vector<permutes> const &perms,
+                        std::vector<std::vector<int>> const &gpntr,
+                        std::vector<std::vector<int>> const &gindx,
+                        std::vector<std::vector<int>> const &gdiag,
+                        std::vector<std::vector<precision>> const &gvals,
+                        std::vector<int> const &terms,
+                        precision const *x, precision *y,
+                        precision *work1, precision *work2);
+
+  cusparseHandle_t cuh_;
+  std::vector<gpu::vector<int>> gpntr_;
+  std::vector<gpu::vector<int>> gindx_;
+  std::vector<gpu::vector<precision>> gvals_;
+
+  std::vector<gpu::sparse_matrix<precision>> mats_;
+  mutable precision *buffer;
+};
+#endif
 #endif
 
 } // namespace asgard::kronmult

--- a/src/device/asgard_kronmult.hpp
+++ b/src/device/asgard_kronmult.hpp
@@ -349,7 +349,7 @@ public:
   int64_t size_workspace() const
   {
     size_t num = 0;
-    for(auto const &m : mats_)
+    for (auto const &m : mats_)
       num = std::max(num, m.size_workspace(hndl_));
     return static_cast<int64_t>(num);
   }
@@ -359,7 +359,7 @@ public:
   //! \brief Perform the global kron operation
   void execute() const
   {
-    for(auto &m : mats_)
+    for (auto &m : mats_)
       m.apply(hndl_, buffer_);
   }
   //! \brief Checks if the operation has been set

--- a/src/device/asgard_kronmult.hpp
+++ b/src/device/asgard_kronmult.hpp
@@ -252,7 +252,7 @@ void global_cpu(permutes const &perms,
                 connect_1d const &conn, std::vector<int> const &terms,
                 std::vector<std::vector<precision>> const &vals,
                 precision alpha, precision const *x, precision *y,
-                precision *worspace);
+                precision *worspace1, precision *worspace2);
 
 /*!
  * \brief Perform global Kronecked product
@@ -275,7 +275,7 @@ void global_cpu(int num_dimensions,
                 std::vector<std::vector<int>> const &gdiag,
                 std::vector<std::vector<precision>> const &gvals,
                 std::vector<int> const &terms, precision const *x, precision *y,
-                precision *worspace);
+                precision *worspace1, precision *worspace2);
 
 #ifdef ASGARD_USE_CUDA
 template<typename precision>
@@ -284,7 +284,7 @@ struct global_gpu_operations
   global_gpu_operations() : cuh_(nullptr), buffer(nullptr)
   {}
 
-  global_gpu_operations(cusparseHandle_t cuh, int num_dimensions,
+  global_gpu_operations(gpu::sparse_handle const &cuh, int num_dimensions,
                         std::vector<permutes> const &perms,
                         std::vector<std::vector<int>> const &gpntr,
                         std::vector<std::vector<int>> const &gindx,
@@ -293,6 +293,15 @@ struct global_gpu_operations
                         std::vector<int> const &terms,
                         precision const *x, precision *y,
                         precision *work1, precision *work2);
+
+  //! \brief Returns the maximum size of the workspace
+  int64_t workspace_size(gpu::sparse_handle const &handle) const
+  {
+    size_t num = 0;
+    for(auto const &m : mats_)
+      num = std::max(num, m.size_workspace(handle));
+    return static_cast<int64_t>(num);
+  }
 
   cusparseHandle_t cuh_;
   std::vector<gpu::vector<int>> gpntr_;

--- a/src/device/asgard_kronmult.hpp
+++ b/src/device/asgard_kronmult.hpp
@@ -285,7 +285,7 @@ public:
   global_gpu_operations() : hndl_(nullptr), buffer_(nullptr)
   {}
 
-  global_gpu_operations(gpu::sparse_handle const &hndl_, int num_dimensions,
+  global_gpu_operations(gpu::sparse_handle const &hndl, int num_dimensions,
                         std::vector<permutes> const &perms,
                         std::vector<std::vector<int>> const &gpntr,
                         std::vector<std::vector<int>> const &gindx,

--- a/src/device/asgard_kronmult.hpp
+++ b/src/device/asgard_kronmult.hpp
@@ -279,9 +279,10 @@ void global_cpu(int num_dimensions,
 
 #ifdef ASGARD_USE_CUDA
 template<typename precision>
-struct global_gpu_operations
+class global_gpu_operations
 {
-  global_gpu_operations() : hndl_(nullptr), buffer(nullptr)
+public:
+  global_gpu_operations() : hndl_(nullptr), buffer_(nullptr)
   {}
 
   global_gpu_operations(gpu::sparse_handle const &hndl_, int num_dimensions,
@@ -290,7 +291,7 @@ struct global_gpu_operations
                         std::vector<std::vector<int>> const &gindx,
                         std::vector<std::vector<precision>> const &gvals,
                         std::vector<int> const &terms,
-                        precision const *x, precision *y,
+                        precision *x, precision *y,
                         precision *work1, precision *work2);
 
   //! \brief Returns the maximum size of the workspace
@@ -301,21 +302,24 @@ struct global_gpu_operations
       num = std::max(num, m.size_workspace(hndl_));
     return static_cast<int64_t>(num);
   }
+  //! \brief Set the work-buffer for the gpu sparse method
+  void set_buffer(void *buffer) { buffer_ = buffer; }
 
   //! \brief Perform the global kron operation
   void execute() const
   {
-    for(auto const &m : mats_)
-      m.apply(hndl_, buffer);
+    for(auto &m : mats_)
+      m.apply(hndl_, buffer_);
   }
 
+private:
   gpu::sparse_handle::htype hndl_;
   std::vector<gpu::vector<int>> gpntr_;
   std::vector<gpu::vector<int>> gindx_;
   std::vector<gpu::vector<precision>> gvals_;
 
-  std::vector<gpu::sparse_matrix<precision>> mats_;
-  mutable precision *buffer;
+  mutable std::vector<gpu::sparse_matrix<precision>> mats_;
+  mutable void *buffer_;
 };
 #endif
 #endif

--- a/src/device/asgard_kronmult.hpp
+++ b/src/device/asgard_kronmult.hpp
@@ -294,11 +294,8 @@ public:
                         precision *x, precision *y,
                         precision *work1, precision *work2);
 
-  //! \brief Update the values of the sparse matrices
-  void update_vals();
-
   //! \brief Returns the maximum size of the workspace
-  int64_t workspace_size() const
+  int64_t size_workspace() const
   {
     size_t num = 0;
     for(auto const &m : mats_)
@@ -317,7 +314,20 @@ public:
   //! \brief Checks if the operation has been set
   operator bool() const { return (not gpntr_.empty()); }
 
-private:
+  //! \brief Returns true if the values at vid are not used
+  bool empty_values(int vid) const
+  {
+    return gvals_[vid].empty();
+  }
+
+  //! \brief Overwrites the existing values of a vector at vid
+  void update_values(int vid, std::vector<precision> const &cpu_values)
+  {
+    expect(gvals_[vid].size() == static_cast<int64_t>(cpu_values.size()));
+    fk::copy_to_device(gvals_[vid].data(), cpu_values.data(), gvals_[vid].size());
+  }
+
+//private:
   gpu::sparse_handle::htype hndl_;
   std::vector<gpu::vector<int>> gpntr_;
   std::vector<gpu::vector<int>> gindx_;

--- a/src/device/asgard_kronmult_common.hpp
+++ b/src/device/asgard_kronmult_common.hpp
@@ -11,6 +11,8 @@
 #include <cuda_runtime.h>
 #include <sm_60_atomic_functions.h>
 
+#include "asgard_cusparse.hpp"
+
 #define ASGARD_GPU_WARP_SIZE 32
 
 #endif

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -127,9 +127,9 @@ simple_gmres_euler(const P dt, matrix_entry mentry,
         lib_dispatch::axpy<resrc>(y.size(), alpha, x_in.data(), 1, y.data(), 1);
       },
       fk::vector<P, mem_type::view, resrc>(x), b,
-      [&](fk::vector<P, mem_type::view, resrc> &x) -> void {
+      [&](fk::vector<P, mem_type::view, resrc> &x_in) -> void {
           tools::time_event performance("kronmult - preconditioner", pc.size());
-          apply_diagonal_precond(pc, dt, x);
+          apply_diagonal_precond(pc, dt, x_in);
       },
       restart, max_iter, tolerance);
 }

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -245,9 +245,6 @@ explicit_advance(PDE<P> const &pde, matrix_list<P> &operator_matrices,
   }
   reduce_results(fx, reduced_fx, plan, get_rank());
 
-  for(auto s : fx)
-    std::cout << s << "\n";
-
   if (pde.num_sources > 0)
   {
     auto const sources =

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -245,6 +245,9 @@ explicit_advance(PDE<P> const &pde, matrix_list<P> &operator_matrices,
   }
   reduce_results(fx, reduced_fx, plan, get_rank());
 
+  for(auto s : fx)
+    std::cout << s << "\n";
+
   if (pde.num_sources > 0)
   {
     auto const sources =


### PR DESCRIPTION
Another code dump:
* global sparse operations now use the cusparse library
* handles the logic of doing all work on the GPU without moving back to the CPU side for the global kronecker
* did not use the existing sparse method, wanted to avoid allocations and keep data-structures persistent
* removed the whole pinned memory thing