### PR TITLE
Fix pde initialization

### DIFF
--- a/src/adapt.hpp
+++ b/src/adapt.hpp
@@ -53,7 +53,7 @@ public:
     return this->get_initial_condition(
         pde.get_dimensions(),
         pde.has_analytic_soln() ? pde.exact_time()(0.0) : static_cast<P>(1.0),
-        pde.num_terms, pde.get_terms(), transformer, cli_opts);
+        pde.num_terms(), pde.get_terms(), transformer, cli_opts);
   }
 
   fk::vector<P> get_initial_condition(

--- a/src/adapt.hpp
+++ b/src/adapt.hpp
@@ -52,7 +52,7 @@ public:
   {
     return this->get_initial_condition(
         pde.get_dimensions(),
-        pde.has_analytic_soln ? pde.exact_time(0.0) : static_cast<P>(1.0),
+        pde.has_analytic_soln() ? pde.exact_time()(0.0) : static_cast<P>(1.0),
         pde.num_terms, pde.get_terms(), transformer, cli_opts);
   }
 

--- a/src/asgard_dimension.hpp
+++ b/src/asgard_dimension.hpp
@@ -273,11 +273,11 @@ struct dimension_set
 template<typename P>
 struct dimension
 {
-  P const domain_min;
-  P const domain_max;
-  std::vector<vector_func<P>> const initial_condition;
-  g_func_type<P> const volume_jacobian_dV;
-  std::string const name;
+  P domain_min;
+  P domain_max;
+  std::vector<vector_func<P>> initial_condition;
+  g_func_type<P> volume_jacobian_dV;
+  std::string name;
   dimension(P const d_min, P const d_max, int const level, int const degree,
             vector_func<P> const initial_condition_in,
             g_func_type<P> const volume_jacobian_dV_in,

--- a/src/asgard_kronmult_matrix.cpp
+++ b/src/asgard_kronmult_matrix.cpp
@@ -25,15 +25,15 @@ std::vector<int> get_used_terms(PDE<precision> const &pde, options const &opts,
 {
   if (not opts.use_imex_stepping)
   {
-    std::vector<int> terms(pde.num_terms);
+    std::vector<int> terms(pde.num_terms());
     std::iota(terms.begin(), terms.end(), 0); // fills with 0, 1, 2, 3 ...
     return terms;
   }
   else
   {
     std::vector<int> terms;
-    terms.reserve(pde.num_terms);
-    for (int t = 0; t < pde.num_terms; t++)
+    terms.reserve(pde.num_terms());
+    for (int t = 0; t < pde.num_terms(); t++)
       if (pde.get_terms()[t][0].flag() == imex)
         terms.push_back(t);
 
@@ -1023,7 +1023,7 @@ void build_preconditioner(PDE<precision> const &pde, int64_t const num_active,
 
   int const pterms = pde.get_dimensions()[0].get_degree();
 
-  int num_dimensions  = pde.num_dims;
+  int num_dimensions  = pde.num_dims();
   int64_t tensor_size = int_pow(pterms, num_dimensions);
 
   if (pc.size() == 0)
@@ -1193,7 +1193,7 @@ bool check_identity_term(PDE<precision> const &pde, int term_id, int dim)
 template<typename precision>
 bool get_flux_direction(PDE<precision> const &pde, int term_id)
 {
-  for (int d = 0; d < pde.num_dims; d++)
+  for (int d = 0; d < pde.num_dims(); d++)
     for (auto const &pt : pde.get_terms()[term_id][d].get_partial_terms())
       if (pt.coeff_type() == coefficient_type::div or
           pt.coeff_type() == coefficient_type::grad or
@@ -1213,10 +1213,10 @@ make_global_kron_matrix(PDE<precision> const &pde,
 
   int const porder    = pde.get_dimensions()[0].get_degree() - 1;
   int const pterms    = porder + 1; // poly degrees of freedom
-  int const max_level = (program_options.do_adapt_levels) ? program_options.max_level : pde.max_level;
+  int const max_level = (program_options.do_adapt_levels) ? program_options.max_level : pde.max_level();
 
-  int const num_dimensions = pde.num_dims;
-  int const num_terms      = pde.num_terms;
+  int const num_dimensions = pde.num_dims();
+  int const num_terms      = pde.num_terms();
 
   connect_1d volumes(max_level, connect_1d::hierarchy::volume);
   connect_1d dof_pattern(connect_1d(max_level), porder);
@@ -1359,7 +1359,7 @@ void set_specific_mode(PDE<precision> const &pde,
   int const porder = pde.get_dimensions()[0].get_degree() - 1;
   mat.porder_      = porder;
 
-  int const num_dimensions = pde.num_dims;
+  int const num_dimensions = pde.num_dims();
 
   // set the values for the global pattern
   // number of patterns per term per dimension to be considered
@@ -1474,7 +1474,7 @@ void update_matrix_coefficients(PDE<precision> const &pde,
 
   std::vector<int> const &used_terms = mat.term_groups[imex_indx];
 
-  int const num_dimensions = pde.num_dims;
+  int const num_dimensions = pde.num_dims();
 
   constexpr int patterns_per_dim = global_kron_matrix<precision>::patterns_per_dim;
 

--- a/src/asgard_kronmult_matrix.cpp
+++ b/src/asgard_kronmult_matrix.cpp
@@ -1182,10 +1182,10 @@ bool check_identity_term(PDE<precision> const &pde, int term_id, int dim)
   // In the edge case, identity will be multiplied instead of ignored
   // resulting in extra work but correct output.
   for (auto const &pt : pde.get_terms()[term_id][dim].get_partial_terms())
-    if (pt.coeff_type != coefficient_type::mass or
-        pt.g_func != nullptr or
-        pt.lhs_mass_func != nullptr or
-        pt.dv_func != nullptr)
+    if (pt.coeff_type() != coefficient_type::mass or
+        pt.g_func() != nullptr or
+        pt.lhs_mass_func() != nullptr or
+        pt.dv_func() != nullptr)
       return false;
   return true;
 }
@@ -1195,9 +1195,9 @@ bool get_flux_direction(PDE<precision> const &pde, int term_id)
 {
   for (int d = 0; d < pde.num_dims; d++)
     for (auto const &pt : pde.get_terms()[term_id][d].get_partial_terms())
-      if (pt.coeff_type == coefficient_type::div or
-          pt.coeff_type == coefficient_type::grad or
-          pt.coeff_type == coefficient_type::penalty)
+      if (pt.coeff_type() == coefficient_type::div or
+          pt.coeff_type() == coefficient_type::grad or
+          pt.coeff_type() == coefficient_type::penalty)
         return d;
   return -1;
 }

--- a/src/asgard_kronmult_matrix.cpp
+++ b/src/asgard_kronmult_matrix.cpp
@@ -34,7 +34,7 @@ std::vector<int> get_used_terms(PDE<precision> const &pde, options const &opts,
     std::vector<int> terms;
     terms.reserve(pde.num_terms);
     for (int t = 0; t < pde.num_terms; t++)
-      if (pde.get_terms()[t][0].flag == imex)
+      if (pde.get_terms()[t][0].flag() == imex)
         terms.push_back(t);
 
     return terms;

--- a/src/asgard_kronmult_matrix.cpp
+++ b/src/asgard_kronmult_matrix.cpp
@@ -69,14 +69,14 @@ make_kronmult_dense(PDE<precision> const &pde,
 {
   // convert pde to kronmult dense matrix
   auto const &grid         = discretization.get_subgrid(get_rank());
-  int const num_dimensions = pde.num_dims;
+  int const num_dimensions = pde.num_dims();
   int const kron_size      = pde.get_dimensions()[0].get_degree();
   int const num_rows       = grid.row_stop - grid.row_start + 1;
   int const num_cols       = grid.col_stop - grid.col_start + 1;
 
   int64_t lda = kron_size * fm::two_raised_to((program_options.do_adapt_levels)
                                                   ? program_options.max_level
-                                                  : pde.max_level);
+                                                  : pde.max_level());
 
   // take into account the terms that will be skipped due to the imex_flag
   std::vector<int> const used_terms = get_used_terms(pde, program_options, imex);
@@ -337,14 +337,14 @@ make_kronmult_sparse(PDE<precision> const &pde,
   tools::time_event performance_("make-kronmult-sparse");
   // convert pde to kronmult dense matrix
   auto const &grid         = discretization.get_subgrid(get_rank());
-  int const num_dimensions = pde.num_dims;
+  int const num_dimensions = pde.num_dims();
   int const kron_size      = pde.get_dimensions()[0].get_degree();
   int const num_rows       = grid.row_stop - grid.row_start + 1;
   int const num_cols       = grid.col_stop - grid.col_start + 1;
 
   int64_t lda = kron_size * fm::two_raised_to((program_options.do_adapt_levels)
                                                   ? program_options.max_level
-                                                  : pde.max_level);
+                                                  : pde.max_level());
 
   // take into account the terms that will be skipped due to the imex_flag
   std::vector<int> const used_terms =
@@ -713,12 +713,12 @@ void update_kronmult_coefficients(PDE<P> const &pde,
                                   kronmult_matrix<P> &mat)
 {
   tools::time_event kron_time_("kronmult-update-coefficients");
-  int const num_dimensions = pde.num_dims;
+  int const num_dimensions = pde.num_dims();
   int const kron_size      = pde.get_dimensions()[0].get_degree();
 
   int64_t lda = kron_size * fm::two_raised_to((program_options.do_adapt_levels)
                                                   ? program_options.max_level
-                                                  : pde.max_level);
+                                                  : pde.max_level());
 
   // take into account the terms that will be skipped due to the imex_flag
   std::vector<int> const used_terms =
@@ -817,7 +817,7 @@ compute_mem_usage(PDE<P> const &pde,
                   int64_t index_limit, bool force_sparse)
 {
   auto const &grid         = discretization.get_subgrid(get_rank());
-  int const num_dimensions = pde.num_dims;
+  int const num_dimensions = pde.num_dims();
   int const kron_size      = pde.get_dimensions()[0].get_degree();
   int const num_rows       = grid.row_stop - grid.row_start + 1;
   int const num_cols       = grid.col_stop - grid.col_start + 1;
@@ -833,7 +833,7 @@ compute_mem_usage(PDE<P> const &pde,
 
   // parameters common to the dense and sparse cases
   // matrices_per_prod is the number of matrices per Kronecker product
-  int64_t matrices_per_prod = pde.num_terms * num_dimensions;
+  int64_t matrices_per_prod = pde.num_terms() * num_dimensions;
 
   // base_line_entries are the entries that must always be loaded in GPU memory
   // first we compute the size of the state vectors (x and y) and then we
@@ -845,7 +845,7 @@ compute_mem_usage(PDE<P> const &pde,
   if (program_options.kmode == kronmult_mode::dense and not force_sparse)
   {
     // assume all terms will be loaded into the GPU, as one IMEX flag or another
-    for (int t = 0; t < pde.num_terms; t++)
+    for (int t = 0; t < pde.num_terms(); t++)
       for (int d = 0; d < num_dimensions; d++)
         base_line_entries += pde.get_coefficients(t, d).size();
 
@@ -892,8 +892,8 @@ compute_mem_usage(PDE<P> const &pde,
   else
   { // sparse mode
     // if possible, keep the 1d connectivity matrix
-    if (pde.max_level != spcache.cells1d.max_loaded_level())
-      spcache.cells1d = connect_1d(pde.max_level);
+    if (pde.max_level() != spcache.cells1d.max_loaded_level())
+      spcache.cells1d = connect_1d(pde.max_level());
 
     int const *const flattened_table =
         discretization.get_table().get_active_table().data();
@@ -936,7 +936,7 @@ compute_mem_usage(PDE<P> const &pde,
     }
 
     base_line_entries += spcache.cells1d.num_connections() * num_dimensions *
-                         pde.num_terms * kron_size * kron_size;
+                         pde.num_terms() * kron_size * kron_size;
 
     stats.baseline_memory = 1 + static_cast<int>(get_MB<P>(base_line_entries));
 
@@ -958,7 +958,7 @@ compute_mem_usage(PDE<P> const &pde,
     }
     else
     {
-      int min_terms = pde.num_terms;
+      int min_terms = pde.num_terms();
       if (imex != imex_flag::unspecified)
       {
         std::vector<int> const explicit_terms =

--- a/src/basis.hpp
+++ b/src/basis.hpp
@@ -51,7 +51,7 @@ public:
         // Otherwise, use the max_level defined in the PDE (max level of all
         // dims)
         wavelet_transform(program_opts.do_adapt_levels ? program_opts.max_level
-                                                       : pde.max_level,
+                                                       : pde.max_level(),
                           pde.get_dimensions()[0].get_degree(), quiet)
   {}
 

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -473,7 +473,7 @@ linear_coords_to_indices(PDE<P> const &pde, int const degree,
                          fk::vector<int> const &coords)
 {
   fk::vector<int> indices(coords.size());
-  for (int d = 0; d < pde.num_dims; ++d)
+  for (int d = 0; d < pde.num_dims(); ++d)
   {
     indices(d) = coords(d) * degree;
   }
@@ -491,7 +491,7 @@ void build_system_matrix(PDE<P> const &pde, elements::table const &elem_table,
 {
   // assume uniform degree for now
   int const degree    = pde.get_dimensions()[0].get_degree();
-  int const elem_size = static_cast<int>(std::pow(degree, pde.num_dims));
+  int const elem_size = static_cast<int>(std::pow(degree, pde.num_dims()));
 
   int const A_cols = elem_size * grid.ncols();
   int const A_rows = elem_size * grid.nrows();
@@ -502,9 +502,9 @@ void build_system_matrix(PDE<P> const &pde, elements::table const &elem_table,
   std::map<key_type, val_type> coef_cache;
 
   // copy coefficients to host for subsequent use
-  for (int k = 0; k < pde.num_terms; ++k)
+  for (int k = 0; k < pde.num_terms(); ++k)
   {
-    for (int d = 0; d < pde.num_dims; d++)
+    for (int d = 0; d < pde.num_dims(); d++)
     {
       coef_cache.emplace(key_type(k, d), pde.get_coefficients(k, d));
     }
@@ -520,7 +520,7 @@ void build_system_matrix(PDE<P> const &pde, elements::table const &elem_table,
     // calculate from the level/cell indices for each
     // dimension
     fk::vector<int> const coords = elem_table.get_coords(i);
-    expect(coords.size() == pde.num_dims * 2);
+    expect(coords.size() == pde.num_dims() * 2);
     fk::vector<int> const elem_indices = linearize(coords);
 
     int const global_row = i * elem_size;
@@ -537,7 +537,7 @@ void build_system_matrix(PDE<P> const &pde, elements::table const &elem_table,
     {
       // get linearized indices for this connected element
       fk::vector<int> const coords_nD = elem_table.get_coords(j);
-      expect(coords_nD.size() == pde.num_dims * 2);
+      expect(coords_nD.size() == pde.num_dims() * 2);
       fk::vector<int> const connected_indices = linearize(coords_nD);
 
       // calculate the col portion of the
@@ -546,7 +546,7 @@ void build_system_matrix(PDE<P> const &pde, elements::table const &elem_table,
       fk::vector<int> const operator_col =
           linear_coords_to_indices(pde, degree, connected_indices);
 
-      for (int k = 0; k < pde.num_terms; ++k)
+      for (int k = 0; k < pde.num_terms(); ++k)
       {
         std::vector<fk::matrix<P>> kron_vals;
         fk::matrix<P> kron0(1, 1);
@@ -560,7 +560,7 @@ void build_system_matrix(PDE<P> const &pde, elements::table const &elem_table,
           kron0(0, 0) = 0.0;
         }
         kron_vals.push_back(std::move(kron0));
-        for (int d = 0; d < pde.num_dims; d++)
+        for (int d = 0; d < pde.num_dims(); d++)
         {
           fk::matrix<P, mem_type::view> op_view = fk::matrix<P, mem_type::view>(
               coef_cache[key_type(k, d)], operator_row(d),

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -551,7 +551,7 @@ void build_system_matrix(PDE<P> const &pde, elements::table const &elem_table,
         std::vector<fk::matrix<P>> kron_vals;
         fk::matrix<P> kron0(1, 1);
         // if using imex, include only terms that match the flag
-        if (imex == imex_flag::unspecified || terms[k][0].flag == imex)
+        if (imex == imex_flag::unspecified || terms[k][0].flag() == imex)
         {
           kron0(0, 0) = 1.0;
         }

--- a/src/boundary_conditions.cpp
+++ b/src/boundary_conditions.cpp
@@ -56,14 +56,14 @@ std::array<unscaled_bc_parts<P>, 2> make_unscaled_bc_parts(
       {
         partial_term<P> const &p_term = partial_terms[p_num];
 
-        if (p_term.left_homo == homogeneity::inhomogeneous)
+        if (p_term.left_homo() == homogeneity::inhomogeneous)
         {
           fk::vector<P> trace_bc = compute_left_boundary_condition(
-              p_term.g_func, p_term.dv_func, t_init, d,
-              p_term.left_bc_funcs[dim_num]);
+              p_term.g_func(), p_term.dv_func(), t_init, d,
+              p_term.left_bc_funcs()[dim_num]);
 
           std::vector<fk::vector<P>> p_term_left_bcs = generate_partial_bcs(
-              dimensions, dim_num, p_term.left_bc_funcs, transformer, t_init,
+              dimensions, dim_num, p_term.left_bc_funcs(), transformer, t_init,
               terms_vec, partial_terms, p_num, std::move(trace_bc));
 
           fk::vector<P> combined =
@@ -73,14 +73,14 @@ std::array<unscaled_bc_parts<P>, 2> make_unscaled_bc_parts(
           left_pvecs.emplace_back(std::move(combined));
         }
 
-        if (p_term.right_homo == homogeneity::inhomogeneous)
+        if (p_term.right_homo() == homogeneity::inhomogeneous)
         {
           fk::vector<P> trace_bc = compute_right_boundary_condition(
-              p_term.g_func, p_term.dv_func, t_init, d,
-              p_term.right_bc_funcs[dim_num]);
+              p_term.g_func(), p_term.dv_func(), t_init, d,
+              p_term.right_bc_funcs()[dim_num]);
 
           std::vector<fk::vector<P>> p_term_right_bcs = generate_partial_bcs(
-              dimensions, dim_num, p_term.right_bc_funcs, transformer, t_init,
+              dimensions, dim_num, p_term.right_bc_funcs(), transformer, t_init,
               terms_vec, partial_terms, p_num, std::move(trace_bc));
 
           fk::vector<P> combined =
@@ -133,17 +133,17 @@ fk::vector<P> generate_scaled_bc(unscaled_bc_parts<P> const &left_bc_parts,
       {
         partial_term<P> const &p_term = partial_terms[p_num];
 
-        if (p_term.left_homo == homogeneity::inhomogeneous)
+        if (p_term.left_homo() == homogeneity::inhomogeneous)
         {
           fm::axpy(left_bc_parts[term_num][dim_num][left_index++], bc,
-                   p_term.left_bc_time_func ? p_term.left_bc_time_func(time)
-                                            : time);
+                   p_term.left_bc_time_func() ? p_term.left_bc_time_func()(time)
+                                              : time);
         }
-        if (p_term.right_homo == homogeneity::inhomogeneous)
+        if (p_term.right_homo() == homogeneity::inhomogeneous)
         {
           fm::axpy(right_bc_parts[term_num][dim_num][right_index++], bc,
-                   p_term.right_bc_time_func ? p_term.right_bc_time_func(time)
-                                             : time);
+                   p_term.right_bc_time_func() ? p_term.right_bc_time_func()(time)
+                                               : time);
         }
       }
     }
@@ -284,7 +284,7 @@ std::vector<fk::vector<P>> generate_partial_bcs(
         dimensions[dim_num].get_degree() *
         fm::two_raised_to(dimensions[dim_num].get_level());
     auto const &f = bc_funcs[dim_num];
-    auto const &g = terms[dim_num].get_partial_terms()[p_index].g_func;
+    auto const &g = terms[dim_num].get_partial_terms()[p_index].g_func();
     vector_func<P> bc_func;
     if (g)
     {
@@ -304,7 +304,7 @@ std::vector<fk::vector<P>> generate_partial_bcs(
     }
     partial_bc_vecs.push_back(
         forward_transform(dimensions[dim_num], bc_func,
-                          terms[dim_num].get_partial_terms()[p_index].dv_func,
+                          terms[dim_num].get_partial_terms()[p_index].dv_func(),
                           transformer, time));
     // Apply inverse mat
     std::vector<int> ipiv(degrees_freedom_1d_other);

--- a/src/boundary_conditions.cpp
+++ b/src/boundary_conditions.cpp
@@ -110,7 +110,7 @@ fk::vector<P> generate_scaled_bc(unscaled_bc_parts<P> const &left_bc_parts,
 {
   fk::vector<P> bc(
       (stop_element - start_element + 1) *
-      std::pow(pde.get_dimensions()[0].get_degree(), pde.num_dims));
+      std::pow(pde.get_dimensions()[0].get_degree(), pde.num_dims()));
 
   term_set<P> const &terms_vec_vec = pde.get_terms();
 

--- a/src/boundary_conditions_tests.cpp
+++ b/src/boundary_conditions_tests.cpp
@@ -99,14 +99,14 @@ void test_compute_boundary_condition(PDE<P> &pde,
             std::to_string(term_num) + "t_" + std::to_string(dim_num) + "dim_" +
             std::to_string(p_num) + "p.dat";
         partial_term<P> const &p_term = partial_terms[p_num];
-        if (p_term.left_homo == homogeneity::inhomogeneous)
+        if (p_term.left_homo() == homogeneity::inhomogeneous)
         {
-          REQUIRE(static_cast<int>(p_term.left_bc_funcs.size()) > dim_num);
+          REQUIRE(static_cast<int>(p_term.left_bc_funcs().size()) > dim_num);
 
           fk::vector<P> const left_bc =
               boundary_conditions::compute_left_boundary_condition(
-                  p_term.g_func, p_term.dv_func, time, d,
-                  p_term.left_bc_funcs[dim_num]);
+                  p_term.g_func(), p_term.dv_func(), time, d,
+                  p_term.left_bc_funcs()[dim_num]);
 
           /* compare to gold left bc */
           fk::vector<P> const gold_left_bc_vector =
@@ -114,14 +114,14 @@ void test_compute_boundary_condition(PDE<P> &pde,
           rmse_comparison(gold_left_bc_vector, left_bc, tol_factor);
         }
 
-        if (p_term.right_homo == homogeneity::inhomogeneous)
+        if (p_term.right_homo() == homogeneity::inhomogeneous)
         {
-          REQUIRE(static_cast<int>(p_term.right_bc_funcs.size()) > dim_num);
+          REQUIRE(static_cast<int>(p_term.right_bc_funcs().size()) > dim_num);
 
           fk::vector<P> const right_bc =
               boundary_conditions::compute_right_boundary_condition(
-                  p_term.g_func, p_term.dv_func, time, d,
-                  p_term.right_bc_funcs[dim_num]);
+                  p_term.g_func(), p_term.dv_func(), time, d,
+                  p_term.right_bc_funcs()[dim_num]);
           /* compare to gold right bc */
 
           std::string const gold_right_filename =

--- a/src/coefficients.cpp
+++ b/src/coefficients.cpp
@@ -23,12 +23,12 @@ void generate_all_coefficients(
   tools::time_event time_generating_("gen_coefficients");
   expect(time >= 0.0);
 
-  for (auto i = 0; i < pde.num_dims; ++i)
+  for (auto i = 0; i < pde.num_dims(); ++i)
   {
     auto const &dim = pde.get_dimensions()[i];
     std::vector<int> ipiv(dim.get_degree() *
                           fm::two_raised_to(dim.get_level()));
-    for (auto j = 0; j < pde.num_terms; ++j)
+    for (auto j = 0; j < pde.num_terms(); ++j)
     {
       auto const &term_1D       = pde.get_terms()[j][i];
       auto const &partial_terms = term_1D.get_partial_terms();
@@ -87,11 +87,11 @@ void generate_all_coefficients_max_level(
   tools::time_event time_generating_("gen_coefficients");
   expect(time >= 0.0);
 
-  for (auto i = 0; i < pde.num_dims; ++i)
+  for (auto i = 0; i < pde.num_dims(); ++i)
   {
     auto const &dim = pde.get_dimensions()[i];
-    std::vector<int> ipiv(dim.get_degree() * fm::two_raised_to(pde.max_level));
-    for (auto j = 0; j < pde.num_terms; ++j)
+    std::vector<int> ipiv(dim.get_degree() * fm::two_raised_to(pde.max_level()));
+    for (auto j = 0; j < pde.num_terms(); ++j)
     {
       auto const &term_1D       = pde.get_terms()[j][i];
       auto const &partial_terms = term_1D.get_partial_terms();
@@ -107,12 +107,12 @@ void generate_all_coefficients_max_level(
             dim.volume_jacobian_dV);
 
         auto mass_coeff = generate_coefficients<P>(
-            dim, lhs_mass_pterm, transformer, pde.max_level, time, rotate);
+            dim, lhs_mass_pterm, transformer, pde.max_level(), time, rotate);
 
         // precompute inv(mass) * coeff for each level up to max level
         std::vector<fk::matrix<P>> pterm_coeffs;
 
-        for (int level = 0; level <= pde.max_level; ++level)
+        for (int level = 0; level <= pde.max_level(); ++level)
         {
           auto result = generate_coefficients<P>(
               dim, partial_terms[k], transformer, level, time, rotate);
@@ -137,11 +137,11 @@ template<typename P>
 void generate_dimension_mass_mat(
     PDE<P> &pde, basis::wavelet_transform<P, resource::host> const &transformer)
 {
-  for (auto i = 0; i < pde.num_dims; ++i)
+  for (auto i = 0; i < pde.num_dims(); ++i)
   {
     auto &dim = pde.get_dimensions()[i];
 
-    for (int level = 0; level <= pde.max_level; ++level)
+    for (int level = 0; level <= pde.max_level(); ++level)
     {
       partial_term<P> const lhs_mass_pterm = partial_term<P>(
           coefficient_type::mass, nullptr, nullptr, flux_type::central,

--- a/src/coefficients.cpp
+++ b/src/coefficients.cpp
@@ -34,7 +34,7 @@ void generate_all_coefficients(
       auto const &partial_terms = term_1D.get_partial_terms();
 
       // skip regenerating coefficients that are constant in time
-      if (!term_1D.time_dependent && time > 0.0)
+      if (!term_1D.time_dependent() && time > 0.0)
       {
         continue;
       }

--- a/src/coefficients.cpp
+++ b/src/coefficients.cpp
@@ -43,7 +43,7 @@ void generate_all_coefficients(
       {
         // TODO: refactor these changes, this is slow!
         partial_term<P> const lhs_mass_pterm = partial_term<P>(
-            coefficient_type::mass, partial_terms[k].lhs_mass_func, nullptr,
+            coefficient_type::mass, partial_terms[k].lhs_mass_func(), nullptr,
             flux_type::central, boundary_condition::periodic,
             boundary_condition::periodic, homogeneity::homogeneous,
             homogeneity::homogeneous, {}, nullptr, {}, nullptr,
@@ -62,7 +62,7 @@ void generate_all_coefficients(
         //{
         auto const dof  = dim.get_degree() * fm::two_raised_to(dim.get_level());
         auto result_tmp = result.extract_submatrix(0, 0, dof, dof);
-        if (partial_terms[k].dv_func || partial_terms[k].g_func)
+        if (partial_terms[k].dv_func() || partial_terms[k].g_func())
         {
           auto mass_tmp = mass_coeff.extract_submatrix(0, 0, dof, dof);
           fm::gesv(mass_tmp, result_tmp, ipiv);
@@ -100,7 +100,7 @@ void generate_all_coefficients_max_level(
       {
         // TODO: refactor these changes, this is slow!
         partial_term<P> const lhs_mass_pterm = partial_term<P>(
-            coefficient_type::mass, partial_terms[k].lhs_mass_func, nullptr,
+            coefficient_type::mass, partial_terms[k].lhs_mass_func(), nullptr,
             flux_type::central, boundary_condition::periodic,
             boundary_condition::periodic, homogeneity::homogeneous,
             homogeneity::homogeneous, {}, nullptr, {}, nullptr,
@@ -116,7 +116,7 @@ void generate_all_coefficients_max_level(
         {
           auto result = generate_coefficients<P>(
               dim, partial_terms[k], transformer, level, time, rotate);
-          if (partial_terms[k].dv_func || partial_terms[k].g_func)
+          if (partial_terms[k].dv_func() || partial_terms[k].g_func())
           {
             auto const dof = dim.get_degree() * fm::two_raised_to(level);
             auto mass_tmp  = mass_coeff.extract_submatrix(0, 0, dof, dof);
@@ -173,10 +173,10 @@ fk::matrix<P> generate_coefficients(
   expect(transformer.degree == dim.get_degree());
   expect(transformer.max_level >= dim.get_level());
   expect(level <= transformer.max_level);
-  expect(coeff_type == pterm.coeff_type);
+  expect(coeff_type == pterm.coeff_type());
 
-  auto g_dv_func = [g_func  = pterm.g_func,
-                    dv_func = pterm.dv_func]() -> g_func_type<P> {
+  auto g_dv_func = [g_func  = pterm.g_func(),
+                    dv_func = pterm.dv_func()]() -> g_func_type<P> {
     if (g_func && dv_func)
     {
       return [g_func, dv_func](P const x, P const t) {
@@ -185,7 +185,7 @@ fk::matrix<P> generate_coefficients(
     }
     else if (g_func)
     {
-      return [g_func](P const x, P const t) { return g_func(x, t); };
+      return [=](P const x, P const t) { return g_func(x, t); };
     }
     else if (dv_func)
     {
@@ -463,7 +463,7 @@ fk::matrix<P> generate_coefficients(
         }
 
         // handle the left-boundary
-        switch (pterm.ileft)
+        switch (pterm.ileft())
         {
         case boundary_condition::dirichlet:
           // If penalty then we add <|g|/2[f],[v]>
@@ -514,7 +514,7 @@ fk::matrix<P> generate_coefficients(
         }
 
         // handle the right boundary condition
-        switch (pterm.iright)
+        switch (pterm.iright())
         {
         case boundary_condition::dirichlet:
           if constexpr (coeff_type == coefficient_type::penalty)
@@ -565,7 +565,7 @@ fk::matrix<P> generate_coefficients(
     basis::wavelet_transform<P, resource::host> const &transformer,
     int const level, P const time, bool const rotate)
 {
-  switch (pterm.coeff_type)
+  switch (pterm.coeff_type())
   {
   case coefficient_type::mass:
     return generate_coefficients<P, coefficient_type::mass>(dim, pterm, transformer, level, time, rotate);

--- a/src/coefficients_tests.cpp
+++ b/src/coefficients_tests.cpp
@@ -33,9 +33,9 @@ void test_coefficients(parser const &parse, std::string const &gold_path,
   auto const filename_base = gold_path + "_l" + lev_string + "d" +
                              std::to_string(parse.get_degree()) + "_";
 
-  for (auto d = 0; d < pde->num_dims; ++d)
+  for (auto d = 0; d < pde->num_dims(); ++d)
   {
-    for (auto t = 0; t < pde->num_terms; ++t)
+    for (auto t = 0; t < pde->num_terms(); ++t)
     {
       auto const filename = filename_base + std::to_string(t + 1) + "_" +
                             std::to_string(d + 1) + ".dat";
@@ -333,9 +333,9 @@ TEMPLATE_TEST_CASE("fokkerplanck2_complete_case4 terms", "[coefficients]",
     generate_all_coefficients(*pde, transformer, time, true);
 
     int row = 0;
-    for (auto i = 0; i < pde->num_dims; ++i)
+    for (auto i = 0; i < pde->num_dims(); ++i)
     {
-      for (auto j = 0; j < pde->num_terms; ++j)
+      for (auto j = 0; j < pde->num_terms(); ++j)
       {
         auto const &term_1D       = pde->get_terms()[j][i];
         auto const &partial_terms = term_1D.get_partial_terms();

--- a/src/distribution_tests.cpp
+++ b/src/distribution_tests.cpp
@@ -695,7 +695,7 @@ TEMPLATE_TEST_CASE("prepare inputs tests", "[distribution]", test_precs)
       auto const pde =
           make_PDE<default_precision>(PDE_opts::continuity_2, level, degree);
       auto const segment_size =
-          static_cast<int>(std::pow(degree, pde->num_dims));
+          static_cast<int>(std::pow(degree, pde->num_dims()));
 
       elements::table const table(o, *pde);
       if (num_ranks > table.size())
@@ -775,7 +775,7 @@ TEMPLATE_TEST_CASE("gather results tests", "[distribution]", test_precs)
 
       auto const plan = get_plan(num_ranks, table);
       auto const segment_size =
-          static_cast<int>(std::pow(degree, pde->num_dims));
+          static_cast<int>(std::pow(degree, pde->num_dims()));
 
       // create the system vector
       fk::vector<TestType> const fx = [&table, segment_size]() {

--- a/src/elements_tests.cpp
+++ b/src/elements_tests.cpp
@@ -44,18 +44,18 @@ void test_element_table(PDE_opts const pde_choice,
     // test id to coord mapping
     auto const &test_coords = elem_table.get_coords(i);
     fk::vector<int> const gold_coords =
-        gold_table.extract_submatrix(i, 0, 1, pde->num_dims * 2);
+        gold_table.extract_submatrix(i, 0, 1, pde->num_dims() * 2);
     fk::vector<int> const mapped_coords =
-        elements::map_to_coords(test_id, opts.max_level, pde->num_dims);
+        elements::map_to_coords(test_id, opts.max_level, pde->num_dims());
     REQUIRE(mapped_coords == test_coords);
     REQUIRE(gold_coords == test_coords);
 
     // test mapping back to id
     auto const mapped_id =
-        elements::map_to_id(mapped_coords, opts.max_level, pde->num_dims);
+        elements::map_to_id(mapped_coords, opts.max_level, pde->num_dims());
     REQUIRE(mapped_id == gold_id);
 
-    auto const coord_size         = pde->num_dims * 2;
+    auto const coord_size         = pde->num_dims() * 2;
     auto const element_flat_index = static_cast<int64_t>(coord_size) * i;
     fk::vector<int, mem_type::const_view> const flat_coords(
         flat_table, element_flat_index, element_flat_index + coord_size - 1);
@@ -219,7 +219,7 @@ void test_element_deletion(PDE_opts const pde_choice,
   REQUIRE(elem_table.size() ==
           old_size - static_cast<int>(indices_to_delete.size()));
   auto const &flat_table = elem_table.get_active_table();
-  auto const coord_size  = pde->num_dims * 2;
+  auto const coord_size  = pde->num_dims() * 2;
   REQUIRE(flat_table.size() / coord_size == elem_table.size());
 
   // check that deleted ids are not present in table

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -165,8 +165,8 @@ void write_output(PDE<P> const &pde, parser const &cli_input,
   H5Easy::dump(file, "degree", dims[0].get_degree());
   H5Easy::dump(file, "dt", pde.get_dt());
   H5Easy::dump(file, "time", time);
-  H5Easy::dump(file, "ndims", pde.num_dims);
-  H5Easy::dump(file, "max_level", pde.max_level);
+  H5Easy::dump(file, "ndims", pde.num_dims());
+  H5Easy::dump(file, "max_level", pde.max_level());
   H5Easy::dump(file, "dof", dof);
   H5Easy::dump(file, "cli", cli_input.cli_opts);
   for (size_t dim = 0; dim < dims.size(); ++dim)
@@ -459,7 +459,7 @@ restart_data<P> read_output(PDE<P> &pde, elements::table const &hash_table,
   pde.E_field = std::move(
       fk::vector<P>(H5Easy::load<std::vector<P>>(file, std::string("Efield"))));
 
-  for (int dim = 0; dim < pde.num_dims; ++dim)
+  for (int dim = 0; dim < pde.num_dims(); ++dim)
   {
     int level = H5Easy::load<int>(
         file, std::string("dim" + std::to_string(dim) + "_level"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -273,7 +273,7 @@ int main(int argc, char **argv)
     asgard::tools::timer.stop(time_id);
 
     // print root mean squared error from analytic solution
-    if (pde->has_analytic_soln)
+    if (pde->has_analytic_soln())
     {
       // get analytic solution at time(step+1)
       auto const analytic_solution = sum_separable_funcs(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main(int argc, char **argv)
   asgard::adapt::distributed_grid adaptive_grid(*pde, opts);
   asgard::node_out() << "  degrees of freedom: "
                      << adaptive_grid.size() * static_cast<uint64_t>(std::pow(
-                                                   degree, pde->num_dims))
+                                                   degree, pde->num_dims()))
                      << '\n';
 
   asgard::node_out() << "  generating: basis operator..." << '\n';
@@ -112,7 +112,7 @@ int main(int argc, char **argv)
       adaptive_grid.get_initial_condition(*pde, transformer, opts);
   asgard::node_out() << "  degrees of freedom (post initial adapt): "
                      << adaptive_grid.size() * static_cast<uint64_t>(std::pow(
-                                                   degree, pde->num_dims))
+                                                   degree, pde->num_dims()))
                      << '\n';
 
   // -- regen mass mats after init conditions - TODO: check dims/rechaining?
@@ -277,7 +277,7 @@ int main(int argc, char **argv)
     {
       // get analytic solution at time(step+1)
       auto const analytic_solution = sum_separable_funcs(
-          pde->exact_vector_funcs, pde->get_dimensions(), adaptive_grid,
+          pde->exact_vector_funcs(), pde->get_dimensions(), adaptive_grid,
           transformer, degree, time + pde->get_dt());
 
       // calculate root mean squared error

--- a/src/moment.cpp
+++ b/src/moment.cpp
@@ -95,7 +95,7 @@ void moment<P>::createMomentReducedMatrix(PDE<P> const &pde,
                                           elements::table const &hash_table)
 {
   tools::time_event performance("createMomentMatrix");
-  switch (pde.num_dims)
+  switch (pde.num_dims())
   {
   case 2:
     createMomentReducedMatrix_nd<1>(pde, hash_table);

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -567,22 +567,22 @@ public:
             moments_in, do_collision_operator_in)
   {}
   PDE(parser const &cli_input, int const num_dims_in, int const num_sources_in,
-      int const max_num_terms, std::vector<dimension<P>> const dimensions,
-      term_set<P> const terms, std::vector<source<P>> const sources_in,
-      std::vector<md_func_type<P>> const exact_vector_funcs_in,
-      scalar_func<P> const exact_time_in, dt_func<P> const get_dt,
-      bool const do_poisson_solve_in          = false,
-      bool const has_analytic_soln_in         = false,
-      std::vector<moment<P>> const moments_in = {},
-      bool const do_collision_operator_in     = true)
+      int const max_num_terms, std::vector<dimension<P>> dimensions,
+      term_set<P> terms, std::vector<source<P>> sources_in,
+      std::vector<md_func_type<P>> exact_vector_funcs_in,
+      scalar_func<P> exact_time_in, dt_func<P> get_dt,
+      bool const do_poisson_solve_in      = false,
+      bool const has_analytic_soln_in     = false,
+      std::vector<moment<P>> moments_in   = {},
+      bool const do_collision_operator_in = true)
   {
     initialize(cli_input, num_dims_in, num_sources_in,
-      max_num_terms, dimensions, terms, sources_in,
-      exact_vector_funcs_in,
-      exact_time_in, get_dt,
+      max_num_terms, std::move(dimensions), std::move(terms), std::move(sources_in),
+      std::move(exact_vector_funcs_in),
+      std::move(exact_time_in), std::move(get_dt),
       do_poisson_solve_in,
       has_analytic_soln_in,
-      moments_in,
+      std::move(moments_in),
       do_collision_operator_in);
   }
 

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -1028,7 +1028,7 @@ private:
     }
     else
     {
-      return exact_time_func;
+      return std::move(exact_time_func);
     }
   }
 

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -456,12 +456,15 @@ public:
   source(std::vector<vector_func<P>> const source_funcs_in,
          scalar_func<P> const time_func_in)
 
-      : source_funcs(source_funcs_in), time_func(time_func_in)
+      : source_funcs_(source_funcs_in), time_func_(time_func_in)
   {}
 
-  // public but const data. no getters
-  std::vector<vector_func<P>> source_funcs;
-  scalar_func<P> time_func;
+  std::vector<vector_func<P>> const &source_funcs() const { return source_funcs_; }
+  scalar_func<P> const &time_func() const { return time_func_; }
+
+private:
+  std::vector<vector_func<P>> source_funcs_;
+  scalar_func<P> time_func_;
 };
 
 template<typename P>
@@ -547,6 +550,7 @@ template<typename P>
 class PDE
 {
 public:
+  PDE() : num_dims(0), num_sources(0), num_terms(0), max_level(0) {}
   PDE(parser const &cli_input, int const num_dims_in, int const num_sources_in,
       int const max_num_terms, std::vector<dimension<P>> const dimensions,
       term_set<P> const terms, std::vector<source<P>> const sources_in,
@@ -733,7 +737,7 @@ public:
     // check all sources
     for (auto const &s : sources)
     {
-      expect(s.source_funcs.size() == static_cast<unsigned>(num_dims));
+      expect(s.source_funcs().size() == static_cast<unsigned>(num_dims));
     }
 
     // set the dt

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -158,30 +158,30 @@ public:
 
   P get_flux_scale() const { return static_cast<P>(flux); };
 
-  coefficient_type const coeff_type;
+  coefficient_type coeff_type;
 
-  g_func_type<P> const g_func;
-  g_func_type<P> const lhs_mass_func;
+  g_func_type<P> g_func;
+  g_func_type<P> lhs_mass_func;
 
-  flux_type const flux;
+  flux_type flux;
 
-  boundary_condition const left;
+  boundary_condition left;
 
-  boundary_condition const right;
+  boundary_condition right;
 
-  boundary_condition const ileft;
-  boundary_condition const iright;
+  boundary_condition ileft;
+  boundary_condition iright;
 
-  homogeneity const left_homo;
-  homogeneity const right_homo;
-  std::vector<vector_func<P>> const left_bc_funcs;
-  std::vector<vector_func<P>> const right_bc_funcs;
-  scalar_func<P> const left_bc_time_func;
-  scalar_func<P> const right_bc_time_func;
+  homogeneity left_homo;
+  homogeneity right_homo;
+  std::vector<vector_func<P>> left_bc_funcs;
+  std::vector<vector_func<P>> right_bc_funcs;
+  scalar_func<P> left_bc_time_func;
+  scalar_func<P> right_bc_time_func;
 
-  g_func_type<P> const dv_func;
+  g_func_type<P> dv_func;
 
-  fk::matrix<P> const get_coefficients(int const level) const
+  fk::matrix<P>  get_coefficients(int const level) const
   {
     // returns precomputed inv(mass) * coeff for this level
     expect(static_cast<int>(coefficients_.size()) > level);
@@ -384,10 +384,10 @@ public:
   }
 
   // public but const data. no getters
-  bool const time_dependent;
-  std::string const name;
+  bool time_dependent;
+  std::string name;
 
-  imex_flag const flag;
+  imex_flag flag;
 
 private:
   std::vector<partial_term<P>> partial_terms_;
@@ -414,8 +414,8 @@ public:
   {}
 
   // public but const data. no getters
-  std::vector<vector_func<P>> const source_funcs;
-  scalar_func<P> const time_func;
+  std::vector<vector_func<P>> source_funcs;
+  scalar_func<P> time_func;
 };
 
 template<typename P>
@@ -525,16 +525,53 @@ public:
       bool const has_analytic_soln_in         = false,
       std::vector<moment<P>> const moments_in = {},
       bool const do_collision_operator_in     = true)
-      : num_dims(num_dims_in), num_sources(num_sources_in),
-        num_terms(get_num_terms(cli_input, max_num_terms)),
-        max_level(get_max_level(cli_input, dimensions)), sources(sources_in),
-        exact_vector_funcs(exact_vector_funcs_in), moments(moments_in),
-        exact_time(check_exact_time(exact_time_in)),
-        do_poisson_solve(do_poisson_solve_in),
-        do_collision_operator(do_collision_operator_in),
-        has_analytic_soln(has_analytic_soln_in), dimensions_(dimensions),
-        terms_(terms)
+      // : num_dims(num_dims_in), num_sources(num_sources_in),
+      //   num_terms(get_num_terms(cli_input, max_num_terms)),
+      //   max_level(get_max_level(cli_input, dimensions)), sources(sources_in),
+      //   exact_vector_funcs(exact_vector_funcs_in), moments(moments_in),
+      //   exact_time(check_exact_time(exact_time_in)),
+      //   do_poisson_solve(do_poisson_solve_in),
+      //   do_collision_operator(do_collision_operator_in),
+      //   has_analytic_soln(has_analytic_soln_in), dimensions_(dimensions),
+      //   terms_(terms)
   {
+    initialize(cli_input, num_dims_in, num_sources_in,
+      max_num_terms, dimensions, terms, sources_in,
+      exact_vector_funcs_in,
+      exact_time_in, get_dt,
+      do_poisson_solve_in,
+      has_analytic_soln_in,
+      moments_in,
+      do_collision_operator_in);
+  }
+
+  void initialize(parser const &cli_input, int const num_dims_in, int const num_sources_in,
+      int const max_num_terms, std::vector<dimension<P>> const dimensions,
+      term_set<P> const terms, std::vector<source<P>> const sources_in,
+      std::vector<md_func_type<P>> const exact_vector_funcs_in,
+      scalar_func<P> const exact_time_in, dt_func<P> const get_dt,
+      bool const do_poisson_solve_in          = false,
+      bool const has_analytic_soln_in         = false,
+      std::vector<moment<P>> const moments_in = {},
+      bool const do_collision_operator_in     = true)
+  {
+    num_dims    = num_dims_in;
+    num_sources = num_sources_in;
+    num_terms   = get_num_terms(cli_input, max_num_terms);
+    max_level   = get_max_level(cli_input, dimensions);
+
+    sources            = std::move(sources_in);
+    exact_vector_funcs = std::move(exact_vector_funcs_in);
+    moments            = std::move(moments_in);
+
+    exact_time = check_exact_time(exact_time_in);
+
+    do_poisson_solve      = do_poisson_solve_in;
+    do_collision_operator = do_collision_operator_in;
+    has_analytic_soln     = has_analytic_soln_in;
+    dimensions_           = std::move(dimensions);
+    terms_                = std::move(terms);
+
     expect(num_dims > 0);
     expect(num_sources >= 0);
     expect(num_terms > 0);
@@ -724,18 +761,18 @@ public:
   {}
 
   // public but const data.
-  int const num_dims;
-  int const num_sources;
-  int const num_terms;
-  int const max_level;
+  int num_dims;
+  int num_sources;
+  int num_terms;
+  int max_level;
 
-  std::vector<source<P>> const sources;
-  std::vector<md_func_type<P>> const exact_vector_funcs;
+  std::vector<source<P>> sources;
+  std::vector<md_func_type<P>> exact_vector_funcs;
   std::vector<moment<P>> moments;
-  scalar_func<P> const exact_time;
-  bool const do_poisson_solve;
-  bool const do_collision_operator;
-  bool const has_analytic_soln;
+  scalar_func<P> exact_time;
+  bool do_poisson_solve;
+  bool do_collision_operator;
+  bool has_analytic_soln;
   // data for poisson solver
   fk::vector<P> poisson_diag;
   fk::vector<P> poisson_off_diag;

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -51,7 +51,7 @@ enum class homogeneity
 // helper - single element size
 auto const element_segment_size = [](auto const &pde) {
   int const degree = pde.get_dimensions()[0].get_degree();
-  return static_cast<int>(std::pow(degree, pde.num_dims));
+  return static_cast<int>(std::pow(degree, pde.num_dims()));
 };
 
 // ---------------------------------------------------------------------------
@@ -550,7 +550,7 @@ template<typename P>
 class PDE
 {
 public:
-  PDE() : num_dims(0), num_sources(0), num_terms(0), max_level(0) {}
+  PDE() : num_dims_(0), num_sources_(0), num_terms_(0), max_level_(0) {}
   PDE(parser const &cli_input, int const num_dims_in, int const num_sources_in,
       int const max_num_terms, std::vector<dimension<P>> const dimensions,
       term_set<P> const terms, std::vector<source<P>> const sources_in,
@@ -596,14 +596,14 @@ public:
       std::vector<moment<P>> const moments_in = {},
       bool const do_collision_operator_in     = true)
   {
-    num_dims    = num_dims_in;
-    num_sources = num_sources_in;
-    num_terms   = get_num_terms(cli_input, max_num_terms);
-    max_level   = get_max_level(cli_input, dimensions);
+    num_dims_    = num_dims_in;
+    num_sources_ = num_sources_in;
+    num_terms_   = get_num_terms(cli_input, max_num_terms);
+    max_level_   = get_max_level(cli_input, dimensions);
 
-    sources            = std::move(sources_in);
-    exact_vector_funcs = std::move(exact_vector_funcs_in);
-    moments            = std::move(moments_in);
+    sources_            = std::move(sources_in);
+    exact_vector_funcs_ = std::move(exact_vector_funcs_in);
+    moments             = std::move(moments_in);
 
     exact_time_ = check_exact_time(exact_time_in);
 
@@ -613,34 +613,34 @@ public:
     dimensions_            = std::move(dimensions);
     terms_                 = std::move(terms);
 
-    expect(num_dims > 0);
-    expect(num_sources >= 0);
-    expect(num_terms > 0);
+    expect(num_dims_ > 0);
+    expect(num_sources_ >= 0);
+    expect(num_terms_ > 0);
 
-    expect(dimensions.size() == static_cast<unsigned>(num_dims));
+    expect(dimensions.size() == static_cast<unsigned>(num_dims_));
     expect(terms.size() == static_cast<unsigned>(max_num_terms));
-    expect(sources.size() == static_cast<unsigned>(num_sources));
+    expect(sources_.size() == static_cast<unsigned>(num_sources_));
 
     // ensure analytic solution functions were provided if this flag is set
     if (has_analytic_soln_)
     {
       // each set of analytical solution functions must have num_dim functions
-      for (const auto &md_func : exact_vector_funcs)
+      for (const auto &md_func : exact_vector_funcs_)
       {
-        expect(md_func.size() == static_cast<size_t>(num_dims) or md_func.size() == static_cast<size_t>(num_dims + 1));
+        expect(md_func.size() == static_cast<size_t>(num_dims_) or md_func.size() == static_cast<size_t>(num_dims_ + 1));
       }
     }
 
     // modify for appropriate level/degree
     // if default lev/degree not used
     auto const user_levels = cli_input.get_starting_levels().size();
-    if (user_levels != 0 && user_levels != num_dims)
+    if (user_levels != 0 && user_levels != num_dims_)
     {
       std::cerr << "failed to parse dimension-many starting levels - parsed "
                 << user_levels << " levels\n";
       exit(1);
     }
-    if (user_levels == num_dims)
+    if (user_levels == num_dims_)
     {
       auto counter = 0;
       for (dimension<P> &d : dimensions_)
@@ -662,7 +662,7 @@ public:
           terms_.erase(terms_.begin() + i);
         }
       }
-      expect(terms_.size() == static_cast<unsigned>(num_terms));
+      expect(terms_.size() == static_cast<unsigned>(num_terms_));
     }
 
     auto const cli_degree = cli_input.get_degree();
@@ -680,13 +680,13 @@ public:
     // check all terms
     for (auto &term_list : terms_)
     {
-      expect(term_list.size() == static_cast<unsigned>(num_dims));
+      expect(term_list.size() == static_cast<unsigned>(num_dims_));
       for (auto &term_1D : term_list)
       {
         expect(term_1D.get_partial_terms().size() > 0);
 
         auto const max_dof =
-            fm::two_raised_to(static_cast<int64_t>(max_level)) * degree;
+            fm::two_raised_to(static_cast<int64_t>(max_level_)) * degree;
         expect(max_dof < INT_MAX);
 
         term_1D.set_coefficients(eye<P>(max_dof));
@@ -696,12 +696,12 @@ public:
           if (p.left_homo() == homogeneity::homogeneous)
             expect(static_cast<int>(p.left_bc_funcs().size()) == 0);
           else if (p.left_homo() == homogeneity::inhomogeneous)
-            expect(static_cast<int>(p.left_bc_funcs().size()) == num_dims);
+            expect(static_cast<int>(p.left_bc_funcs().size()) == num_dims_);
 
           if (p.right_homo() == homogeneity::homogeneous)
             expect(static_cast<int>(p.right_bc_funcs().size()) == 0);
           else if (p.right_homo() == homogeneity::inhomogeneous)
-            expect(static_cast<int>(p.right_bc_funcs().size()) == num_dims);
+            expect(static_cast<int>(p.right_bc_funcs().size()) == num_dims_);
         }
       }
     }
@@ -715,9 +715,9 @@ public:
     }
 
     // initialize mass matrices to a default value
-    for (auto i = 0; i < num_dims; ++i)
+    for (auto i = 0; i < num_dims_; ++i)
     {
-      for (int level = 0; level <= max_level; ++level)
+      for (int level = 0; level <= max_level_; ++level)
       {
         auto const dof = fm::two_raised_to(level) * degree;
         expect(dof < INT_MAX);
@@ -726,9 +726,9 @@ public:
     }
 
     // check all sources
-    for (auto const &s : sources)
+    for (auto const &s : sources_)
     {
-      expect(s.source_funcs().size() == static_cast<unsigned>(num_dims));
+      expect(s.source_funcs().size() == static_cast<unsigned>(num_dims_));
     }
 
     // set the dt
@@ -748,7 +748,7 @@ public:
       auto md_funcs = m.get_md_funcs();
       for (auto md_func : md_funcs)
       {
-        expect(md_func.size() == static_cast<unsigned>(num_dims) + 1);
+        expect(md_func.size() == static_cast<unsigned>(num_dims_) + 1);
       }
     }
 
@@ -762,17 +762,17 @@ public:
     gmres_outputs.resize(cli_input.using_imex() ? 2 : 1);
 
     // hack to preallocate empty matrix for pterm coefficients for adapt
-    for (auto i = 0; i < num_dims; ++i)
+    for (auto i = 0; i < num_dims_; ++i)
     {
       auto const &dim = this->get_dimensions()[i];
-      for (auto j = 0; j < num_terms; ++j)
+      for (auto j = 0; j < num_terms_; ++j)
       {
         auto const &term_1D       = this->get_terms()[j][i];
         auto const &partial_terms = term_1D.get_partial_terms();
         for (auto k = 0; k < static_cast<int>(partial_terms.size()); ++k)
         {
           std::vector<fk::matrix<P>> pterm_coeffs;
-          for (int level = 0; level <= max_level; ++level)
+          for (int level = 0; level <= max_level_; ++level)
           {
             auto const dof = dim.get_degree() * fm::two_raised_to(level);
             fk::matrix<P> result_tmp = eye<P>(dof);
@@ -791,10 +791,10 @@ public:
   // TODO: there is likely a better way to do this. Another option is to flatten
   // element table to 1D (see hash_table_2D_to_1D.m)
   PDE(const PDE &pde, int)
-      : num_dims(1), num_sources(pde.sources.size()),
-        num_terms(pde.get_terms().size()), max_level(pde.max_level),
-        sources(pde.sources), exact_vector_funcs(pde.exact_vector_funcs),
-        moments(pde.moments), exact_time_(pde.exact_time()),
+      : moments(pde.moments), num_dims_(1), num_sources_(pde.sources_.size()),
+        num_terms_(pde.get_terms().size()), max_level_(pde.max_level_),
+        sources_(pde.sources_), exact_vector_funcs_(pde.exact_vector_funcs_),
+        exact_time_(pde.exact_time()),
         do_poisson_solve_(pde.do_poisson_solve()),
         do_collision_operator_(pde.do_collision_operator()),
         has_analytic_soln_(pde.has_analytic_soln()),
@@ -802,13 +802,17 @@ public:
   {}
 
   // public but const data.
-  int num_dims;
-  int num_sources;
-  int num_terms;
-  int max_level;
+  int num_dims() const { return num_dims_; }
+  int num_sources() const { return num_sources_; }
+  int num_terms() const { return num_terms_; }
+  int max_level() const { return max_level_; }
 
-  std::vector<source<P>> sources;
-  std::vector<md_func_type<P>> exact_vector_funcs;
+  std::vector<source<P>> const &sources() const { return sources_; };
+  std::vector<md_func_type<P>> const &exact_vector_funcs() const
+  {
+    return exact_vector_funcs_;
+  }
+
   std::vector<moment<P>> moments;
   scalar_func<P> const& exact_time() const { return exact_time_; }
   bool do_poisson_solve() const { return do_poisson_solve_; }
@@ -840,9 +844,9 @@ public:
   fk::matrix<P> const &get_coefficients(int const term, int const dim) const
   {
     expect(term >= 0);
-    expect(term < num_terms);
+    expect(term < num_terms_);
     expect(dim >= 0);
-    expect(dim < num_dims);
+    expect(dim < num_dims_);
     return terms_[term][dim].get_coefficients();
   }
 
@@ -852,9 +856,9 @@ public:
   set_coefficients(fk::matrix<P> const &coeffs, int const term, int const dim)
   {
     expect(term >= 0);
-    expect(term < num_terms);
+    expect(term < num_terms_);
     expect(dim >= 0);
-    expect(dim < num_dims);
+    expect(dim < num_dims_);
     terms_[term][dim].set_coefficients(coeffs);
   }
 
@@ -862,9 +866,9 @@ public:
                                 fk::matrix<P> const &&coeffs)
   {
     expect(term >= 0);
-    expect(term < num_terms);
+    expect(term < num_terms_);
     expect(dim >= 0);
-    expect(dim < num_dims);
+    expect(dim < num_dims_);
     terms_[term][dim].set_partial_coefficients(std::move(coeffs), pterm,
                                                dimensions_[dim].get_degree(),
                                                dimensions_[dim].get_level());
@@ -874,9 +878,9 @@ public:
                                 std::vector<fk::matrix<P>> const &coeffs)
   {
     expect(term >= 0);
-    expect(term < num_terms);
+    expect(term < num_terms_);
     expect(dim >= 0);
-    expect(dim < num_dims);
+    expect(dim < num_dims_);
     terms_[term][dim].set_partial_coefficients(coeffs, pterm);
   }
 
@@ -884,9 +888,9 @@ public:
                     fk::matrix<P> const &mass)
   {
     expect(term >= 0);
-    expect(term < num_terms);
+    expect(term < num_terms_);
     expect(dim >= 0);
-    expect(dim < num_dims);
+    expect(dim < num_dims_);
     terms_[term][dim].set_lhs_mass(mass, pterm);
   }
 
@@ -894,16 +898,16 @@ public:
                     fk::matrix<P> &&mass)
   {
     expect(term >= 0);
-    expect(term < num_terms);
+    expect(term < num_terms_);
     expect(dim >= 0);
-    expect(dim < num_dims);
+    expect(dim < num_dims_);
     terms_[term][dim].set_lhs_mass(mass, std::move(pterm));
   }
 
   void update_dimension(int const dim_index, int const new_level)
   {
     assert(dim_index >= 0);
-    assert(dim_index < num_dims);
+    assert(dim_index < num_dims_);
     assert(new_level >= 0);
 
     dimensions_[dim_index].set_level(new_level);
@@ -912,8 +916,8 @@ public:
   void rechain_dimension(int const dim_index)
   {
     expect(dim_index >= 0);
-    expect(dim_index < num_dims);
-    for (auto i = 0; i < num_terms; ++i)
+    expect(dim_index < num_dims_);
+    for (auto i = 0; i < num_terms_; ++i)
     {
       terms_[i][dim_index].rechain_coefficients(dimensions_[dim_index]);
     }
@@ -923,7 +927,7 @@ public:
                                  int const level)
   {
     assert(dim_index >= 0);
-    assert(dim_index < num_dims);
+    assert(dim_index < num_dims_);
 
     dimensions_[dim_index].set_mass_matrix(std::move(mass), level);
   }
@@ -1008,6 +1012,14 @@ private:
       return exact_time_func;
     }
   }
+
+  int num_dims_;
+  int num_sources_;
+  int num_terms_;
+  int max_level_;
+
+  std::vector<source<P>> sources_;
+  std::vector<md_func_type<P>> exact_vector_funcs_;
 
   scalar_func<P> exact_time_;
   bool do_poisson_solve_;

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -323,7 +323,7 @@ public:
   term(bool const time_dependent_in, std::string const name_in,
        std::initializer_list<partial_term<P>> const partial_terms,
        imex_flag const flag_in = imex_flag::unspecified)
-      : time_dependent(time_dependent_in), name(name_in), flag(flag_in),
+      : time_dependent_(time_dependent_in), name_(name_in), flag_(flag_in),
         partial_terms_(partial_terms)
   {}
 
@@ -425,13 +425,17 @@ public:
     }
   }
 
-  // public but const data. no getters
-  bool time_dependent;
-  std::string name;
+  bool time_dependent() const { return time_dependent_; }
+  std::string const &name() const { return name_; }
 
-  imex_flag flag;
+  imex_flag flag() const { return flag_; }
 
 private:
+  bool time_dependent_;
+  std::string name_;
+
+  imex_flag flag_;
+
   std::vector<partial_term<P>> partial_terms_;
 
   // operator matrix for this term at a single dimension

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -146,40 +146,17 @@ public:
                scalar_func<P> const right_bc_time_func_in          = nullptr,
                g_func_type<P> const dv_func_in                     = nullptr)
 
-      : coeff_type(coeff_type_in), g_func(g_func_in),
-        lhs_mass_func(lhs_mass_func_in), flux(set_flux(flux_in)), left(left_in),
-        right(right_in), ileft(set_bilinear_boundary(left_in)),
-        iright(set_bilinear_boundary(right_in)), left_homo(left_homo_in),
-        right_homo(right_homo_in), left_bc_funcs(left_bc_funcs_in),
-        right_bc_funcs(right_bc_funcs_in),
-        left_bc_time_func(left_bc_time_func_in),
-        right_bc_time_func(right_bc_time_func_in), dv_func(dv_func_in)
+      : coeff_type_(coeff_type_in), g_func_(g_func_in),
+        lhs_mass_func_(lhs_mass_func_in), flux_(set_flux(flux_in)), left_(left_in),
+        right_(right_in), ileft_(set_bilinear_boundary(left_in)),
+        iright_(set_bilinear_boundary(right_in)), left_homo_(left_homo_in),
+        right_homo_(right_homo_in), left_bc_funcs_(left_bc_funcs_in),
+        right_bc_funcs_(right_bc_funcs_in),
+        left_bc_time_func_(left_bc_time_func_in),
+        right_bc_time_func_(right_bc_time_func_in), dv_func_(dv_func_in)
   {}
 
-  P get_flux_scale() const { return static_cast<P>(flux); };
-
-  coefficient_type coeff_type;
-
-  g_func_type<P> g_func;
-  g_func_type<P> lhs_mass_func;
-
-  flux_type flux;
-
-  boundary_condition left;
-
-  boundary_condition right;
-
-  boundary_condition ileft;
-  boundary_condition iright;
-
-  homogeneity left_homo;
-  homogeneity right_homo;
-  std::vector<vector_func<P>> left_bc_funcs;
-  std::vector<vector_func<P>> right_bc_funcs;
-  scalar_func<P> left_bc_time_func;
-  scalar_func<P> right_bc_time_func;
-
-  g_func_type<P> dv_func;
+  P get_flux_scale() const { return static_cast<P>(flux_); };
 
   fk::matrix<P>  get_coefficients(int const level) const
   {
@@ -245,7 +222,7 @@ public:
     // Instead we have another BC flag IBCL/IBCR which will build the
     // bilinear form with respect to Dirichlet/Free boundary
     // conditions while leaving the BC routine unaffected.
-    if (coeff_type == coefficient_type::grad)
+    if (coeff_type_ == coefficient_type::grad)
     {
       if (bc == boundary_condition::dirichlet)
       {
@@ -261,7 +238,7 @@ public:
 
   flux_type set_flux(flux_type const flux_in)
   {
-    if (coeff_type == coefficient_type::grad)
+    if (coeff_type_ == coefficient_type::grad)
     {
       // Switch the upwinding direction
       return static_cast<flux_type>(-static_cast<P>(flux_in));
@@ -269,7 +246,72 @@ public:
     return flux_in;
   }
 
+  coefficient_type coeff_type() const { return coeff_type_; }
+
+  g_func_type<P> const &g_func() const { return g_func_; }
+  g_func_type<P> const &lhs_mass_func() const { return lhs_mass_func_; }
+
+  flux_type flux() const { return flux_; }
+
+  boundary_condition left() const { return left_; }
+
+  boundary_condition right() const { return right_; }
+
+  boundary_condition ileft() const { return ileft_; }
+  boundary_condition iright() const { return iright_; }
+
+  homogeneity left_homo() const { return left_homo_; };
+  homogeneity right_homo() const { return right_homo_; };
+
+  std::vector<vector_func<P>> const &left_bc_funcs() const
+  {
+    return left_bc_funcs_;
+  };
+  std::vector<vector_func<P>> const &right_bc_funcs() const
+  {
+    return right_bc_funcs_;
+  };
+
+  scalar_func<P> const &left_bc_time_func() const
+  {
+    return left_bc_time_func_;
+  }
+
+  scalar_func<P> const &right_bc_time_func() const
+  {
+    return right_bc_time_func_;
+  }
+
+  g_func_type<P> const &dv_func() const
+  {
+    return dv_func_;
+  }
+
 private:
+  coefficient_type coeff_type_;
+
+  g_func_type<P> g_func_;
+  g_func_type<P> lhs_mass_func_;
+
+  flux_type flux_;
+
+  boundary_condition left_;
+
+  boundary_condition right_;
+
+  boundary_condition ileft_;
+  boundary_condition iright_;
+
+  homogeneity left_homo_;
+  homogeneity right_homo_;
+
+  std::vector<vector_func<P>> left_bc_funcs_;
+  std::vector<vector_func<P>> right_bc_funcs_;
+
+  scalar_func<P> left_bc_time_func_;
+  scalar_func<P> right_bc_time_func_;
+  g_func_type<P> dv_func_;
+
   std::vector<fk::matrix<P>> coefficients_;
   fk::matrix<P> mass_;
 };
@@ -652,15 +694,15 @@ public:
 
         for (auto &p : term_1D.get_partial_terms())
         {
-          if (p.left_homo == homogeneity::homogeneous)
-            expect(static_cast<int>(p.left_bc_funcs.size()) == 0);
-          else if (p.left_homo == homogeneity::inhomogeneous)
-            expect(static_cast<int>(p.left_bc_funcs.size()) == num_dims);
+          if (p.left_homo() == homogeneity::homogeneous)
+            expect(static_cast<int>(p.left_bc_funcs().size()) == 0);
+          else if (p.left_homo() == homogeneity::inhomogeneous)
+            expect(static_cast<int>(p.left_bc_funcs().size()) == num_dims);
 
-          if (p.right_homo == homogeneity::homogeneous)
-            expect(static_cast<int>(p.right_bc_funcs.size()) == 0);
-          else if (p.right_homo == homogeneity::inhomogeneous)
-            expect(static_cast<int>(p.right_bc_funcs.size()) == num_dims);
+          if (p.right_homo() == homogeneity::homogeneous)
+            expect(static_cast<int>(p.right_bc_funcs().size()) == 0);
+          else if (p.right_homo() == homogeneity::inhomogeneous)
+            expect(static_cast<int>(p.right_bc_funcs().size()) == num_dims);
         }
       }
     }

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -575,15 +575,6 @@ public:
       bool const has_analytic_soln_in         = false,
       std::vector<moment<P>> const moments_in = {},
       bool const do_collision_operator_in     = true)
-      // : num_dims(num_dims_in), num_sources(num_sources_in),
-      //   num_terms(get_num_terms(cli_input, max_num_terms)),
-      //   max_level(get_max_level(cli_input, dimensions)), sources(sources_in),
-      //   exact_vector_funcs(exact_vector_funcs_in), moments(moments_in),
-      //   exact_time(check_exact_time(exact_time_in)),
-      //   do_poisson_solve(do_poisson_solve_in),
-      //   do_collision_operator(do_collision_operator_in),
-      //   has_analytic_soln(has_analytic_soln_in), dimensions_(dimensions),
-      //   terms_(terms)
   {
     initialize(cli_input, num_dims_in, num_sources_in,
       max_num_terms, dimensions, terms, sources_in,
@@ -614,13 +605,13 @@ public:
     exact_vector_funcs = std::move(exact_vector_funcs_in);
     moments            = std::move(moments_in);
 
-    exact_time = check_exact_time(exact_time_in);
+    exact_time_ = check_exact_time(exact_time_in);
 
-    do_poisson_solve      = do_poisson_solve_in;
-    do_collision_operator = do_collision_operator_in;
-    has_analytic_soln     = has_analytic_soln_in;
-    dimensions_           = std::move(dimensions);
-    terms_                = std::move(terms);
+    do_poisson_solve_      = do_poisson_solve_in;
+    do_collision_operator_ = do_collision_operator_in;
+    has_analytic_soln_     = has_analytic_soln_in;
+    dimensions_            = std::move(dimensions);
+    terms_                 = std::move(terms);
 
     expect(num_dims > 0);
     expect(num_sources >= 0);
@@ -631,7 +622,7 @@ public:
     expect(sources.size() == static_cast<unsigned>(num_sources));
 
     // ensure analytic solution functions were provided if this flag is set
-    if (has_analytic_soln)
+    if (has_analytic_soln_)
     {
       // each set of analytical solution functions must have num_dim functions
       for (const auto &md_func : exact_vector_funcs)
@@ -803,10 +794,10 @@ public:
       : num_dims(1), num_sources(pde.sources.size()),
         num_terms(pde.get_terms().size()), max_level(pde.max_level),
         sources(pde.sources), exact_vector_funcs(pde.exact_vector_funcs),
-        moments(pde.moments), exact_time(pde.exact_time),
-        do_poisson_solve(pde.do_poisson_solve),
-        do_collision_operator(pde.do_collision_operator),
-        has_analytic_soln(pde.has_analytic_soln),
+        moments(pde.moments), exact_time_(pde.exact_time()),
+        do_poisson_solve_(pde.do_poisson_solve()),
+        do_collision_operator_(pde.do_collision_operator()),
+        has_analytic_soln_(pde.has_analytic_soln()),
         dimensions_({pde.get_dimensions()[0]}), terms_(pde.get_terms())
   {}
 
@@ -819,10 +810,11 @@ public:
   std::vector<source<P>> sources;
   std::vector<md_func_type<P>> exact_vector_funcs;
   std::vector<moment<P>> moments;
-  scalar_func<P> exact_time;
-  bool do_poisson_solve;
-  bool do_collision_operator;
-  bool has_analytic_soln;
+  scalar_func<P> const& exact_time() const { return exact_time_; }
+  bool do_poisson_solve() const { return do_poisson_solve_; }
+  bool do_collision_operator() const { return do_collision_operator_; }
+  bool has_analytic_soln() const { return has_analytic_soln_; }
+
   // data for poisson solver
   fk::vector<P> poisson_diag;
   fk::vector<P> poisson_off_diag;
@@ -834,7 +826,7 @@ public:
   std::vector<gmres_info<P>> gmres_outputs;
   adaptive_info<P> adapt_info;
 
-  virtual ~PDE() {}
+  virtual ~PDE() = default;
 
   std::vector<dimension<P>> const &get_dimensions() const
   {
@@ -1016,6 +1008,11 @@ private:
       return exact_time_func;
     }
   }
+
+  scalar_func<P> exact_time_;
+  bool do_poisson_solve_;
+  bool do_collision_operator_;
+  bool has_analytic_soln_;
 
   std::vector<dimension<P>> dimensions_;
   term_set<P> terms_;

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -587,14 +587,33 @@ public:
   }
 
   void initialize(parser const &cli_input, int const num_dims_in, int const num_sources_in,
-      int const max_num_terms, std::vector<dimension<P>> const dimensions,
-      term_set<P> const terms, std::vector<source<P>> const sources_in,
-      std::vector<md_func_type<P>> const exact_vector_funcs_in,
-      scalar_func<P> const exact_time_in, dt_func<P> const get_dt,
-      bool const do_poisson_solve_in          = false,
-      bool const has_analytic_soln_in         = false,
-      std::vector<moment<P>> const moments_in = {},
-      bool const do_collision_operator_in     = true)
+      int const max_num_terms, std::vector<dimension<P>> const &dimensions,
+      term_set<P> const &terms, std::vector<source<P>> const &sources_in,
+      std::vector<md_func_type<P>> const &exact_vector_funcs_in,
+      scalar_func<P> const &exact_time_in, dt_func<P> const &get_dt,
+      bool const do_poisson_solve_in           = false,
+      bool const has_analytic_soln_in          = false,
+      std::vector<moment<P>> const &moments_in = {},
+      bool const do_collision_operator_in      = true)
+  {
+    this->initialize(cli_input, num_dims_in, num_sources_in, max_num_terms,
+                     std::vector<dimension<P>>(dimensions), term_set<P>(terms),
+                     std::vector<source<P>>(sources_in),
+                     std::vector<md_func_type<P>>(exact_vector_funcs_in),
+                     scalar_func<P>(exact_time_in), dt_func<P>(get_dt), do_poisson_solve_in,
+                     has_analytic_soln_in, std::vector<moment<P>>(moments_in),
+                     do_collision_operator_in);
+  }
+
+  void initialize(parser const &cli_input, int const num_dims_in, int const num_sources_in,
+      int const max_num_terms, std::vector<dimension<P>> &&dimensions,
+      term_set<P> &&terms, std::vector<source<P>> &&sources_in,
+      std::vector<md_func_type<P>> &&exact_vector_funcs_in,
+      scalar_func<P> &&exact_time_in, dt_func<P> &&get_dt,
+      bool const do_poisson_solve_in      = false,
+      bool const has_analytic_soln_in     = false,
+      std::vector<moment<P>> &&moments_in = {},
+      bool const do_collision_operator_in = true)
   {
     num_dims_    = num_dims_in;
     num_sources_ = num_sources_in;
@@ -605,7 +624,7 @@ public:
     exact_vector_funcs_ = std::move(exact_vector_funcs_in);
     moments             = std::move(moments_in);
 
-    exact_time_ = check_exact_time(exact_time_in);
+    exact_time_ = check_exact_time(std::move(exact_time_in));
 
     do_poisson_solve_      = do_poisson_solve_in;
     do_collision_operator_ = do_collision_operator_in;
@@ -617,8 +636,8 @@ public:
     expect(num_sources_ >= 0);
     expect(num_terms_ > 0);
 
-    expect(dimensions.size() == static_cast<unsigned>(num_dims_));
-    expect(terms.size() == static_cast<unsigned>(max_num_terms));
+    expect(dimensions_.size() == static_cast<unsigned>(num_dims_));
+    expect(terms_.size() == static_cast<unsigned>(max_num_terms));
     expect(sources_.size() == static_cast<unsigned>(num_sources_));
 
     // ensure analytic solution functions were provided if this flag is set
@@ -997,7 +1016,7 @@ private:
     }
   }
 
-  scalar_func<P> check_exact_time(scalar_func<P> const &exact_time_func)
+  scalar_func<P> check_exact_time(scalar_func<P> &&exact_time_func)
   {
     // check if the PDE exact time function was defined, or return an empty one
     if (!exact_time_func)

--- a/src/pde/pde_two_stream.hpp
+++ b/src/pde/pde_two_stream.hpp
@@ -15,11 +15,20 @@ class PDE_vlasov_two_stream : public PDE<P>
 {
 public:
   PDE_vlasov_two_stream(parser const &cli_input)
-      : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
-               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
-               get_dt_, do_poisson_solve_, has_analytic_soln_, moments_,
-               do_collision_operator_)
   {
+    std::vector<dimension<P>> dimensions = {
+      dimension<P>(-2.0 * PI, 2.0 * PI, 4, default_degree,
+                   initial_condition_dim_x_0, nullptr, "x"),
+      dimension<P>(-2.0 * PI, 2.0 * PI, 3, default_degree,
+                   initial_condition_dim_v_0, nullptr, "v")
+    };
+
+    // using empty instances for exact_vector_funcs and exact_time
+    this->initialize(cli_input, num_dims_, num_sources_, num_terms_, dimensions,
+                     terms_, sources_, std::vector<md_func_type<P>>{}, scalar_func<P>{},
+                     get_dt_, do_poisson_solve_, has_analytic_soln_, moments_,
+                     do_collision_operator_);
+
     param_manager.add_parameter(parameter<P>{"n", n});
     param_manager.add_parameter(parameter<P>{"u", u});
     param_manager.add_parameter(parameter<P>{"theta", theta});
@@ -63,17 +72,6 @@ private:
         });
     return fx;
   }
-
-  /* Define the dimension */
-  inline static dimension<P> const dim_0 =
-      dimension<P>(-2.0 * PI, 2.0 * PI, 4, default_degree,
-                   initial_condition_dim_x_0, nullptr, "x");
-
-  inline static dimension<P> const dim_1 =
-      dimension<P>(-2.0 * PI, 2.0 * PI, 3, default_degree,
-                   initial_condition_dim_v_0, nullptr, "v");
-
-  inline static std::vector<dimension<P>> const dimensions_ = {dim_0, dim_1};
 
   /* Define the moments */
   static fk::vector<P> moment0_f1(fk::vector<P> const &x, P const t = 0)
@@ -300,9 +298,6 @@ private:
   inline static std::vector<term<P>> const terms_4 = {E_mass_x_neg, div_v_up};
 
   inline static term_set<P> const terms_ = {terms_1, terms_2, terms_3, terms_4};
-
-  inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {};
-  inline static scalar_func<P> const exact_scalar_func_               = {};
 
   static P get_dt_(dimension<P> const &dim)
   {

--- a/src/pde/pde_two_stream.hpp
+++ b/src/pde/pde_two_stream.hpp
@@ -16,17 +16,39 @@ class PDE_vlasov_two_stream : public PDE<P>
 public:
   PDE_vlasov_two_stream(parser const &cli_input)
   {
-    std::vector<dimension<P>> dimensions = {
-        dimension<P>(-2.0 * PI, 2.0 * PI, 4, default_degree,
-                     initial_condition_dim_x_0, nullptr, "x"),
-        dimension<P>(-2.0 * PI, 2.0 * PI, 3, default_degree,
-                     initial_condition_dim_v_0, nullptr, "v")};
+    int constexpr num_dims          = 2;
+    int constexpr num_sources       = 0;
+    int constexpr num_terms         = 4;
+    bool constexpr do_poisson_solve = true;
+    // disable implicit steps in IMEX
+    bool constexpr do_collision_operator = false;
+    bool constexpr has_analytic_soln     = false;
+    int constexpr default_degree         = 3;
+
+    term_set<P> terms = {std::vector<term<P>>{term_e1x, term_e1v},
+                         std::vector<term<P>>{term_e2x, term_e2v},
+                         std::vector<term<P>>{E_mass_x_pos, div_v_dn},
+                         std::vector<term<P>>{E_mass_x_neg, div_v_up}};
 
     // using empty instances for exact_vector_funcs and exact_time
-    this->initialize(cli_input, num_dims_, num_sources_, num_terms_, dimensions,
-                     terms_, sources_, std::vector<md_func_type<P>>{}, scalar_func<P>{},
-                     get_dt_, do_poisson_solve_, has_analytic_soln_, moments_,
-                     do_collision_operator_);
+    this->initialize(cli_input, num_dims, num_sources, num_terms,
+                     // defining the dimensions
+                     std::vector<dimension<P>>{
+                         dimension<P>(-2.0 * PI, 2.0 * PI, 4, default_degree,
+                                      initial_condition_dim_x_0, nullptr, "x"),
+                         dimension<P>(-2.0 * PI, 2.0 * PI, 3, default_degree,
+                                      initial_condition_dim_v_0, nullptr, "v")},
+                     // defining the set of terms
+                     term_set<P>{std::vector<term<P>>{term_e1x, term_e1v},
+                                 std::vector<term<P>>{term_e2x, term_e2v},
+                                 std::vector<term<P>>{E_mass_x_pos, div_v_dn},
+                                 std::vector<term<P>>{E_mass_x_neg, div_v_up}},
+                     std::vector<source<P>>{},       // no sources
+                     std::vector<md_func_type<P>>{}, // no exact solution
+                     scalar_func<P>{},               // no exact time
+                     get_dt_, do_poisson_solve, has_analytic_soln,
+                     std::vector<moment<P>>{moment0, moment1, moment2}, // moments
+                     do_collision_operator);
 
     param_manager.add_parameter(parameter<P>{"n", n});
     param_manager.add_parameter(parameter<P>{"u", u});
@@ -37,15 +59,6 @@ public:
   }
 
 private:
-  static int constexpr num_dims_          = 2;
-  static int constexpr num_sources_       = 0;
-  static int constexpr num_terms_         = 4;
-  static bool constexpr do_poisson_solve_ = true;
-  // disable implicit steps in IMEX
-  static bool constexpr do_collision_operator_ = false;
-  static bool constexpr has_analytic_soln_     = false;
-  static int constexpr default_degree          = 3;
-
   static fk::vector<P>
   initial_condition_dim_x_0(fk::vector<P> const &x, P const t = 0)
   {
@@ -104,9 +117,6 @@ private:
       std::vector<md_func_type<P>>({{moment0_f1, moment1_f1, moment0_f1}}));
   inline static moment<P> const moment2 = moment<P>(
       std::vector<md_func_type<P>>({{moment0_f1, moment2_f1, moment0_f1}}));
-
-  inline static std::vector<moment<P>> const moments_ = {moment0, moment1,
-                                                         moment2};
 
   /* Construct (n, u, theta) */
   static P n(P const &x, P const t = 0)
@@ -187,8 +197,6 @@ private:
               "E1_v", // name
               {e1_pterm_v}, imex_flag::imex_explicit);
 
-  inline static std::vector<term<P>> const terms_1 = {term_e1x, term_e1v};
-
   // Term 2
   // -v\cdot\grad_x f for v < 0
   //
@@ -222,8 +230,6 @@ private:
       term<P>(false,  // time-dependent
               "E2_v", // name
               {e2_pterm_v}, imex_flag::imex_explicit);
-
-  inline static std::vector<term<P>> const terms_2 = {term_e2x, term_e2v};
 
   // Term 3
   // -E\cdot\grad_v f for E > 0
@@ -262,8 +268,6 @@ private:
               "",    // name
               {pterm_div_v_dn}, imex_flag::imex_explicit);
 
-  inline static std::vector<term<P>> const terms_3 = {E_mass_x_pos, div_v_dn};
-
   // Term 4
   // E\cdot\grad_v f for E < 0
   //
@@ -294,10 +298,6 @@ private:
               "",    // name
               {pterm_div_v_up}, imex_flag::imex_explicit);
 
-  inline static std::vector<term<P>> const terms_4 = {E_mass_x_neg, div_v_up};
-
-  inline static term_set<P> const terms_ = {terms_1, terms_2, terms_3, terms_4};
-
   static P get_dt_(dimension<P> const &dim)
   {
     ignore(dim);
@@ -309,9 +309,6 @@ private:
     // (Lmax - Lmin) / 2 ^ LevX * CFL
     return (6.0 - (-6.0)) / fm::two_raised_to(3);
   }
-
-  /* problem contains no sources */
-  inline static std::vector<source<P>> const sources_ = {};
 };
 
 } // namespace asgard

--- a/src/pde/pde_two_stream.hpp
+++ b/src/pde/pde_two_stream.hpp
@@ -17,11 +17,10 @@ public:
   PDE_vlasov_two_stream(parser const &cli_input)
   {
     std::vector<dimension<P>> dimensions = {
-      dimension<P>(-2.0 * PI, 2.0 * PI, 4, default_degree,
-                   initial_condition_dim_x_0, nullptr, "x"),
-      dimension<P>(-2.0 * PI, 2.0 * PI, 3, default_degree,
-                   initial_condition_dim_v_0, nullptr, "v")
-    };
+        dimension<P>(-2.0 * PI, 2.0 * PI, 4, default_degree,
+                     initial_condition_dim_x_0, nullptr, "x"),
+        dimension<P>(-2.0 * PI, 2.0 * PI, 3, default_degree,
+                     initial_condition_dim_v_0, nullptr, "v")};
 
     // using empty instances for exact_vector_funcs and exact_time
     this->initialize(cli_input, num_dims_, num_sources_, num_terms_, dimensions,

--- a/src/pde_tests.cpp
+++ b/src/pde_tests.cpp
@@ -63,12 +63,13 @@ void test_source_vectors(PDE<P> const &pde, std::filesystem::path base_dir,
   for (auto i = 0; i < pde.num_sources(); ++i)
   {
     auto const source_string = filename + "source" + std::to_string(i) + "_";
+    auto const &source_funcs = pde.sources()[i].source_funcs();
     for (auto j = 0; j < pde.num_dims(); ++j)
     {
       auto const full_path = base_dir.replace_filename(
           source_string + "dim" + std::to_string(j) + ".dat");
       auto const gold = read_vector_from_txt_file<P>(full_path);
-      auto const fx   = pde.sources()[i].source_funcs()[j](x, time);
+      auto const fx   = source_funcs[j](x, time);
       rmse_comparison(fx, gold, tol_factor);
     }
     P const gold = read_scalar_from_txt_file(

--- a/src/pde_tests.cpp
+++ b/src/pde_tests.cpp
@@ -32,7 +32,7 @@ template<typename P>
 void test_exact_solution(PDE<P> const &pde, std::filesystem::path base_dir,
                          fk::vector<P> const &x, P const time)
 {
-  if (!pde.has_analytic_soln)
+  if (not pde.has_analytic_soln())
   {
     return;
   }
@@ -49,7 +49,7 @@ void test_exact_solution(PDE<P> const &pde, std::filesystem::path base_dir,
 
   P const gold = read_scalar_from_txt_file(
       base_dir.replace_filename(filename + "exact_time.dat"));
-  P const fx = pde.exact_time(time);
+  P const fx = pde.exact_time()(time);
   relaxed_fp_comparison(fx, gold, pde_eps_multiplier);
 }
 

--- a/src/pde_tests.cpp
+++ b/src/pde_tests.cpp
@@ -327,7 +327,7 @@ TEMPLATE_TEST_CASE("testing fokkerplanck2_complete_case4 implementations",
         for (auto k = 0; k < static_cast<int>(partial_terms.size()); ++k)
         {
           fk::vector<TestType> transformed(x);
-          auto const &g_func = partial_terms[k].g_func;
+          auto const &g_func = partial_terms[k].g_func();
           if (g_func)
           {
             std::transform(x.begin(), x.end(), transformed.begin(),
@@ -345,7 +345,7 @@ TEMPLATE_TEST_CASE("testing fokkerplanck2_complete_case4 implementations",
           rmse_comparison(transformed, gold_pterm, tol_factor);
 
           fk::vector<TestType> dv(x);
-          auto const &dv_func = partial_terms[k].dv_func;
+          auto const &dv_func = partial_terms[k].dv_func();
           if (dv_func)
           {
             std::transform(x.begin(), x.end(), dv.begin(),

--- a/src/pde_tests.cpp
+++ b/src/pde_tests.cpp
@@ -16,7 +16,7 @@ void test_initial_condition(PDE<P> const &pde, std::filesystem::path base_dir,
                             fk::vector<P> const &x)
 {
   auto const filename = base_dir.filename().string();
-  for (auto i = 0; i < pde.num_dims; ++i)
+  for (auto i = 0; i < pde.num_dims(); ++i)
   {
     auto const gold = read_vector_from_txt_file<P>(base_dir.replace_filename(
         filename + "initial_dim" + std::to_string(i) + ".dat"));
@@ -39,11 +39,11 @@ void test_exact_solution(PDE<P> const &pde, std::filesystem::path base_dir,
 
   auto constexpr tol_factor = get_tolerance<P>(10);
   auto const filename       = base_dir.filename().string();
-  for (auto i = 0; i < pde.num_dims; ++i)
+  for (auto i = 0; i < pde.num_dims(); ++i)
   {
     auto const gold = read_vector_from_txt_file<P>(base_dir.replace_filename(
         filename + "exact_dim" + std::to_string(i) + ".dat"));
-    auto const fx   = pde.exact_vector_funcs[0][i](x, time);
+    auto const fx   = pde.exact_vector_funcs()[0][i](x, time);
     rmse_comparison(fx, gold, tol_factor);
   }
 
@@ -60,20 +60,20 @@ void test_source_vectors(PDE<P> const &pde, std::filesystem::path base_dir,
   auto constexpr tol_factor = get_tolerance<P>(10);
   auto const filename       = base_dir.filename().string();
 
-  for (auto i = 0; i < pde.num_sources; ++i)
+  for (auto i = 0; i < pde.num_sources(); ++i)
   {
     auto const source_string = filename + "source" + std::to_string(i) + "_";
-    for (auto j = 0; j < pde.num_dims; ++j)
+    for (auto j = 0; j < pde.num_dims(); ++j)
     {
       auto const full_path = base_dir.replace_filename(
           source_string + "dim" + std::to_string(j) + ".dat");
       auto const gold = read_vector_from_txt_file<P>(full_path);
-      auto const fx   = pde.sources[i].source_funcs()[j](x, time);
+      auto const fx   = pde.sources()[i].source_funcs()[j](x, time);
       rmse_comparison(fx, gold, tol_factor);
     }
     P const gold = read_scalar_from_txt_file(
         base_dir.replace_filename(source_string + "time.dat"));
-    auto const fx = pde.sources[i].time_func()(time);
+    auto const fx = pde.sources()[i].time_func()(time);
     relaxed_fp_comparison(fx, gold, pde_eps_multiplier);
   }
 }
@@ -318,9 +318,9 @@ TEMPLATE_TEST_CASE("testing fokkerplanck2_complete_case4 implementations",
         pde_base_dir / (filename + "dvfuncs.dat"));
 
     int row = 0;
-    for (auto i = 0; i < pde->num_dims; ++i)
+    for (auto i = 0; i < pde->num_dims(); ++i)
     {
-      for (auto j = 0; j < pde->num_terms; ++j)
+      for (auto j = 0; j < pde->num_terms(); ++j)
       {
         auto const &term_1D       = pde->get_terms()[j][i];
         auto const &partial_terms = term_1D.get_partial_terms();
@@ -403,6 +403,6 @@ TEST_CASE("testing pde term selection", "[pde]")
   parser const parse = make_parser({"-p", pde_choice, "--terms", active_terms});
   auto const pde     = make_PDE<default_precision>(parse);
 
-  REQUIRE(pde->num_terms == 4);
+  REQUIRE(pde->num_terms() == 4);
   REQUIRE(pde->get_terms().size() == 4);
 }

--- a/src/pde_tests.cpp
+++ b/src/pde_tests.cpp
@@ -68,12 +68,12 @@ void test_source_vectors(PDE<P> const &pde, std::filesystem::path base_dir,
       auto const full_path = base_dir.replace_filename(
           source_string + "dim" + std::to_string(j) + ".dat");
       auto const gold = read_vector_from_txt_file<P>(full_path);
-      auto const fx   = pde.sources[i].source_funcs[j](x, time);
+      auto const fx   = pde.sources[i].source_funcs()[j](x, time);
       rmse_comparison(fx, gold, tol_factor);
     }
     P const gold = read_scalar_from_txt_file(
         base_dir.replace_filename(source_string + "time.dat"));
-    auto const fx = pde.sources[i].time_func(time);
+    auto const fx = pde.sources[i].time_func()(time);
     relaxed_fp_comparison(fx, gold, pde_eps_multiplier);
   }
 }

--- a/src/solver_tests.cpp
+++ b/src/solver_tests.cpp
@@ -45,7 +45,7 @@ void test_kronmult(parser const &parse, P const tol_factor)
   auto const gen = [&dist, &mersenne_engine]() {
     return dist(mersenne_engine);
   };
-  auto const elem_size  = static_cast<int>(std::pow(degree, pde->num_dims));
+  auto const elem_size  = static_cast<int>(std::pow(degree, pde->num_dims()));
   fk::vector<P> const b = [&table, gen, elem_size]() {
     fk::vector<P> output(elem_size * table.size());
     std::generate(output.begin(), output.end(), gen);

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -553,7 +553,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
       // expect(m.get_moment_matrix().nrows() > 0);
     }
 
-    if (pde.do_poisson_solve)
+    if (pde.do_poisson_solve())
     {
       // Setup poisson matrix initially
       solver::setup_poisson(N_elements, min, max, pde.poisson_diag,
@@ -785,7 +785,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
         }
       };
 
-  if (pde.do_poisson_solve)
+  if (pde.do_poisson_solve())
   {
     do_poisson_update(f);
   }
@@ -832,7 +832,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   int const max_iter = program_opts.gmres_outer_iterations;
   fk::vector<P, mem_type::owner, imex_resrc> f_1(f.size());
   fk::vector<P, mem_type::owner, imex_resrc> f_1_output(f.size());
-  if (pde.do_collision_operator)
+  if (pde.do_collision_operator())
   {
     // Update coeffs
     generate_all_coefficients<P>(pde, transformer);
@@ -884,7 +884,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   tools::timer.start("explicit_2");
   fm::copy(f_orig_dev, f); // f here is now f_0
 
-  if (pde.do_poisson_solve)
+  if (pde.do_poisson_solve())
   {
     do_poisson_update(f_1);
   }
@@ -919,7 +919,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   fm::axpy(f_1, f);    // f is now f_0 + f_2
   fm::scal(P{0.5}, f); // f = 0.5 * (f_0 + f_2) = f_2s
   tools::timer.stop("explicit_2");
-  if (pde.do_collision_operator)
+  if (pde.do_collision_operator())
   {
     tools::timer.start("implicit_2");
   }
@@ -929,7 +929,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   tools::timer.stop("implicit_2_mom");
 
   // Implicit step f_2: f_2 - dt B f_2 = f_2s
-  if (pde.do_collision_operator)
+  if (pde.do_collision_operator())
   {
     // Update coeffs
     tools::timer.start("implicit_2_coeff");

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -33,9 +33,9 @@ get_sources(PDE<P> const &pde, adapt::distributed_grid<P> const &grid,
   for (auto const &source : pde.sources)
   {
     auto const source_vect = transform_and_combine_dimensions(
-        pde, source.source_funcs, grid.get_table(), transformer,
+        pde, source.source_funcs(), grid.get_table(), transformer,
         my_subgrid.row_start, my_subgrid.row_stop, degree, time,
-        source.time_func(time));
+        source.time_func()(time));
     fm::axpy(source_vect, sources);
   }
   return sources;

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -28,9 +28,9 @@ get_sources(PDE<P> const &pde, adapt::distributed_grid<P> const &grid,
   auto const my_subgrid = grid.get_subgrid(get_rank());
   // FIXME assume uniform degree
   auto const degree = pde.get_dimensions()[0].get_degree();
-  auto const dof    = std::pow(degree, pde.num_dims) * my_subgrid.nrows();
+  auto const dof    = std::pow(degree, pde.num_dims()) * my_subgrid.nrows();
   fk::vector<P> sources(dof);
-  for (auto const &source : pde.sources)
+  for (auto const &source : pde.sources())
   {
     auto const source_vect = transform_and_combine_dimensions(
         pde, source.source_funcs(), grid.get_table(), transformer,
@@ -220,7 +220,7 @@ explicit_advance(PDE<P> const &pde, matrix_list<P> &operator_matrices,
   }
   reduce_results(fx, reduced_fx, plan, get_rank());
 
-  if (pde.num_sources > 0)
+  if (pde.num_sources() > 0)
   {
     auto const sources = get_sources(pde, adaptive_grid, transformer, time);
     fm::axpy(sources, reduced_fx);
@@ -245,7 +245,7 @@ explicit_advance(PDE<P> const &pde, matrix_list<P> &operator_matrices,
   }
   reduce_results(fx, reduced_fx, plan, get_rank());
 
-  if (pde.num_sources > 0)
+  if (pde.num_sources() > 0)
   {
     auto const sources =
         get_sources(pde, adaptive_grid, transformer, time + c2 * dt);
@@ -275,7 +275,7 @@ explicit_advance(PDE<P> const &pde, matrix_list<P> &operator_matrices,
   }
   reduce_results(fx, reduced_fx, plan, get_rank());
 
-  if (pde.num_sources > 0)
+  if (pde.num_sources() > 0)
   {
     auto const sources =
         get_sources(pde, adaptive_grid, transformer, time + c3 * dt);
@@ -328,7 +328,7 @@ implicit_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   auto const &table   = adaptive_grid.get_table();
   auto const dt       = pde.get_dt();
   int const degree    = pde.get_dimensions()[0].get_degree();
-  int const elem_size = static_cast<int>(std::pow(degree, pde.num_dims));
+  int const elem_size = static_cast<int>(std::pow(degree, pde.num_dims()));
 
 #ifdef ASGARD_USE_SCALAPACK
   auto const size = elem_size * adaptive_grid.get_subgrid(get_rank()).nrows();
@@ -337,7 +337,7 @@ implicit_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
 #else
   fk::vector<P> x(x_orig);
 #endif
-  if (pde.num_sources > 0)
+  if (pde.num_sources() > 0)
   {
     auto const sources =
         get_sources(pde, adaptive_grid, transformer, time + dt);
@@ -530,7 +530,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
 
   auto const &plan       = adaptive_grid.get_distrib_plan();
   auto const &grid       = adaptive_grid.get_subgrid(get_rank());
-  int const elem_size    = static_cast<int>(std::pow(degree, pde.num_dims));
+  int const elem_size    = static_cast<int>(std::pow(degree, pde.num_dims()));
   int const A_local_rows = elem_size * grid.nrows();
 
   fk::vector<P, mem_type::owner, imex_resrc> reduced_fx(A_local_rows);
@@ -665,7 +665,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
           return interp1(nodes, mom1_real, {x_v})[0] /
                  param_manager.get_parameter("n")->value(x_v, t);
         };
-        if (pde.num_dims == 3 && pde.moments.size() > 3)
+        if (pde.num_dims() == 3 && pde.moments.size() > 3)
         {
           // Calculate additional moments for PDEs with more than one velocity
           // dimension
@@ -714,7 +714,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
                    0.5 * (std::pow(u1, 2) + std::pow(u2, 2));
           };
         }
-        else if (pde.num_dims == 4 && pde.moments.size() > 6)
+        else if (pde.num_dims() == 4 && pde.moments.size() > 6)
         {
           // Moments for 1X3V case
           // TODO: this will be refactored to replace dimension cases in the

--- a/src/time_advance_tests.cpp
+++ b/src/time_advance_tests.cpp
@@ -107,7 +107,7 @@ void time_advance_test(parser const &parse,
 
     // each rank generates partial answer
     auto const dof =
-        static_cast<int>(std::pow(parse.get_degree(), pde->num_dims));
+        static_cast<int>(std::pow(parse.get_degree(), pde->num_dims()));
     auto const subgrid = adaptive_grid.get_subgrid(get_rank());
     REQUIRE((subgrid.col_stop + 1) * dof - 1 <= gold.size());
     auto const my_gold = fk::vector<P, mem_type::const_view>(
@@ -1749,7 +1749,7 @@ TEMPLATE_TEST_CASE("IMEX time advance - relaxation1x1v", "[imex]", test_precs)
     if (i == opts.num_time_steps - 1)
     {
       fk::vector<TestType> const analytic_solution = sum_separable_funcs(
-          pde->exact_vector_funcs, pde->get_dimensions(), adaptive_grid,
+          pde->exact_vector_funcs(), pde->get_dimensions(), adaptive_grid,
           transformer, degree, time + pde->get_dt());
 
       // calculate L2 error between simulation and analytical solution

--- a/src/transformations.hpp
+++ b/src/transformations.hpp
@@ -204,17 +204,17 @@ inline fk::vector<P> transform_and_combine_dimensions(
     int const start, int const stop, int const degree, P const time = 0.0,
     P const time_multiplier = 1.0)
 {
-  expect(static_cast<int>(v_functions.size()) == pde.num_dims);
+  expect(static_cast<int>(v_functions.size()) == pde.num_dims());
   expect(start <= stop);
   expect(stop < table.size());
   expect(degree > 0);
 
   std::vector<fk::vector<P>> dimension_components;
-  dimension_components.reserve(pde.num_dims);
+  dimension_components.reserve(pde.num_dims());
 
   auto const &dimensions = pde.get_dimensions();
 
-  for (int i = 0; i < pde.num_dims; ++i)
+  for (int i = 0; i < pde.num_dims(); ++i)
   {
     auto const &dim = dimensions[i];
     dimension_components.push_back(forward_transform<P>(

--- a/src/transformations_tests.cpp
+++ b/src/transformations_tests.cpp
@@ -17,7 +17,7 @@ void test_combine_dimensions(PDE<P> const &pde, P const time = 1.0,
                              int const num_ranks  = 1,
                              bool const full_grid = false)
 {
-  int const dims = pde.num_dims;
+  int const dims = pde.num_dims();
 
   // FIXME assuming uniform degree across dims
   dimension const dim = pde.get_dimensions()[0];
@@ -36,7 +36,7 @@ void test_combine_dimensions(PDE<P> const &pde, P const time = 1.0,
 
   std::vector<fk::vector<P>> vectors;
   P counter = 1.0;
-  for (int i = 0; i < pde.num_dims; ++i)
+  for (int i = 0; i < pde.num_dims(); ++i)
   {
     int const vect_size         = dims * fm::two_raised_to(lev);
     fk::vector<P> const vect_1d = [&counter, vect_size] {
@@ -191,7 +191,7 @@ void test_wavelet_to_realspace(PDE<P> const &pde,
     auto const arbitrary_func = [](P const x) { return 2.0 * x; };
 
     auto const wave_space_size =
-        static_cast<uint64_t>(table.size()) * std::pow(degree, pde.num_dims);
+        static_cast<uint64_t>(table.size()) * std::pow(degree, pde.num_dims());
     expect(wave_space_size < INT_MAX);
     fk::vector<P> wave_space_in(wave_space_size);
 


### PR DESCRIPTION
Allows for instantiation of an empty PDE object with no dimensions and terms. The PDE can later be re-initialized. This allows for delayed initialization.