### PR TITLE
fix the init of workspaces

### DIFF
--- a/src/asgard_kronmult_matrix.hpp
+++ b/src/asgard_kronmult_matrix.hpp
@@ -954,12 +954,10 @@ protected:
                   "no buffer associated with the last entry (num_spaces)");
     default_vector<precision> &w = (*work_)[static_cast<int>(wid)];
     if (static_cast<int64_t>(w.size()) < min_size)
-    {
       w.resize(min_size);
-      // x must always be padded by zeros
-      if constexpr (wid == workspace::pad_x)
-        kronmult::set_buffer_to_zero(w);
-    }
+    // x must always be padded by zeros
+    if constexpr (wid == workspace::pad_x)
+      kronmult::set_buffer_to_zero(w);
   }
 
 private:


### PR DESCRIPTION
Avoiding excessive allocations, the workspace buffer does not shrink if the number of degrees of freedom is reduced. On the other hand, the workspace buffer for `x` needs to be padded with zeros for the padding cells that complete the hierarchy. If the buffer is not reset to zero every time the problem size-changes, then at some point we will be padding with the old entries for `x` from the previous time-step or previous refinement iteration, i.e., padding with non-zeros. Most of the time, using non-zeros for the padding will change the time-step significantly, which will trigger a refinement cycle that rejects the time-step and tries to repeat it on a different grid. If the grid is denser, the workspace vector will be resized and zeroed out, leaving no clearly observable problem. However, a small but non-zero entry can introduce a small enough change to fly below the refinement threshold, yet large enough to break the physics over several iterations.

TL;DR: Sometimes we were padding with non-zeros and that breaks the physics, but only over multiple iterations/timesteps.

closes #670 