### PR TITLE
diffusion_1 pde missing time dependence?

### DIFF
--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -549,7 +549,7 @@ public:
       // each set of analytical solution functions must have num_dim functions
       for (const auto &md_func : exact_vector_funcs)
       {
-        expect(std::clamp(md_func.size(), static_cast<size_t>(num_dims), static_cast<size_t>(num_dims) + 1u) == md_func.size());
+        expect(md_func.size() == static_cast<size_t>(num_dims) or md_func.size() == static_cast<size_t>(num_dims + 1));
       }
     }
 

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -549,7 +549,7 @@ public:
       // each set of analytical solution functions must have num_dim functions
       for (const auto &md_func : exact_vector_funcs)
       {
-        expect(md_func.size() == static_cast<unsigned>(num_dims));
+        expect(std::clamp(md_func.size(), static_cast<size_t>(num_dims), static_cast<size_t>(num_dims) + 1u) == md_func.size());
       }
     }
 

--- a/src/pde/pde_continuity1.hpp
+++ b/src/pde/pde_continuity1.hpp
@@ -80,6 +80,13 @@ private:
 
   static P exact_time(P const time) { return std::sin(time); }
 
+  static fk::vector<P> exact_time_v(fk::vector<P> x, P const time)
+  {
+    x.resize(1);
+    x[0] = exact_time(time);
+    return x;
+  }
+
   // specify source functions...
 
   // source 0
@@ -159,7 +166,7 @@ private:
 
   // define exact soln functions
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {
-      exact_solution_dim0};
+      exact_solution_dim0, exact_time_v};
 
   inline static scalar_func<P> const exact_scalar_func_ = exact_time;
 };

--- a/src/pde/pde_continuity2.hpp
+++ b/src/pde/pde_continuity2.hpp
@@ -86,6 +86,13 @@ private:
 
   static P exact_time(P const time) { return std::sin(2.0 * time); }
 
+  static fk::vector<P> exact_time_v(fk::vector<P> x, P const time)
+  {
+    x.resize(1);
+    x[0] = exact_time(time);
+    return x;
+  }
+
   // specify source functions...
 
   // source 0
@@ -254,7 +261,7 @@ private:
 
   // define exact soln
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {
-      exact_solution_dim0, exact_solution_dim1};
+      exact_solution_dim0, exact_solution_dim1, exact_time_v};
 
   inline static scalar_func<P> const exact_scalar_func_ = exact_time;
 };

--- a/src/pde/pde_continuity3.hpp
+++ b/src/pde/pde_continuity3.hpp
@@ -96,6 +96,13 @@ private:
 
   static P exact_time(P const time) { return std::sin(2.0 * time); }
 
+  static fk::vector<P> exact_time_v(fk::vector<P> x, P const time)
+  {
+    x.resize(1);
+    x[0] = exact_time(time);
+    return x;
+  }
+
   // specify source functions...
 
   // source 0
@@ -348,7 +355,7 @@ private:
 
   // define exact soln
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {
-      exact_solution_dim0, exact_solution_dim1, exact_solution_dim2};
+      exact_solution_dim0, exact_solution_dim1, exact_solution_dim2, exact_time_v};
 
   inline static scalar_func<P> const exact_scalar_func_ = exact_time;
 };

--- a/src/pde/pde_continuity6.hpp
+++ b/src/pde/pde_continuity6.hpp
@@ -126,10 +126,17 @@ private:
 
   static P exact_time(P const time) { return std::sin(targ * time); }
 
+  static fk::vector<P> exact_time_v(fk::vector<P> x, P const time)
+  {
+    x.resize(1);
+    x[0] = exact_time(time);
+    return x;
+  }
+
   // define exact soln
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {
-      exact_solution_x,  exact_solution_y,  exact_solution_z,
-      exact_solution_vx, exact_solution_vy, exact_solution_vz};
+      exact_solution_x, exact_solution_y, exact_solution_z,
+      exact_solution_vx, exact_solution_vy, exact_solution_vz, exact_time_v};
 
   // specify source functions...
 

--- a/src/pde/pde_diffusion1.hpp
+++ b/src/pde/pde_diffusion1.hpp
@@ -151,10 +151,10 @@ private:
   /* exact solutions */
   static fk::vector<P> exact_solution_0(fk::vector<P> const x, P const t = 0)
   {
-    ignore(t);
     fk::vector<P> fx(x.size());
+    P const time = source_0_t(t);
     std::transform(x.begin(), x.end(), fx.begin(),
-                   [](P const &x_v) { return std::cos(nu * x_v); });
+                   [time](P const &x_v) { return std::cos(nu * x_v) * time; });
     return fx;
   }
 

