### PR TITLE
handle case when non-identity and no flux term

### DIFF
--- a/src/asgard_kronmult_matrix.cpp
+++ b/src/asgard_kronmult_matrix.cpp
@@ -1327,7 +1327,7 @@ make_global_kron_matrix(PDE<precision> const &pde,
     if (num_active > 1)
     {
       int const flux_dir = get_flux_direction(pde, t);
-      if (flux_dir != active_dirs[0]) // make the flux direction first
+      if (flux_dir > -1 and flux_dir != active_dirs[0]) // make the flux direction first
         std::swap(active_dirs[0], active_dirs[flux_dir]);
     }
 

--- a/src/asgard_kronmult_matrix.cpp
+++ b/src/asgard_kronmult_matrix.cpp
@@ -1196,7 +1196,8 @@ bool get_flux_direction(PDE<precision> const &pde, int term_id)
   for (int d = 0; d < pde.num_dims; d++)
     for (auto const &pt : pde.get_terms()[term_id][d].get_partial_terms())
       if (pt.coeff_type == coefficient_type::div or
-          pt.coeff_type == coefficient_type::grad)
+          pt.coeff_type == coefficient_type::grad or
+          pt.coeff_type == coefficient_type::penalty)
         return d;
   return -1;
 }


### PR DESCRIPTION
@stefan-schnake

The flux term should always be at position `0` in the `active_terms` as this is the one that doesn't get split into upper/lower part. Active term `0` does not require completeness of the hierarchy, the rest of directions can be given in any order.

This fixes the case when we have a term that is a mass term (no flux) but is not identity. We should also double-check the logic in `get_flux_direction()`.