--- a/src/pde/pde_diffusion1.hpp
+++ b/src/pde/pde_diffusion1.hpp
@@ -151,17 +151,22 @@ private:
   /* exact solutions */
   static fk::vector<P> exact_solution_0(fk::vector<P> const x, P const t = 0)
   {
+    ignore(t);
     fk::vector<P> fx(x.size());
-    P const time = source_0_t(t);
     std::transform(x.begin(), x.end(), fx.begin(),
-                   [time](P const &x_v) { return std::cos(nu * x_v) * time; });
+                   [](P const &x_v) { return std::cos(nu * x_v); });
     return fx;
   }
 
-  static P exact_time(P const time) { return source_0_t(time); }
+  static fk::vector<P> exact_time(fk::vector<P> x, P const time)
+  {
+    x.resize(1);
+    x[0] = source_0_t(time);
+    return x;
+  }
 
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {
-      exact_solution_0};
+      exact_solution_0, exact_time};
 
   /* This is not used ever */
   inline static scalar_func<P> const exact_scalar_func_ = source_0_t;

--- a/src/pde/pde_diffusion2.hpp
+++ b/src/pde/pde_diffusion2.hpp
@@ -114,13 +114,20 @@ private:
 
   static P exact_time(P const time)
   {
-    static double neg_two_pi_squared = -2.0 * PI * PI;
+    constexpr P neg_two_pi_squared = static_cast<P>(-2.0 * PI * PI);
 
     return std::exp(neg_two_pi_squared * time);
   }
 
+  static fk::vector<P> exact_time_v(fk::vector<P> x, P const time)
+  {
+    x.resize(1);
+    x[0] = exact_time(time);
+    return x;
+  }
+
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {
-      exact_solution, exact_solution};
+      exact_solution, exact_solution, exact_time_v};
 
   /* This is not used ever */
   static P exact_scalar_func(P const t)

--- a/src/transformations.hpp
+++ b/src/transformations.hpp
@@ -92,7 +92,7 @@ template<typename P, typename F>
 fk::vector<P> forward_transform(
     dimension<P> const &dim, F function, g_func_type<P> dv_func,
     basis::wavelet_transform<P, resource::host> const &transformer,
-    P const t = 0)
+    P const time = 0)
 {
   int const num_levels = dim.get_level();
   int const degree     = dim.get_degree();
@@ -148,15 +148,15 @@ fk::vector<P> forward_transform(
     }();
 
     // get the f(v) initial condition at the quadrature points.
-    fk::vector<P> f_here = function(mapped_roots, t);
+    fk::vector<P> f_here = function(mapped_roots, time);
 
     // apply dv to f(v)
     if (dv_func)
     {
       std::transform(f_here.begin(), f_here.end(), mapped_roots.begin(),
                      f_here.begin(),
-                     [dv_func, t](P &f_elem, P const &x_elem) -> P {
-                       return f_elem * dv_func(x_elem, t);
+                     [dv_func, time](P &f_elem, P const &x_elem) -> P {
+                       return f_elem * dv_func(x_elem, time);
                      });
     }
 

--- a/src/transformations.hpp
+++ b/src/transformations.hpp
@@ -242,7 +242,7 @@ inline void transform_and_combine_dimensions(
     P const time_multiplier, fk::vector<P, mem_type::view> result)
 
 {
-  expect(std::clamp(v_functions.size(), dims.size(), dims.size() + 1u) == v_functions.size());
+  expect(v_functions.size() == static_cast<size_t>(dims.size()) or v_functions.size() == static_cast<size_t>(dims.size() + 1));
   expect(start <= stop);
   expect(stop < table.size());
   expect(degree >= 0);

--- a/src/transformations.hpp
+++ b/src/transformations.hpp
@@ -242,7 +242,7 @@ inline void transform_and_combine_dimensions(
     P const time_multiplier, fk::vector<P, mem_type::view> result)
 
 {
-  expect(v_functions.size() == dims.size());
+  expect(std::clamp(v_functions.size(), dims.size(), dims.size() + 1u) == v_functions.size());
   expect(start <= stop);
   expect(stop < table.size());
   expect(degree >= 0);


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/project-asgard/asgard/wiki/developing)
on the wiki of this project that contains help and requirements.

## Proposed changes

Describe what this PR changes and why.  If it closes an issue, link to it here
with [a supported keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Time dependence of the analytic solution appears to be broken on at least `diffusion_1` and `diffusion_2`. This drops relative difference (numeric-analytic) from ~15% to ~0.5%, but I'm hoping there's a better way.

## What type(s) of changes does this code introduce?
_Put an `x` in the boxes that apply._

- [ ] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Does this introduce a breaking change?

- [ ] Yes
- [ ] No

## What systems has this change been tested on?

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- [ ] this PR is up to date with current the current state of 'develop'
- [ ] code added or changed in the PR has been clang-formatted
- [ ] this PR adds tests to cover any new code, or to catch a bug that is being fixed
- [ ] documentation has been added (if appropriate)
