### PR TITLE
Organize kronmults

### DIFF
--- a/src/asgard_kronmult_benchmark.cpp
+++ b/src/asgard_kronmult_benchmark.cpp
@@ -85,25 +85,7 @@ int main(int argc, char **argv)
     ip++;
   }
 
-  asgard::kronmult_matrix<precision> mat;
-
-#ifdef ASGARD_USE_CUDA
-  // mat = asgard::kronmult_matrix<precision>(dimensions, n, num_rows, num_rows,
-  //                                          num_terms, iA.clone_onto_device(),
-  //                                          vA.clone_onto_device());
-  //
-  // asgard::fk::vector<precision, asgard::mem_type::owner,
-  //                    asgard::resource::device>
-  //     xdev(mat.input_size());
-  // asgard::fk::vector<precision, asgard::mem_type::owner,
-  //                    asgard::resource::device>
-  //     ydev(mat.output_size());
-  // mat.set_workspace(xdev, ydev);
-#else
-  // mat = asgard::kronmult_matrix<precision>(dimensions, n, num_rows, num_rows,
-  //                                          num_terms, std::move(iA),
-  //                                          std::move(vA));
-#endif
+  asgard::local_kronmult_matrix<precision> mat;
 
   // dry run to wake up the devices
   mat.apply(1.0, data->input_x.data(), 1.0, data->output_y.data());

--- a/src/asgard_kronmult_matrix.cpp
+++ b/src/asgard_kronmult_matrix.cpp
@@ -1604,10 +1604,10 @@ void global_kron_matrix<precision>::apply(
 template<typename precision>
 template<resource rec>
 void block_global_kron_matrix<precision>::apply(
-    matrix_entry etype, precision alpha, precision const *x,
+    imex_flag etype, precision alpha, precision const *x,
     precision beta, precision *y) const
 {
-  int const imex = flag2int(etype);
+  int const imex = static_cast<int>(etype);
 
   std::vector<int> const &used_terms = term_groups_[imex];
 
@@ -1707,7 +1707,7 @@ void set_specific_mode(PDE<precision> const &pde,
                        options const &program_options, imex_flag const imex,
                        block_global_kron_matrix<precision> &mat)
 {
-  int const imex_indx = block_global_kron_matrix<precision>::flag2int(imex);
+  int const imex_indx = static_cast<int>(imex);
 
   mat.term_groups_[imex_indx] = get_used_terms(pde, program_options, imex);
 
@@ -1754,7 +1754,7 @@ template std::vector<int> get_used_terms(PDE<double> const &pde, options const &
 #ifdef KRON_MODE_GLOBAL_BLOCK
 template class block_global_kron_matrix<double>;
 template void block_global_kron_matrix<double>::apply<resource::host>(
-    matrix_entry, double, double const *, double, double *) const;
+    imex_flag, double, double const *, double, double *) const;
 
 template block_global_kron_matrix<double>
 make_block_global_kron_matrix<double>(PDE<double> const &,
@@ -1814,7 +1814,7 @@ template std::vector<int> get_used_terms(PDE<float> const &pde, options const &o
 template class block_global_kron_matrix<float>;
 
 template void block_global_kron_matrix<float>::apply<resource::host>(
-    matrix_entry, float, float const *, float, float *) const;
+    imex_flag, float, float const *, float, float *) const;
 
 template block_global_kron_matrix<float>
 make_block_global_kron_matrix<float>(PDE<float> const &,

--- a/src/asgard_kronmult_matrix.cpp
+++ b/src/asgard_kronmult_matrix.cpp
@@ -1067,6 +1067,42 @@ void build_preconditioner(PDE<precision> const &pde, int64_t const num_active,
   }
 }
 
+//! Returns true if the current term is identity and can be omitted
+template<typename precision>
+bool check_identity_term(PDE<precision> const &pde, int term_id, int dim)
+{
+  // Check that the volumne jacobian in this dimension is not identity,
+  if (pde.get_dimensions()[dim].volume_jacobian_dV != nullptr)
+    return false;
+  // Now check g_func, the lhs_func, and local surface jacobian are identity.
+  // TODO: There is an edge case where the mass matrices with the same volume
+  // jacobians can cancel out, but this requires us to know that both the
+  // dimensions' and the local terms' volume jacobian are equal.
+  // In the edge case, identity will be multiplied instead of ignored
+  // resulting in extra work but correct output.
+  for (auto const &pt : pde.get_terms()[term_id][dim].get_partial_terms())
+    if (pt.coeff_type() != coefficient_type::mass or
+        pt.g_func() != nullptr or
+        pt.lhs_mass_func() != nullptr or
+        pt.dv_func() != nullptr)
+      return false;
+  return true;
+}
+
+//! Return the direction of the flux term or -1 for mass term
+template<typename precision>
+int get_flux_direction(PDE<precision> const &pde, int term_id)
+{
+  for (int d = 0; d < pde.num_dims(); d++)
+    for (auto const &pt : pde.get_terms()[term_id][d].get_partial_terms())
+      if (pt.coeff_type() == coefficient_type::div or
+          pt.coeff_type() == coefficient_type::grad or
+          pt.coeff_type() == coefficient_type::penalty)
+        return d;
+  return -1;
+}
+
+#ifndef KRON_MODE_GLOBAL_BLOCK
 /*!
  * \brief Walks over the sparse matrix pattern and makes call-back for each non-zero
  *
@@ -1173,47 +1209,11 @@ void split_pattern(std::vector<int> const &pntr, std::vector<int> const &indx,
 }
 
 template<typename precision>
-bool check_identity_term(PDE<precision> const &pde, int term_id, int dim)
-{
-  // Check that the volumne jacobian in this dimension is not identity,
-  if (pde.get_dimensions()[dim].volume_jacobian_dV != nullptr)
-    return false;
-  // Now check g_func, the lhs_func, and local surface jacobian are identity.
-  // TODO: There is an edge case where the mass matrices with the same volume
-  // jacobians can cancel out, but this requires us to know that both the
-  // dimensions' and the local terms' volume jacobian are equal.
-  // In the edge case, identity will be multiplied instead of ignored
-  // resulting in extra work but correct output.
-  for (auto const &pt : pde.get_terms()[term_id][dim].get_partial_terms())
-    if (pt.coeff_type() != coefficient_type::mass or
-        pt.g_func() != nullptr or
-        pt.lhs_mass_func() != nullptr or
-        pt.dv_func() != nullptr)
-      return false;
-  return true;
-}
-
-template<typename precision>
-int get_flux_direction(PDE<precision> const &pde, int term_id)
-{
-  for (int d = 0; d < pde.num_dims(); d++)
-    for (auto const &pt : pde.get_terms()[term_id][d].get_partial_terms())
-      if (pt.coeff_type() == coefficient_type::div or
-          pt.coeff_type() == coefficient_type::grad or
-          pt.coeff_type() == coefficient_type::penalty)
-        return d;
-  return -1;
-}
-
-template<typename precision>
 global_kron_matrix<precision>
 make_global_kron_matrix(PDE<precision> const &pde,
                         adapt::distributed_grid<precision> const &dis_grid,
                         options const &program_options)
 {
-  auto const &grid         = dis_grid.get_subgrid(get_rank());
-  int const *const asg_idx = dis_grid.get_table().get_active_table().data();
-
   int const porder    = pde.get_dimensions()[0].get_degree() - 1;
   int const pterms    = porder + 1; // poly degrees of freedom
   int const max_level = (program_options.do_adapt_levels) ? program_options.max_level : pde.max_level();
@@ -1224,8 +1224,8 @@ make_global_kron_matrix(PDE<precision> const &pde,
   connect_1d volumes(max_level, connect_1d::hierarchy::volume);
   connect_1d dof_pattern(connect_1d(max_level), porder);
 
-  int const num_cells = grid.col_stop - grid.col_start + 1;
-  vector2d<int> cells = asg2tsg_convert(num_dimensions, num_cells, asg_idx);
+  vector2d<int> cells = get_cells(num_dimensions, dis_grid);
+  int const num_cells = cells.num_strips();
 
   indexset padded = compute_ancestry_completion(make_index_set(cells), volumes);
   std::cout << " number of padding cells = " << padded.num_indexes() << '\n';
@@ -1235,9 +1235,7 @@ make_global_kron_matrix(PDE<precision> const &pde,
   dimension_sort dsort(ilist);
 
   int64_t num_all_dof    = ilist.num_strips();
-  int64_t num_active_dof = num_cells * pterms;
-  for (int d = 1; d < num_dimensions; d++)
-    num_active_dof *= pterms;
+  int64_t num_active_dof = num_cells * fm::ipow(pterms, num_dimensions);
 
   // form the 1D pattern for the matrices in each dimension
   std::vector<std::vector<int>> global_pntr(num_dimensions,
@@ -1333,7 +1331,7 @@ make_global_kron_matrix(PDE<precision> const &pde,
           std::swap(active_dirs.front(), active_dirs.back());
       }
 
-    permutations.push_back(kronmult::permutes(active_dirs));
+    permutations.emplace_back(active_dirs);
   }
 
   return global_kron_matrix<precision>(
@@ -1348,7 +1346,7 @@ void set_specific_mode(PDE<precision> const &pde,
                        options const &program_options, imex_flag const imex,
                        global_kron_matrix<precision> &mat)
 {
-  int const imex_indx = global_kron_matrix<precision>::flag2int(imex);
+  int const imex_indx = static_cast<int>(imex);
 
   mat.term_groups[imex_indx] = get_used_terms(pde, program_options, imex);
 
@@ -1441,7 +1439,7 @@ template<typename precision>
 void global_kron_matrix<precision>::
     preset_gpu_gkron(gpu::sparse_handle const &hndl, imex_flag const imex)
 {
-  int const imex_indx = global_kron_matrix<precision>::flag2int(imex);
+  int const imex_indx = static_cast<int>(imex);
 
   gpu_global[imex_indx] = kronmult::global_gpu_operations<precision>(
       hndl, num_dimensions_, perms_, gpntr_, gindx_, gvals_, term_groups[imex_indx],
@@ -1470,7 +1468,7 @@ void update_matrix_coefficients(PDE<precision> const &pde,
                                 options const &program_options, imex_flag const imex,
                                 global_kron_matrix<precision> &mat)
 {
-  int const imex_indx = global_kron_matrix<precision>::flag2int(imex);
+  int const imex_indx = static_cast<int>(imex);
 
   std::vector<int> const &used_terms = mat.term_groups[imex_indx];
 
@@ -1484,7 +1482,7 @@ void update_matrix_coefficients(PDE<precision> const &pde,
 
   // number of matrices per term per dimension that should be considered
   int const num_mats = (num_dimensions == 1) ? 1 : patterns_per_dim;
-  for (int t : used_terms)
+  for (int const t : used_terms)
   {
     for (int d = 0; d < num_dimensions; d++)
     {
@@ -1538,10 +1536,10 @@ void update_matrix_coefficients(PDE<precision> const &pde,
 template<typename precision>
 template<resource rec>
 void global_kron_matrix<precision>::apply(
-    matrix_entry etype, precision alpha, precision const *x,
+    imex_flag etype, precision alpha, precision const *x,
     precision beta, precision *y) const
 {
-  int const imex = flag2int(etype);
+  int const imex = static_cast<int>(etype);
 
   std::vector<int> const &used_terms = term_groups[imex];
   if (used_terms.size() == 0)
@@ -1598,7 +1596,8 @@ void global_kron_matrix<precision>::apply(
     y[i] += alpha * py[i];
 #endif
 }
-#endif
+#endif // end ifndef KRON_MODE_GLOBAL_BLOCK
+#endif // end ifdef KRON_MODE_GLOBAL
 
 #ifdef KRON_MODE_GLOBAL_BLOCK
 
@@ -1752,26 +1751,6 @@ template std::vector<int> get_used_terms(PDE<double> const &pde, options const &
                                          imex_flag const imex);
 
 #ifdef KRON_MODE_GLOBAL
-template global_kron_matrix<double>
-make_global_kron_matrix(PDE<double> const &,
-                        adapt::distributed_grid<double> const &,
-                        options const &);
-template void update_matrix_coefficients(PDE<double> const &,
-                                         adapt::distributed_grid<double> const &,
-                                         options const &, imex_flag const,
-                                         global_kron_matrix<double> &);
-template void set_specific_mode<double>(PDE<double> const &,
-                                        adapt::distributed_grid<double> const &,
-                                        options const &, imex_flag const,
-                                        global_kron_matrix<double> &);
-template class global_kron_matrix<double>;
-template void global_kron_matrix<double>::apply<resource::host>(
-    matrix_entry, double, double const *, double, double *) const;
-#ifdef ASGARD_USE_CUDA
-template void global_kron_matrix<double>::apply<resource::device>(
-    matrix_entry, double, double const *, double, double *) const;
-#endif
-
 #ifdef KRON_MODE_GLOBAL_BLOCK
 template class block_global_kron_matrix<double>;
 template void block_global_kron_matrix<double>::apply<resource::host>(
@@ -1786,7 +1765,27 @@ template void set_specific_mode<double>(PDE<double> const &,
                                         adapt::distributed_grid<double> const &,
                                         options const &, imex_flag const,
                                         block_global_kron_matrix<double> &);
+#else
+template global_kron_matrix<double>
+make_global_kron_matrix(PDE<double> const &,
+                        adapt::distributed_grid<double> const &,
+                        options const &);
+template void update_matrix_coefficients(PDE<double> const &,
+                                         adapt::distributed_grid<double> const &,
+                                         options const &, imex_flag const,
+                                         global_kron_matrix<double> &);
+template void set_specific_mode<double>(PDE<double> const &,
+                                        adapt::distributed_grid<double> const &,
+                                        options const &, imex_flag const,
+                                        global_kron_matrix<double> &);
+template class global_kron_matrix<double>;
+template void global_kron_matrix<double>::apply<resource::host>(
+    imex_flag, double, double const *, double, double *) const;
+#ifdef ASGARD_USE_CUDA
+template void global_kron_matrix<double>::apply<resource::device>(
+    imex_flag, double, double const *, double, double *) const;
 #endif
+#endif // KRON_MODE_GLOBAL_BLOCK
 
 #else // KRON_MODE_GLOBAL
 template kronmult_matrix<double>
@@ -1811,26 +1810,6 @@ template std::vector<int> get_used_terms(PDE<float> const &pde, options const &o
                                          imex_flag const imex);
 
 #ifdef KRON_MODE_GLOBAL
-template global_kron_matrix<float>
-make_global_kron_matrix(PDE<float> const &,
-                        adapt::distributed_grid<float> const &,
-                        options const &);
-template void update_matrix_coefficients(PDE<float> const &,
-                                         adapt::distributed_grid<float> const &,
-                                         options const &, imex_flag const,
-                                         global_kron_matrix<float> &);
-template void set_specific_mode<float>(PDE<float> const &,
-                                       adapt::distributed_grid<float> const &,
-                                       options const &, imex_flag const,
-                                       global_kron_matrix<float> &);
-template class global_kron_matrix<float>;
-template void global_kron_matrix<float>::apply<resource::host>(
-    matrix_entry, float, float const *, float, float *) const;
-#ifdef ASGARD_USE_CUDA
-template void global_kron_matrix<float>::apply<resource::device>(
-    matrix_entry, float, float const *, float, float *) const;
-#endif
-
 #ifdef KRON_MODE_GLOBAL_BLOCK
 template class block_global_kron_matrix<float>;
 
@@ -1846,7 +1825,27 @@ template void set_specific_mode<float>(PDE<float> const &,
                                        adapt::distributed_grid<float> const &,
                                        options const &, imex_flag const,
                                        block_global_kron_matrix<float> &);
+#else
+template global_kron_matrix<float>
+make_global_kron_matrix(PDE<float> const &,
+                        adapt::distributed_grid<float> const &,
+                        options const &);
+template void update_matrix_coefficients(PDE<float> const &,
+                                         adapt::distributed_grid<float> const &,
+                                         options const &, imex_flag const,
+                                         global_kron_matrix<float> &);
+template void set_specific_mode<float>(PDE<float> const &,
+                                       adapt::distributed_grid<float> const &,
+                                       options const &, imex_flag const,
+                                       global_kron_matrix<float> &);
+template class global_kron_matrix<float>;
+template void global_kron_matrix<float>::apply<resource::host>(
+    imex_flag, float, float const *, float, float *) const;
+#ifdef ASGARD_USE_CUDA
+template void global_kron_matrix<float>::apply<resource::device>(
+    imex_flag, float, float const *, float, float *) const;
 #endif
+#endif // KRON_MODE_GLOBAL_BLOCK
 
 #else // KRON_MODE_GLOBAL
 template kronmult_matrix<float>

--- a/src/asgard_kronmult_matrix.cpp
+++ b/src/asgard_kronmult_matrix.cpp
@@ -67,7 +67,7 @@ void check_available_memory(int64_t baseline_memory, int64_t available_MB)
 }
 
 template<typename precision>
-kronmult_matrix<precision>
+local_kronmult_matrix<precision>
 make_kronmult_dense(PDE<precision> const &pde,
                     adapt::distributed_grid<precision> const &discretization,
                     options const &program_options, imex_flag const imex)
@@ -88,8 +88,8 @@ make_kronmult_dense(PDE<precision> const &pde,
   int const num_terms               = static_cast<int>(used_terms.size());
 
   if (used_terms.empty())
-    return asgard::kronmult_matrix<precision>(num_dimensions, kron_size,
-                                              num_rows, num_cols);
+    return asgard::local_kronmult_matrix<precision>(num_dimensions, kron_size,
+                                                    num_rows, num_cols);
 
   constexpr resource mode = resource::host;
 
@@ -136,7 +136,7 @@ make_kronmult_dense(PDE<precision> const &pde,
     }
   }
 
-  int64_t flps = kronmult_matrix<precision>::compute_flops(
+  int64_t flps = local_kronmult_matrix<precision>::compute_flops(
       num_dimensions, kron_size, num_terms, int64_t{num_rows} * num_cols);
 
   std::cout << "  kronmult dense matrix size: " << num_rows << " rows/cols\n";
@@ -154,12 +154,12 @@ make_kronmult_dense(PDE<precision> const &pde,
 
   auto gpu_elem = elem.clone_onto_device();
 
-  return asgard::kronmult_matrix<precision>(
+  return asgard::local_kronmult_matrix<precision>(
       num_dimensions, kron_size, num_rows, num_cols, num_terms,
       std::move(gpu_terms), std::move(gpu_elem), grid.row_start, grid.col_start,
       num_1d_blocks);
 #else
-  return asgard::kronmult_matrix<precision>(
+  return asgard::local_kronmult_matrix<precision>(
       num_dimensions, kron_size, num_rows, num_cols, num_terms,
       std::move(terms), std::move(elem), grid.row_start, grid.col_start,
       num_1d_blocks);
@@ -332,7 +332,7 @@ void compute_coefficient_offsets(kron_sparse_cache const &spcache,
 }
 
 template<typename precision>
-kronmult_matrix<precision>
+local_kronmult_matrix<precision>
 make_kronmult_sparse(PDE<precision> const &pde,
                      adapt::distributed_grid<precision> const &discretization,
                      options const &program_options,
@@ -357,8 +357,8 @@ make_kronmult_sparse(PDE<precision> const &pde,
   int const num_terms = static_cast<int>(used_terms.size());
 
   if (used_terms.empty())
-    return asgard::kronmult_matrix<precision>(num_dimensions, kron_size,
-                                              num_rows, num_cols);
+    return asgard::local_kronmult_matrix<precision>(
+        num_dimensions, kron_size, num_rows, num_cols);
 
   // size of the small kron matrices
   int const kron_squared = kron_size * kron_size;
@@ -625,7 +625,7 @@ make_kronmult_sparse(PDE<precision> const &pde,
                    (double(num_rows) * double(num_cols))
             << "%\n";
 
-  int64_t flops = kronmult_matrix<precision>::compute_flops(
+  int64_t flops = local_kronmult_matrix<precision>::compute_flops(
       num_dimensions, kron_size, num_terms, spcache.num_nonz);
   std::cout << "  -- work: " << flops * 1.E-9 << " Gflops\n";
 
@@ -638,7 +638,7 @@ make_kronmult_sparse(PDE<precision> const &pde,
                      get_MB<int>(list_iA[0].size()) +
                      get_MB<precision>(vA.size())
               << "\n";
-    return kronmult_matrix<precision>(
+    return local_kronmult_matrix<precision>(
         num_dimensions, kron_size, num_rows, num_cols, num_terms,
         list_row_indx[0].clone_onto_device(),
         list_col_indx[0].clone_onto_device(), list_iA[0].clone_onto_device(),
@@ -653,7 +653,7 @@ make_kronmult_sparse(PDE<precision> const &pde,
               << 2 * get_MB<int>(mem_stats.work_size) +
                      4 * get_MB<int>(mem_stats.row_work_size)
               << "\n";
-    return kronmult_matrix<precision>(
+    return local_kronmult_matrix<precision>(
         num_dimensions, kron_size, num_rows, num_cols, num_terms,
         std::move(list_row_indx), std::move(list_col_indx), std::move(list_iA),
         vA.clone_onto_device());
@@ -675,15 +675,15 @@ make_kronmult_sparse(PDE<precision> const &pde,
     }
     std::cout << "        memory usage (MB): "
               << get_MB<precision>(vA.size()) + get_MB<int>(num_ints) << "\n";
-    return kronmult_matrix<precision>(num_dimensions, kron_size, num_rows,
-                                      num_cols, num_terms, std::move(gpu_row),
-                                      std::move(gpu_col), std::move(gpu_iA),
-                                      vA.clone_onto_device());
+    return local_kronmult_matrix<precision>(
+        num_dimensions, kron_size, num_rows, num_cols, num_terms,
+        std::move(gpu_row), std::move(gpu_col), std::move(gpu_iA),
+        vA.clone_onto_device());
 #endif
   }
 #else
 
-  return kronmult_matrix<precision>(
+  return local_kronmult_matrix<precision>(
       num_dimensions, kron_size, num_rows, num_cols, num_terms,
       std::move(list_row_indx), std::move(list_col_indx), std::move(list_iA),
       std::move(vA));
@@ -692,11 +692,11 @@ make_kronmult_sparse(PDE<precision> const &pde,
 }
 
 template<typename P>
-kronmult_matrix<P>
-make_kronmult_matrix(PDE<P> const &pde, adapt::distributed_grid<P> const &grid,
-                     options const &cli_opts, memory_usage const &mem_stats,
-                     imex_flag const imex, kron_sparse_cache &spcache,
-                     bool force_sparse)
+local_kronmult_matrix<P>
+make_local_kronmult_matrix(
+    PDE<P> const &pde, adapt::distributed_grid<P> const &grid, options const &cli_opts,
+    memory_usage const &mem_stats, imex_flag const imex, kron_sparse_cache &spcache,
+    bool force_sparse)
 {
   if (cli_opts.kmode == kronmult_mode::dense and not force_sparse)
   {
@@ -714,7 +714,7 @@ void update_kronmult_coefficients(PDE<P> const &pde,
                                   options const &program_options,
                                   imex_flag const imex,
                                   kron_sparse_cache &spcache,
-                                  kronmult_matrix<P> &mat)
+                                  local_kronmult_matrix<P> &mat)
 {
   tools::time_event kron_time_("kronmult-update-coefficients");
   int const num_dimensions = pde.num_dims();
@@ -1788,15 +1788,14 @@ template void global_kron_matrix<double>::apply<resource::device>(
 #endif // KRON_MODE_GLOBAL_BLOCK
 
 #else // KRON_MODE_GLOBAL
-template kronmult_matrix<double>
-make_kronmult_matrix<double>(PDE<double> const &,
-                             adapt::distributed_grid<double> const &,
-                             options const &, memory_usage const &,
-                             imex_flag const, kron_sparse_cache &, bool);
+template local_kronmult_matrix<double>
+make_local_kronmult_matrix<double>(
+    PDE<double> const &, adapt::distributed_grid<double> const &,
+    options const &, memory_usage const &, imex_flag const, kron_sparse_cache &, bool);
 template void
 update_kronmult_coefficients<double>(PDE<double> const &, options const &,
                                      imex_flag const, kron_sparse_cache &,
-                                     kronmult_matrix<double> &);
+                                     local_kronmult_matrix<double> &);
 template memory_usage
 compute_mem_usage<double>(PDE<double> const &,
                           adapt::distributed_grid<double> const &,
@@ -1848,14 +1847,13 @@ template void global_kron_matrix<float>::apply<resource::device>(
 #endif // KRON_MODE_GLOBAL_BLOCK
 
 #else // KRON_MODE_GLOBAL
-template kronmult_matrix<float>
-make_kronmult_matrix<float>(PDE<float> const &,
-                            adapt::distributed_grid<float> const &,
-                            options const &, memory_usage const &,
-                            imex_flag const, kron_sparse_cache &, bool);
+template local_kronmult_matrix<float>
+make_local_kronmult_matrix<float>(
+    PDE<float> const &, adapt::distributed_grid<float> const &,
+    options const &, memory_usage const &, imex_flag const, kron_sparse_cache &, bool);
 template void update_kronmult_coefficients<float>(PDE<float> const &, options const &,
                                                   imex_flag const, kron_sparse_cache &,
-                                                  kronmult_matrix<float> &);
+                                                  local_kronmult_matrix<float> &);
 template memory_usage
 compute_mem_usage<float>(PDE<float> const &,
                          adapt::distributed_grid<float> const &,

--- a/src/asgard_kronmult_matrix.hpp
+++ b/src/asgard_kronmult_matrix.hpp
@@ -113,18 +113,18 @@ struct kron_sparse_cache
  * Each row/column entry corresponds to a Kronecker product.
  */
 template<typename precision>
-class kronmult_matrix
+class local_kronmult_matrix
 {
 public:
   //! \brief Creates uninitialized matrix cannot be used except to be reinitialized.
-  kronmult_matrix()
+  local_kronmult_matrix()
       : num_dimensions_(0), kron_size_(0), num_rows_(0), num_cols_(0),
         num_terms_(0), tensor_size_(0), flops_(0), list_row_stride_(0),
         row_offset_(0), col_offset_(0), num_1d_blocks_(0)
   {}
 
   //! \brief Creates a zero/empty matrix no terms.
-  kronmult_matrix(int num_dimensions, int kron_size, int num_rows, int num_cols)
+  local_kronmult_matrix(int num_dimensions, int kron_size, int num_rows, int num_cols)
       : num_dimensions_(num_dimensions), kron_size_(kron_size),
         num_rows_(num_rows), num_cols_(num_cols), num_terms_(0),
         tensor_size_(fm::ipow(kron_size_, num_dimensions_)),
@@ -133,7 +133,7 @@ public:
   {}
 
   template<resource input_mode>
-  kronmult_matrix(
+  local_kronmult_matrix(
       int num_dimensions, int kron_size, int num_rows, int num_cols,
       int num_terms,
       std::vector<fk::vector<precision, mem_type::owner, input_mode>> &&terms,
@@ -236,12 +236,13 @@ public:
    * product uses tensors at row_indx[i] and col_indx[i].
    */
   template<resource input_mode>
-  kronmult_matrix(int num_dimensions, int kron_size, int num_rows, int num_cols,
-                  int num_terms,
-                  fk::vector<int, mem_type::owner, input_mode> &&row_indx,
-                  fk::vector<int, mem_type::owner, input_mode> &&col_indx,
-                  fk::vector<int, mem_type::owner, input_mode> &&index_A,
-                  fk::vector<precision, mem_type::owner, input_mode> &&values_A)
+  local_kronmult_matrix(
+      int num_dimensions, int kron_size, int num_rows, int num_cols,
+      int num_terms,
+      fk::vector<int, mem_type::owner, input_mode> &&row_indx,
+      fk::vector<int, mem_type::owner, input_mode> &&col_indx,
+      fk::vector<int, mem_type::owner, input_mode> &&index_A,
+      fk::vector<precision, mem_type::owner, input_mode> &&values_A)
       : num_dimensions_(num_dimensions), kron_size_(kron_size),
         num_rows_(num_rows), num_cols_(num_cols), num_terms_(num_terms),
         tensor_size_(1), row_indx_(std::move(row_indx)),
@@ -285,16 +286,16 @@ public:
    *         for the CPU and device when CUDA is enabled
    */
   template<resource multi_mode, resource input_mode>
-  kronmult_matrix(
+  local_kronmult_matrix(
       int num_dimensions, int kron_size, int num_rows, int num_cols,
       int num_terms,
       std::vector<fk::vector<int, mem_type::owner, multi_mode>> &&row_indx,
       std::vector<fk::vector<int, mem_type::owner, multi_mode>> &&col_indx,
       std::vector<fk::vector<int, mem_type::owner, multi_mode>> &&list_index_A,
       fk::vector<precision, mem_type::owner, input_mode> &&values_A)
-      : kronmult_matrix(num_dimensions, kron_size, num_rows, num_cols,
-                        num_terms, 0, std::move(row_indx), std::move(col_indx),
-                        std::move(list_index_A), std::move(values_A))
+      : local_kronmult_matrix(num_dimensions, kron_size, num_rows, num_cols,
+                              num_terms, 0, std::move(row_indx), std::move(col_indx),
+                              std::move(list_index_A), std::move(values_A))
   {
     expect(not(list_row_indx_.empty() and list_col_indx_.empty()));
   }
@@ -574,7 +575,7 @@ public:
 private:
   //! \brief Multi-call constructors delegate to this one, handles list_row_stride_
   template<resource multi_mode, resource input_mode>
-  kronmult_matrix(
+  local_kronmult_matrix(
       int num_dimensions, int kron_size, int num_rows, int num_cols,
       int num_terms, int list_row_stride,
       std::vector<fk::vector<int, mem_type::owner, multi_mode>> const
@@ -702,11 +703,11 @@ private:
  * \param force_sparse (testing purposes only) forces a sparse matrix
  */
 template<typename P>
-kronmult_matrix<P>
-make_kronmult_matrix(PDE<P> const &pde, adapt::distributed_grid<P> const &grid,
-                     options const &program_options,
-                     memory_usage const &mem_stats, imex_flag const imex,
-                     kron_sparse_cache &spcache, bool force_sparse = false);
+local_kronmult_matrix<P>
+make_local_kronmult_matrix(
+    PDE<P> const &pde, adapt::distributed_grid<P> const &grid, options const &program_options,
+    memory_usage const &mem_stats, imex_flag const imex, kron_sparse_cache &spcache,
+    bool force_sparse = false);
 
 /*!
  * \brief Update the coefficients stored in the matrix without changing the rest
@@ -723,7 +724,7 @@ void update_kronmult_coefficients(PDE<P> const &pde,
                                   options const &program_options,
                                   imex_flag const imex,
                                   kron_sparse_cache &spcache,
-                                  kronmult_matrix<P> &mat);
+                                  local_kronmult_matrix<P> &mat);
 
 /*!
  * \brief Compute the stats for the memory usage
@@ -801,8 +802,8 @@ struct kron_operators
 
     int const ientry = static_cast<int>(entry);
     if (not matrices[ientry])
-      matrices[ientry] = make_kronmult_matrix(pde, grid, opts, mem_stats,
-                                              entry, spcache);
+      matrices[ientry] = make_local_kronmult_matrix(
+          pde, grid, opts, mem_stats, entry, spcache);
 
 #ifdef ASGARD_USE_CUDA
     if (matrices[ientry].input_size() != xdev.size())
@@ -875,13 +876,13 @@ struct kron_operators
   {
     for (auto &matrix : matrices)
       if (matrix)
-        matrix = kronmult_matrix<precision>();
+        matrix = local_kronmult_matrix<precision>();
     mem_stats.reset();
   }
 
 private:
   //! \brief Holds the matrices
-  std::array<kronmult_matrix<precision>, num_imex_variants> matrices;
+  std::array<local_kronmult_matrix<precision>, num_imex_variants> matrices;
 
   //! \brief Cache holding the memory stats, limits bounds etc.
   memory_usage mem_stats;

--- a/src/asgard_kronmult_matrix.hpp
+++ b/src/asgard_kronmult_matrix.hpp
@@ -871,15 +871,8 @@ struct kron_operators
                                    matrices[ientry]);
   }
 
-  //! \brief Clear the specified matrix
-  void clear(imex_flag entry)
-  {
-    int const ientry = static_cast<int>(entry);
-    if (matrices[ientry])
-      matrices[ientry] = kronmult_matrix<precision>();
-  }
   //! \brief Clear all matrices
-  void clear_all()
+  void clear()
   {
     for (auto &matrix : matrices)
       if (matrix)
@@ -1227,15 +1220,8 @@ struct kron_operators
     }
   }
 
-  //! \brief Clear the specified matrix
-  void clear(imex_flag entry)
-  {
-    ignore(entry);
-    if (kglobal)
-      kglobal = global_kron_matrix<precision>();
-  }
   //! \brief Clear all matrices
-  void clear_all()
+  void clear()
   {
     if (kglobal)
       kglobal = global_kron_matrix<precision>();
@@ -1299,13 +1285,13 @@ public:
   }
 
   template<resource rec>
-  void apply(matrix_entry etype, precision alpha, precision const *x, precision beta, precision *y) const;
+  void apply(imex_flag etype, precision alpha, precision const *x, precision beta, precision *y) const;
 
   operator bool() const { return (num_dimensions_ > 0); }
 
-  bool specific_is_set(matrix_entry etype)
+  bool specific_is_set(imex_flag etype)
   {
-    std::vector<int> const &terms = term_groups_[flag2int(etype)];
+    std::vector<int> const &terms = term_groups_[static_cast<int>(etype)];
     if (terms.empty())
       return true; // nothing to set, so we're OK
 
@@ -1325,9 +1311,9 @@ public:
   }
 
   //! \brief Return the number of flops for the current matrix type
-  int64_t flops(matrix_entry etype) const
+  int64_t flops(imex_flag etype) const
   {
-    int i = flag2int(etype);
+    int i = static_cast<int>(etype);
     if (flops_[i] == -1)
     {
       flops_[i] = kronmult::block_global_count_flops(num_dimensions_, blockn_, block_size_, ilist_, dsort_,
@@ -1335,13 +1321,13 @@ public:
                                                      term_groups_[i], *workspace_);
       switch (etype)
       {
-      case matrix_entry::regular:
+      case imex_flag::unspecified:
         std::cout << "regular block-global kronmult matrix\n";
         break;
-      case matrix_entry::imex_explicit:
+      case imex_flag::imex_explicit:
         std::cout << "imex-explicit block-global kronmult matrix\n";
         break;
-      case matrix_entry::imex_implicit:
+      case imex_flag::imex_implicit:
         std::cout << "imex-implicit block-global kronmult matrix\n";
         break;
       };
@@ -1360,20 +1346,7 @@ public:
       options const &program_options, imex_flag const imex,
       block_global_kron_matrix<precision> &mat);
 
-  //! \brief Convert the imex flag to an index of the arrays.
-  static int flag2int(imex_flag imex)
-  {
-    return static_cast<int>(imex);
-  }
-  //! \brief Convert the matrix entry to an index of the arrays.
-  static int flag2int(matrix_entry imex)
-  {
-    return static_cast<int>(imex);
-  }
-
 private:
-  static constexpr int num_variants = 3;
-
   int64_t num_active_, num_padded_;
   int num_dimensions_, blockn_;
   int64_t block_size_;
@@ -1387,7 +1360,7 @@ private:
   std::array<std::vector<int>, 3> term_groups_;
   mutable kronmult::block_global_workspace<precision> *workspace_;
 
-  mutable std::array<int64_t, num_variants> flops_;
+  mutable std::array<int64_t, num_imex_variants> flops_;
 
   // preconditioner
   std::vector<precision> pre_con_;
@@ -1401,82 +1374,65 @@ make_block_global_kron_matrix(PDE<precision> const &pde,
                               kronmult::block_global_workspace<precision> *workspace);
 
 template<typename precision>
-struct matrix_list
+struct kron_operators
 {
-  //! \brief Makes a list of uninitialized matrices
-  matrix_list() = default;
-
-  //! \brief Frees the matrix list and any cache vectors
-  ~matrix_list() = default;
-
   //! \brief Apply the given matrix entry
   template<resource rec = resource::host>
-  void apply(matrix_entry entry, precision alpha, precision const x[], precision beta, precision y[])
+  void apply(imex_flag entry, precision alpha, precision const x[], precision beta, precision y[]) const
   {
     kglobal.template apply<rec>(entry, alpha, x, beta, y);
   }
 
-  int64_t flops(matrix_entry entry)
+  int64_t flops(imex_flag entry) const
   {
     return kglobal.flops(entry);
   }
 
   //! \brief Make the matrix for the given entry
-  void make(matrix_entry entry, PDE<precision> const &pde,
+  void make(imex_flag entry, PDE<precision> const &pde,
             adapt::distributed_grid<precision> const &grid, options const &opts)
   {
     if (not kglobal)
     {
       kglobal = make_block_global_kron_matrix(pde, grid, opts, &workspace);
-      set_specific_mode(pde, grid, opts, imex(entry), kglobal);
+      set_specific_mode(pde, grid, opts, entry, kglobal);
     }
     else if (not kglobal.specific_is_set(entry))
-      set_specific_mode(pde, grid, opts, imex(entry), kglobal);
+      set_specific_mode(pde, grid, opts, entry, kglobal);
   }
 
   /*!
    * \brief Either makes the matrix or if it exists, just updates only the
    *        coefficients
    */
-  void reset_coefficients(matrix_entry entry, PDE<precision> const &pde,
+  void reset_coefficients(imex_flag entry, PDE<precision> const &pde,
                           adapt::distributed_grid<precision> const &grid,
                           options const &opts)
   {
     if (not kglobal)
       make(entry, pde, grid, opts);
     else
-      set_specific_mode(pde, grid, opts, imex(entry), kglobal);
+      set_specific_mode(pde, grid, opts, entry, kglobal);
   }
 
-  //! \brief Clear the specified matrix
-  void clear(matrix_entry entry)
-  {
-    ignore(entry);
-    if (kglobal)
-      kglobal = block_global_kron_matrix<precision>();
-  }
   //! \brief Clear all matrices
-  void clear_all()
+  void clear()
   {
     if (kglobal)
       kglobal = block_global_kron_matrix<precision>();
   }
 
-  //! \brief Holds the global part of the kron product
-  block_global_kron_matrix<precision> kglobal;
+  //! \brief Returns the preconditioner.
+  template<resource rec>
+  auto const &get_diagonal_preconditioner() const
+  {
+    return kglobal.template get_diagonal_preconditioner<rec>();
+  }
 
 private:
-  kronmult::block_global_workspace<precision> workspace;
+  block_global_kron_matrix<precision> kglobal;
 
-  //! \brief Maps the entry enum to the IMEX flag
-  static imex_flag imex(matrix_entry entry)
-  {
-    return flag_map[static_cast<int>(entry)];
-  }
-  //! \brief Maps imex flags to integers
-  static constexpr std::array<imex_flag, 3> flag_map = {
-      imex_flag::unspecified, imex_flag::imex_explicit,
-      imex_flag::imex_implicit};
+  kronmult::block_global_workspace<precision> workspace;
 };
 
 #endif

--- a/src/asgard_kronmult_matrix.hpp
+++ b/src/asgard_kronmult_matrix.hpp
@@ -810,7 +810,7 @@ struct kron_operators
     {
       xdev = fk::vector<precision, mem_type::owner, resource::device>();
       xdev = fk::vector<precision, mem_type::owner, resource::device>(
-          (*this)[entry].input_size());
+          matrices[ientry].input_size());
     }
     if (matrices[ientry].output_size() != ydev.size())
     {

--- a/src/asgard_kronmult_matrix.hpp
+++ b/src/asgard_kronmult_matrix.hpp
@@ -912,20 +912,15 @@ private:
 #endif
 };
 
-#endif // ifndef KRON_MODE_GLOBAL
-
-// //! \brief Expressive indexing for the matrices
-// enum matrix_entry
-// {
-//   //! \brief Regular matrix for implicit or explicit time-stepping
-//   regular = 0,
-//   //! \brief IMEX explicit matrix
-//   imex_explicit = 1,
-//   //! \brief IMEX implicit matrix
-//   imex_implicit = 2
-// };
+#endif // end the ifndef KRON_MODE_GLOBAL
 
 #ifdef KRON_MODE_GLOBAL
+#ifndef KRON_MODE_GLOBAL_BLOCK
+// using GLOBAL kronmult where the explicitly form the sparse matrices
+// can be used with the cuSparse library (in CUDA mode)
+// will be replaced by the block global mode
+
+// forward declaration that allows set/update methods to be friends
 template<typename precision>
 class global_kron_matrix;
 
@@ -1039,13 +1034,13 @@ public:
 
   //! \brief Apply the operator, including expanding and remapping.
   template<resource rec = resource::host>
-  void apply(matrix_entry etype, precision alpha, precision const *x,
+  void apply(imex_flag etype, precision alpha, precision const *x,
              precision beta, precision *y) const;
 
   //! \brief The matrix evaluates to true if it has been initialized and false otherwise.
   operator bool() const { return (not gvals_.empty()); }
 
-  //! \brief Allows overwriting of the loaded coefficients.
+  //! \brief Returns the preconditioner.
   template<resource rec>
   auto const &get_diagonal_preconditioner() const
   {
@@ -1065,12 +1060,12 @@ public:
   }
 
   //! \brief Return the number of flops for the current matrix type
-  int64_t flops(matrix_entry etype) const
+  int64_t flops(imex_flag etype) const
   {
-    return flops_[flag2int(etype)];
+    return flops_[static_cast<int>(etype)];
   }
   //! \brief Check if the corresponding lock pattern is set.
-  bool local_unset(matrix_entry etype) const
+  bool local_unset(imex_flag etype) const
   {
     return (flops(etype) == 0);
   }
@@ -1107,16 +1102,6 @@ public:
       global_kron_matrix<precision> &mat);
 
 protected:
-  //! \brief Convert the imex flag to an index of the arrays.
-  static int flag2int(imex_flag imex)
-  {
-    return static_cast<int>(imex);
-  }
-  //! \brief Convert the matrix entry to an index of the arrays.
-  static int flag2int(matrix_entry imex)
-  {
-    return static_cast<int>(imex);
-  }
   // the workspace is kept externally to minimize allocations
   mutable workspace_type *work_;
 
@@ -1143,14 +1128,13 @@ protected:
   }
 
 private:
-  static constexpr int num_variants = 3;
   // description of the multi-indexes and the sparsity pattern
   // global case data
   int num_dimensions_;
   int64_t num_active_;
   int64_t num_padded_;
   std::vector<kronmult::permutes> perms_;
-  std::array<int64_t, num_variants> flops_;
+  std::array<int64_t, num_imex_variants> flops_;
   // data for the 1D tensors
   std::vector<std::vector<int>> gpntr_;
   std::vector<std::vector<int>> gindx_;
@@ -1163,7 +1147,7 @@ private:
   // preconditioner
   std::vector<precision> pre_con_;
 #ifdef ASGARD_USE_CUDA
-  std::array<kronmult::global_gpu_operations<precision>, num_variants> gpu_global;
+  std::array<kronmult::global_gpu_operations<precision>, num_imex_variants> gpu_global;
   mutable gpu::vector<precision> gpu_pre_con_; // gpu copy
 #endif
 };
@@ -1178,259 +1162,108 @@ global_kron_matrix<precision>
 make_global_kron_matrix(PDE<precision> const &pde,
                         adapt::distributed_grid<precision> const &dis_grid,
                         options const &program_options);
+
+/*!
+ * \brief Holds a list of matrices used for time-stepping.
+ *
+ * There are multiple types of matrices based on the time-stepping and the
+ * different terms being used. Matrices are grouped in one object so they can go
+ * as a set and reduce the number of matrix making.
+ */
+template<typename precision>
+struct kron_operators
+{
+  //! \brief Apply the given matrix entry
+  template<resource rec = resource::host>
+  void apply(imex_flag entry, precision alpha, precision const x[], precision beta, precision y[]) const
+  {
+    kglobal.template apply<rec>(entry, alpha, x, beta, y);
+  }
+  int64_t flops(imex_flag entry) const
+  {
+    return kglobal.flops(entry);
+  }
+
+  //! \brief Make the matrix for the given entry
+  void make(imex_flag entry, PDE<precision> const &pde,
+            adapt::distributed_grid<precision> const &grid, options const &opts)
+  {
+    if (not kglobal)
+    {
+      kglobal = make_global_kron_matrix(pde, grid, opts);
+      // the buffers must be set before preset_gpu_gkron()
+      kglobal.set_workspace_buffers(&workspaces);
+    }
+
+    if (kglobal.local_unset(entry))
+    {
+      set_specific_mode(pde, grid, opts, entry, kglobal);
+#ifdef ASGARD_USE_CUDA
+      kglobal.preset_gpu_gkron(sp_handle, entry);
+#endif
+    }
+  }
+  /*!
+   * \brief Either makes the matrix or if it exists, just updates only the
+   *        coefficients
+   */
+  void reset_coefficients(imex_flag entry, PDE<precision> const &pde,
+                          adapt::distributed_grid<precision> const &grid,
+                          options const &opts)
+  {
+    if (not kglobal)
+      make(entry, pde, grid, opts);
+    else
+    {
+      if (kglobal.local_unset(entry))
+      {
+        set_specific_mode(pde, grid, opts, entry, kglobal);
+#ifdef ASGARD_USE_CUDA
+        kglobal.preset_gpu_gkron(sp_handle, entry);
+#endif
+      }
+      else
+        update_matrix_coefficients(pde, grid, opts, entry, kglobal);
+    }
+  }
+
+  //! \brief Clear the specified matrix
+  void clear(imex_flag entry)
+  {
+    ignore(entry);
+    if (kglobal)
+      kglobal = global_kron_matrix<precision>();
+  }
+  //! \brief Clear all matrices
+  void clear_all()
+  {
+    if (kglobal)
+      kglobal = global_kron_matrix<precision>();
+  }
+
+  //! \brief Returns the preconditioner.
+  template<resource rec>
+  auto const &get_diagonal_preconditioner() const
+  {
+    return kglobal.template get_diagonal_preconditioner<rec>();
+  }
+
+private:
+  //! \brief Holds the global part of the kron product
+  global_kron_matrix<precision> kglobal;
+
+  typename global_kron_matrix<precision>::workspace_type workspaces;
+#ifdef ASGARD_USE_CUDA
+  gpu::sparse_handle sp_handle;
+  gpu::vector<std::byte> gpu_sparse_buffer;
 #endif
 
+};
+#endif // end ifndef KRON_MODE_GLOBAL_BLOCK
+#endif // end ifdef KRON_MODE_GLOBAL
 
-#ifndef KRON_MODE_GLOBAL_BLOCK
-
-// /*!
-//  * \brief Holds a list of matrices used for time-stepping.
-//  *
-//  * There are multiple types of matrices based on the time-stepping and the
-//  * different terms being used. Matrices are grouped in one object so they can go
-//  * as a set and reduce the number of matrix making.
-//  */
-// template<typename precision>
-// struct matrix_list
-// {
-//   //! \brief Makes a list of uninitialized matrices
-//   matrix_list()
-// #ifndef KRON_MODE_GLOBAL
-//       : matrices(3)
-// #endif
-//   {
-// #ifndef KRON_MODE_GLOBAL
-//     // make sure we have defined flags for all matrices
-//     expect(matrices.size() == flag_map.size());
-// #ifdef ASGARD_USE_GPU_MEM_LIMIT
-//     load_stream = nullptr;
-// #endif
-// #endif
-//   }
-//   //! \brief Frees the matrix list and any cache vectors
-//   ~matrix_list()
-//   {
-// #ifdef ASGARD_USE_GPU_MEM_LIMIT
-//     if (load_stream != nullptr)
-//     {
-//       auto status = cudaStreamDestroy(load_stream);
-//       expect(status == cudaSuccess);
-//     }
-// #endif
-//   }
-//
-// #ifndef KRON_MODE_GLOBAL
-//   //! \brief Returns an entry indexed by the enum
-//   kronmult_matrix<precision> &operator[](matrix_entry entry)
-//   {
-//     return matrices[static_cast<int>(entry)];
-//   }
-// #endif
-//
-//   //! \brief Apply the given matrix entry
-//   template<resource rec = resource::host>
-//   void apply(matrix_entry entry, precision alpha, precision const x[], precision beta, precision y[])
-//   {
-// #ifdef KRON_MODE_GLOBAL
-//     kglobal.template apply<rec>(entry, alpha, x, beta, y);
-// #else
-//     matrices[static_cast<int>(entry)].template apply<rec>(alpha, x, beta, y);
-// #endif
-//   }
-//   int64_t flops(matrix_entry entry)
-//   {
-// #ifdef KRON_MODE_GLOBAL
-//     return kglobal.flops(entry);
-// #else
-//     return matrices[static_cast<int>(entry)].flops();
-// #endif
-//   }
-//
-//   //! \brief Make the matrix for the given entry
-//   void make(matrix_entry entry, PDE<precision> const &pde,
-//             adapt::distributed_grid<precision> const &grid, options const &opts)
-//   {
-// #ifdef KRON_MODE_GLOBAL
-//     if (not kglobal)
-//     {
-//       kglobal = make_global_kron_matrix(pde, grid, opts);
-//       // the buffers must be set before preset_gpu_gkron()
-//       kglobal.set_workspace_buffers(&workspaces);
-//     }
-//
-//     if (kglobal.local_unset(entry))
-//     {
-//       set_specific_mode(pde, grid, opts, imex(entry), kglobal);
-// #ifdef ASGARD_USE_CUDA
-//       kglobal.preset_gpu_gkron(sp_handle, imex(entry));
-// #endif
-//     }
-// #else
-//     if (not mem_stats)
-//       mem_stats = compute_mem_usage(pde, grid, opts, imex(entry), spcache);
-//
-//     if (not(*this)[entry])
-//       (*this)[entry] = make_kronmult_matrix(pde, grid, opts, mem_stats,
-//                                             imex(entry), spcache);
-//
-// #ifdef ASGARD_USE_CUDA
-//     if ((*this)[entry].input_size() != xdev.size())
-//     {
-//       xdev = fk::vector<precision, mem_type::owner, resource::device>();
-//       xdev = fk::vector<precision, mem_type::owner, resource::device>(
-//           (*this)[entry].input_size());
-//     }
-//     if ((*this)[entry].output_size() != ydev.size())
-//     {
-//       ydev = fk::vector<precision, mem_type::owner, resource::device>();
-//       ydev = fk::vector<precision, mem_type::owner, resource::device>(
-//           (*this)[entry].output_size());
-//     }
-//     (*this)[entry].set_workspace(xdev, ydev);
-// #endif
-// #ifdef ASGARD_USE_GPU_MEM_LIMIT
-//     if (mem_stats.kron_call == memory_usage::multi_calls)
-//     {
-//       // doing multiple calls, prepare streams and workspaces
-//       if (load_stream == nullptr)
-//         cudaStreamCreate(&load_stream);
-//       if (worka.size() < static_cast<int>(mem_stats.work_size))
-//       {
-//         worka = fk::vector<int, mem_type::owner, resource::device>();
-//         workb = fk::vector<int, mem_type::owner, resource::device>();
-//         worka = fk::vector<int, mem_type::owner, resource::device>(
-//             mem_stats.work_size);
-//         workb = fk::vector<int, mem_type::owner, resource::device>(
-//             mem_stats.work_size);
-//         if (not(*this)[entry].is_dense())
-//         {
-//           irowa = fk::vector<int, mem_type::owner, resource::device>();
-//           irowb = fk::vector<int, mem_type::owner, resource::device>();
-//           icola = fk::vector<int, mem_type::owner, resource::device>();
-//           icolb = fk::vector<int, mem_type::owner, resource::device>();
-//           irowa = fk::vector<int, mem_type::owner, resource::device>(
-//               mem_stats.row_work_size);
-//           irowb = fk::vector<int, mem_type::owner, resource::device>(
-//               mem_stats.row_work_size);
-//           icola = fk::vector<int, mem_type::owner, resource::device>(
-//               mem_stats.row_work_size);
-//           icolb = fk::vector<int, mem_type::owner, resource::device>(
-//               mem_stats.row_work_size);
-//         }
-//       }
-//     }
-//     (*this)[entry].set_workspace_ooc(worka, workb, load_stream);
-//     (*this)[entry].set_workspace_ooc_sparse(irowa, irowb, icola, icolb);
-// #endif
-// #endif
-//   }
-//   /*!
-//    * \brief Either makes the matrix or if it exists, just updates only the
-//    *        coefficients
-//    */
-//   void reset_coefficients(matrix_entry entry, PDE<precision> const &pde,
-//                           adapt::distributed_grid<precision> const &grid,
-//                           options const &opts)
-//   {
-// #ifdef KRON_MODE_GLOBAL
-//     if (not kglobal)
-//       make(entry, pde, grid, opts);
-//     else
-//     {
-//       if (kglobal.local_unset(entry))
-//       {
-//         set_specific_mode(pde, grid, opts, imex(entry), kglobal);
-// #ifdef ASGARD_USE_CUDA
-//         kglobal.preset_gpu_gkron(sp_handle, imex(entry));
-// #endif
-//       }
-//       else
-//         update_matrix_coefficients(pde, grid, opts, imex(entry), kglobal);
-//     }
-// #else
-//     if (not(*this)[entry])
-//       make(entry, pde, grid, opts);
-//     else
-//       update_kronmult_coefficients(pde, opts, imex(entry), spcache,
-//                                    (*this)[entry]);
-// #endif
-//   }
-//
-//   //! \brief Clear the specified matrix
-//   void clear(matrix_entry entry)
-//   {
-// #ifdef KRON_MODE_GLOBAL
-//     ignore(entry);
-//     if (kglobal)
-//       kglobal = global_kron_matrix<precision>();
-// #else
-//     if (matrices[static_cast<int>(entry)])
-//       matrices[static_cast<int>(entry)] = kronmult_matrix<precision>();
-// #endif
-//   }
-//   //! \brief Clear all matrices
-//   void clear_all()
-//   {
-// #ifdef KRON_MODE_GLOBAL
-//     if (kglobal)
-//       kglobal = global_kron_matrix<precision>();
-// #else
-//     for (auto &matrix : matrices)
-//       if (matrix)
-//         matrix = kronmult_matrix<precision>();
-//     mem_stats.reset();
-// #endif
-//   }
-//
-// #ifdef KRON_MODE_GLOBAL
-//   //! \brief Holds the global part of the kron product
-//   global_kron_matrix<precision> kglobal;
-//
-//   typename global_kron_matrix<precision>::workspace_type workspaces;
-// #ifdef ASGARD_USE_CUDA
-//   gpu::sparse_handle sp_handle;
-//   gpu::vector<std::byte> gpu_sparse_buffer;
-// #endif
-// #else
-//   //! \brief Holds the matrices
-//   std::vector<kronmult_matrix<precision>> matrices;
-// #endif
-//
-// private:
-//   //! \brief Maps the entry enum to the IMEX flag
-//   static imex_flag imex(matrix_entry entry)
-//   {
-//     return flag_map[static_cast<int>(entry)];
-//   }
-//   //! \brief Maps imex flags to integers
-//   static constexpr std::array<imex_flag, 3> flag_map = {
-//       imex_flag::unspecified, imex_flag::imex_explicit,
-//       imex_flag::imex_implicit};
-//
-// #ifndef KRON_MODE_GLOBAL
-//   //! \brief Cache holding the memory stats, limits bounds etc.
-//   memory_usage mem_stats;
-//
-//   //! \brief Cache holding sparse parameters to avoid recomputing data
-//   kron_sparse_cache spcache;
-//
-// #ifdef ASGARD_USE_CUDA
-//   //! \brief Work buffers for the input and output
-//   mutable fk::vector<precision, mem_type::owner, resource::device> xdev, ydev;
-// #endif
-// #ifdef ASGARD_USE_GPU_MEM_LIMIT
-//   mutable fk::vector<int, mem_type::owner, resource::device> worka;
-//   mutable fk::vector<int, mem_type::owner, resource::device> workb;
-//   mutable fk::vector<int, mem_type::owner, resource::device> irowa;
-//   mutable fk::vector<int, mem_type::owner, resource::device> irowb;
-//   mutable fk::vector<int, mem_type::owner, resource::device> icola;
-//   mutable fk::vector<int, mem_type::owner, resource::device> icolb;
-//   cudaStream_t load_stream;
-// #endif
-// #endif
-// };
-
-#else
+#ifdef KRON_MODE_GLOBAL_BLOCK
+// using BLOCK-GLOBAL kronmult, the fastest method on the cpu and very memory conservative
 
 template<typename precision>
 class block_global_kron_matrix;

--- a/src/asgard_kronmult_matrix.hpp
+++ b/src/asgard_kronmult_matrix.hpp
@@ -864,7 +864,7 @@ struct kron_operators
                           options const &opts)
   {
     int const ientry = static_cast<int>(entry);
-    if (matrices[ientry])
+    if (not matrices[ientry])
       make(entry, pde, grid, opts);
     else
       update_kronmult_coefficients(pde, opts, entry, spcache,

--- a/src/asgard_kronmult_matrix.hpp
+++ b/src/asgard_kronmult_matrix.hpp
@@ -752,7 +752,6 @@ compute_mem_usage(PDE<P> const &pde, adapt::distributed_grid<P> const &grid,
                   kron_sparse_cache &spcache, int memory_limit_MB = 0,
                   int64_t index_limit = 2147483646, bool force_sparse = false);
 
-
 /*!
  * \brief Holds a list of matrices used for time-stepping.
  *
@@ -1243,7 +1242,6 @@ private:
   gpu::sparse_handle sp_handle;
   gpu::vector<std::byte> gpu_sparse_buffer;
 #endif
-
 };
 #endif // end ifndef KRON_MODE_GLOBAL_BLOCK
 #endif // end ifdef KRON_MODE_GLOBAL

--- a/src/asgard_kronmult_matrix.hpp
+++ b/src/asgard_kronmult_matrix.hpp
@@ -24,6 +24,10 @@ std::vector<int> get_used_terms(PDE<precision> const &pde, options const &opts,
                                 imex_flag const imex);
 
 #ifndef KRON_MODE_GLOBAL
+// using LOCAL kronmult, can be parallelised using MPI but much more expensive
+// then the global modes below
+// also has the ability to limit memory and do some operations out-of-core
+// hence it is currently the most memory conserving mode
 
 /*!
  * \brief Holds data for the pre-computed memory sizes.
@@ -721,18 +725,205 @@ void update_kronmult_coefficients(PDE<P> const &pde,
                                   kron_sparse_cache &spcache,
                                   kronmult_matrix<P> &mat);
 
-#endif // KRON_MODE_GLOBAL
+/*!
+ * \brief Compute the stats for the memory usage
+ *
+ * Computes how to avoid overflow or the use of more memory than
+ * is available on the GPU device.
+ *
+ * \tparam P is float or double
+ *
+ * \param pde holds the problem data
+ * \param grid is the discretization
+ * \param program_options is the user provided options
+ * \param imex is the flag indicating the IMEX mode
+ * \param spcache holds precomputed data about the sparsity pattern which is
+ *        used between multiple calls to avoid recomputing identical entries
+ * \param memory_limit_MB can override the user specified limit (in MB),
+ *        if set to zero the user selection will be used
+ * \param index_limit should be set to the max value held by the 32-bit index,
+ *        namely 2^31 -2 since 2^31 causes an overflow,
+ *        a different value can be used for testing purposes
+ */
+template<typename P>
+memory_usage
+compute_mem_usage(PDE<P> const &pde, adapt::distributed_grid<P> const &grid,
+                  options const &program_options, imex_flag const imex,
+                  kron_sparse_cache &spcache, int memory_limit_MB = 0,
+                  int64_t index_limit = 2147483646, bool force_sparse = false);
 
-//! \brief Expressive indexing for the matrices
-enum matrix_entry
+
+/*!
+ * \brief Holds a list of matrices used for time-stepping.
+ *
+ * There are multiple types of matrices based on the time-stepping and the
+ * different terms being used. Matrices are grouped in one object so they can go
+ * as a set and reduce the number of matrix making.
+ */
+template<typename precision>
+struct kron_operators
 {
-  //! \brief Regular matrix for implicit or explicit time-stepping
-  regular = 0,
-  //! \brief IMEX explicit matrix
-  imex_explicit = 1,
-  //! \brief IMEX implicit matrix
-  imex_implicit = 2
+  //! \brief Makes a list of uninitialized matrices
+  kron_operators()
+  {
+#ifdef ASGARD_USE_GPU_MEM_LIMIT
+    load_stream = nullptr;
+#endif
+  }
+  //! \brief Frees the matrix list and any cache vectors
+  ~kron_operators()
+  {
+#ifdef ASGARD_USE_GPU_MEM_LIMIT
+    if (load_stream != nullptr)
+    {
+      auto status = cudaStreamDestroy(load_stream);
+      expect(status == cudaSuccess);
+    }
+#endif
+  }
+
+  //! \brief Apply the given matrix entry
+  template<resource rec = resource::host>
+  void apply(imex_flag entry, precision alpha, precision const x[], precision beta, precision y[]) const
+  {
+    matrices[static_cast<int>(entry)].template apply<rec>(alpha, x, beta, y);
+  }
+  int64_t flops(imex_flag entry) const
+  {
+    return matrices[static_cast<int>(entry)].flops();
+  }
+
+  //! \brief Make the matrix for the given entry
+  void make(imex_flag entry, PDE<precision> const &pde,
+            adapt::distributed_grid<precision> const &grid, options const &opts)
+  {
+    if (not mem_stats)
+      mem_stats = compute_mem_usage(pde, grid, opts, entry, spcache);
+
+    int const ientry = static_cast<int>(entry);
+    if (not matrices[ientry])
+      matrices[ientry] = make_kronmult_matrix(pde, grid, opts, mem_stats,
+                                              entry, spcache);
+
+#ifdef ASGARD_USE_CUDA
+    if (matrices[ientry].input_size() != xdev.size())
+    {
+      xdev = fk::vector<precision, mem_type::owner, resource::device>();
+      xdev = fk::vector<precision, mem_type::owner, resource::device>(
+          (*this)[entry].input_size());
+    }
+    if (matrices[ientry].output_size() != ydev.size())
+    {
+      ydev = fk::vector<precision, mem_type::owner, resource::device>();
+      ydev = fk::vector<precision, mem_type::owner, resource::device>(
+          matrices[ientry].output_size());
+    }
+    matrices[ientry].set_workspace(xdev, ydev);
+#endif
+#ifdef ASGARD_USE_GPU_MEM_LIMIT
+    if (mem_stats.kron_call == memory_usage::multi_calls)
+    {
+      // doing multiple calls, prepare streams and workspaces
+      if (load_stream == nullptr)
+        cudaStreamCreate(&load_stream);
+      if (worka.size() < static_cast<int>(mem_stats.work_size))
+      {
+        worka = fk::vector<int, mem_type::owner, resource::device>();
+        workb = fk::vector<int, mem_type::owner, resource::device>();
+        worka = fk::vector<int, mem_type::owner, resource::device>(
+            mem_stats.work_size);
+        workb = fk::vector<int, mem_type::owner, resource::device>(
+            mem_stats.work_size);
+        if (matrices[ientry].is_dense())
+        {
+          irowa = fk::vector<int, mem_type::owner, resource::device>();
+          irowb = fk::vector<int, mem_type::owner, resource::device>();
+          icola = fk::vector<int, mem_type::owner, resource::device>();
+          icolb = fk::vector<int, mem_type::owner, resource::device>();
+          irowa = fk::vector<int, mem_type::owner, resource::device>(
+              mem_stats.row_work_size);
+          irowb = fk::vector<int, mem_type::owner, resource::device>(
+              mem_stats.row_work_size);
+          icola = fk::vector<int, mem_type::owner, resource::device>(
+              mem_stats.row_work_size);
+          icolb = fk::vector<int, mem_type::owner, resource::device>(
+              mem_stats.row_work_size);
+        }
+      }
+    }
+    matrices[ientry].set_workspace_ooc(worka, workb, load_stream);
+    matrices[ientry].set_workspace_ooc_sparse(irowa, irowb, icola, icolb);
+#endif
+  }
+  /*!
+   * \brief Either makes the matrix or if it exists, just updates only the
+   *        coefficients
+   */
+  void reset_coefficients(imex_flag entry, PDE<precision> const &pde,
+                          adapt::distributed_grid<precision> const &grid,
+                          options const &opts)
+  {
+    int const ientry = static_cast<int>(entry);
+    if (matrices[ientry])
+      make(entry, pde, grid, opts);
+    else
+      update_kronmult_coefficients(pde, opts, entry, spcache,
+                                   matrices[ientry]);
+  }
+
+  //! \brief Clear the specified matrix
+  void clear(imex_flag entry)
+  {
+    int const ientry = static_cast<int>(entry);
+    if (matrices[ientry])
+      matrices[ientry] = kronmult_matrix<precision>();
+  }
+  //! \brief Clear all matrices
+  void clear_all()
+  {
+    for (auto &matrix : matrices)
+      if (matrix)
+        matrix = kronmult_matrix<precision>();
+    mem_stats.reset();
+  }
+
+private:
+  //! \brief Holds the matrices
+  std::array<kronmult_matrix<precision>, num_imex_variants> matrices;
+
+  //! \brief Cache holding the memory stats, limits bounds etc.
+  memory_usage mem_stats;
+
+  //! \brief Cache holding sparse parameters to avoid recomputing data
+  kron_sparse_cache spcache;
+
+#ifdef ASGARD_USE_CUDA
+  //! \brief Work buffers for the input and output
+  mutable fk::vector<precision, mem_type::owner, resource::device> xdev, ydev;
+#endif
+#ifdef ASGARD_USE_GPU_MEM_LIMIT
+  mutable fk::vector<int, mem_type::owner, resource::device> worka;
+  mutable fk::vector<int, mem_type::owner, resource::device> workb;
+  mutable fk::vector<int, mem_type::owner, resource::device> irowa;
+  mutable fk::vector<int, mem_type::owner, resource::device> irowb;
+  mutable fk::vector<int, mem_type::owner, resource::device> icola;
+  mutable fk::vector<int, mem_type::owner, resource::device> icolb;
+  cudaStream_t load_stream;
+#endif
 };
+
+#endif // ifndef KRON_MODE_GLOBAL
+
+// //! \brief Expressive indexing for the matrices
+// enum matrix_entry
+// {
+//   //! \brief Regular matrix for implicit or explicit time-stepping
+//   regular = 0,
+//   //! \brief IMEX explicit matrix
+//   imex_explicit = 1,
+//   //! \brief IMEX implicit matrix
+//   imex_implicit = 2
+// };
 
 #ifdef KRON_MODE_GLOBAL
 template<typename precision>
@@ -989,285 +1180,255 @@ make_global_kron_matrix(PDE<precision> const &pde,
                         options const &program_options);
 #endif
 
-#ifndef KRON_MODE_GLOBAL
-
-/*!
- * \brief Compute the stats for the memory usage
- *
- * Computes how to avoid overflow or the use of more memory than
- * is available on the GPU device.
- *
- * \tparam P is float or double
- *
- * \param pde holds the problem data
- * \param grid is the discretization
- * \param program_options is the user provided options
- * \param imex is the flag indicating the IMEX mode
- * \param spcache holds precomputed data about the sparsity pattern which is
- *        used between multiple calls to avoid recomputing identical entries
- * \param memory_limit_MB can override the user specified limit (in MB),
- *        if set to zero the user selection will be used
- * \param index_limit should be set to the max value held by the 32-bit index,
- *        namely 2^31 -2 since 2^31 causes an overflow,
- *        a different value can be used for testing purposes
- */
-template<typename P>
-memory_usage
-compute_mem_usage(PDE<P> const &pde, adapt::distributed_grid<P> const &grid,
-                  options const &program_options, imex_flag const imex,
-                  kron_sparse_cache &spcache, int memory_limit_MB = 0,
-                  int64_t index_limit = 2147483646, bool force_sparse = false);
-
-#endif // KRON_MODE_GLOBAL
 
 #ifndef KRON_MODE_GLOBAL_BLOCK
 
-/*!
- * \brief Holds a list of matrices used for time-stepping.
- *
- * There are multiple types of matrices based on the time-stepping and the
- * different terms being used. Matrices are grouped in one object so they can go
- * as a set and reduce the number of matrix making.
- */
-template<typename precision>
-struct matrix_list
-{
-  //! \brief Makes a list of uninitialized matrices
-  matrix_list()
-#ifndef KRON_MODE_GLOBAL
-      : matrices(3)
-#endif
-  {
-#ifndef KRON_MODE_GLOBAL
-    // make sure we have defined flags for all matrices
-    expect(matrices.size() == flag_map.size());
-#ifdef ASGARD_USE_GPU_MEM_LIMIT
-    load_stream = nullptr;
-#endif
-#endif
-  }
-  //! \brief Frees the matrix list and any cache vectors
-  ~matrix_list()
-  {
-#ifdef ASGARD_USE_GPU_MEM_LIMIT
-    if (load_stream != nullptr)
-    {
-      auto status = cudaStreamDestroy(load_stream);
-      expect(status == cudaSuccess);
-    }
-#endif
-  }
-
-#ifndef KRON_MODE_GLOBAL
-  //! \brief Returns an entry indexed by the enum
-  kronmult_matrix<precision> &operator[](matrix_entry entry)
-  {
-    return matrices[static_cast<int>(entry)];
-  }
-#endif
-
-  //! \brief Apply the given matrix entry
-  template<resource rec = resource::host>
-  void apply(matrix_entry entry, precision alpha, precision const x[], precision beta, precision y[])
-  {
-#ifdef KRON_MODE_GLOBAL
-    kglobal.template apply<rec>(entry, alpha, x, beta, y);
-#else
-    matrices[static_cast<int>(entry)].template apply<rec>(alpha, x, beta, y);
-#endif
-  }
-  int64_t flops(matrix_entry entry)
-  {
-#ifdef KRON_MODE_GLOBAL
-    return kglobal.flops(entry);
-#else
-    return matrices[static_cast<int>(entry)].flops();
-#endif
-  }
-
-  //! \brief Make the matrix for the given entry
-  void make(matrix_entry entry, PDE<precision> const &pde,
-            adapt::distributed_grid<precision> const &grid, options const &opts)
-  {
-#ifdef KRON_MODE_GLOBAL
-    if (not kglobal)
-    {
-      kglobal = make_global_kron_matrix(pde, grid, opts);
-      // the buffers must be set before preset_gpu_gkron()
-      kglobal.set_workspace_buffers(&workspaces);
-    }
-
-    if (kglobal.local_unset(entry))
-    {
-      set_specific_mode(pde, grid, opts, imex(entry), kglobal);
-#ifdef ASGARD_USE_CUDA
-      kglobal.preset_gpu_gkron(sp_handle, imex(entry));
-#endif
-    }
-#else
-    if (not mem_stats)
-      mem_stats = compute_mem_usage(pde, grid, opts, imex(entry), spcache);
-
-    if (not(*this)[entry])
-      (*this)[entry] = make_kronmult_matrix(pde, grid, opts, mem_stats,
-                                            imex(entry), spcache);
-
-#ifdef ASGARD_USE_CUDA
-    if ((*this)[entry].input_size() != xdev.size())
-    {
-      xdev = fk::vector<precision, mem_type::owner, resource::device>();
-      xdev = fk::vector<precision, mem_type::owner, resource::device>(
-          (*this)[entry].input_size());
-    }
-    if ((*this)[entry].output_size() != ydev.size())
-    {
-      ydev = fk::vector<precision, mem_type::owner, resource::device>();
-      ydev = fk::vector<precision, mem_type::owner, resource::device>(
-          (*this)[entry].output_size());
-    }
-    (*this)[entry].set_workspace(xdev, ydev);
-#endif
-#ifdef ASGARD_USE_GPU_MEM_LIMIT
-    if (mem_stats.kron_call == memory_usage::multi_calls)
-    {
-      // doing multiple calls, prepare streams and workspaces
-      if (load_stream == nullptr)
-        cudaStreamCreate(&load_stream);
-      if (worka.size() < static_cast<int>(mem_stats.work_size))
-      {
-        worka = fk::vector<int, mem_type::owner, resource::device>();
-        workb = fk::vector<int, mem_type::owner, resource::device>();
-        worka = fk::vector<int, mem_type::owner, resource::device>(
-            mem_stats.work_size);
-        workb = fk::vector<int, mem_type::owner, resource::device>(
-            mem_stats.work_size);
-        if (not(*this)[entry].is_dense())
-        {
-          irowa = fk::vector<int, mem_type::owner, resource::device>();
-          irowb = fk::vector<int, mem_type::owner, resource::device>();
-          icola = fk::vector<int, mem_type::owner, resource::device>();
-          icolb = fk::vector<int, mem_type::owner, resource::device>();
-          irowa = fk::vector<int, mem_type::owner, resource::device>(
-              mem_stats.row_work_size);
-          irowb = fk::vector<int, mem_type::owner, resource::device>(
-              mem_stats.row_work_size);
-          icola = fk::vector<int, mem_type::owner, resource::device>(
-              mem_stats.row_work_size);
-          icolb = fk::vector<int, mem_type::owner, resource::device>(
-              mem_stats.row_work_size);
-        }
-      }
-    }
-    (*this)[entry].set_workspace_ooc(worka, workb, load_stream);
-    (*this)[entry].set_workspace_ooc_sparse(irowa, irowb, icola, icolb);
-#endif
-#endif
-  }
-  /*!
-   * \brief Either makes the matrix or if it exists, just updates only the
-   *        coefficients
-   */
-  void reset_coefficients(matrix_entry entry, PDE<precision> const &pde,
-                          adapt::distributed_grid<precision> const &grid,
-                          options const &opts)
-  {
-#ifdef KRON_MODE_GLOBAL
-    if (not kglobal)
-      make(entry, pde, grid, opts);
-    else
-    {
-      if (kglobal.local_unset(entry))
-      {
-        set_specific_mode(pde, grid, opts, imex(entry), kglobal);
-#ifdef ASGARD_USE_CUDA
-        kglobal.preset_gpu_gkron(sp_handle, imex(entry));
-#endif
-      }
-      else
-        update_matrix_coefficients(pde, grid, opts, imex(entry), kglobal);
-    }
-#else
-    if (not(*this)[entry])
-      make(entry, pde, grid, opts);
-    else
-      update_kronmult_coefficients(pde, opts, imex(entry), spcache,
-                                   (*this)[entry]);
-#endif
-  }
-
-  //! \brief Clear the specified matrix
-  void clear(matrix_entry entry)
-  {
-#ifdef KRON_MODE_GLOBAL
-    ignore(entry);
-    if (kglobal)
-      kglobal = global_kron_matrix<precision>();
-#else
-    if (matrices[static_cast<int>(entry)])
-      matrices[static_cast<int>(entry)] = kronmult_matrix<precision>();
-#endif
-  }
-  //! \brief Clear all matrices
-  void clear_all()
-  {
-#ifdef KRON_MODE_GLOBAL
-    if (kglobal)
-      kglobal = global_kron_matrix<precision>();
-#else
-    for (auto &matrix : matrices)
-      if (matrix)
-        matrix = kronmult_matrix<precision>();
-    mem_stats.reset();
-#endif
-  }
-
-#ifdef KRON_MODE_GLOBAL
-  //! \brief Holds the global part of the kron product
-  global_kron_matrix<precision> kglobal;
-
-  typename global_kron_matrix<precision>::workspace_type workspaces;
-#ifdef ASGARD_USE_CUDA
-  gpu::sparse_handle sp_handle;
-  gpu::vector<std::byte> gpu_sparse_buffer;
-#endif
-#else
-  //! \brief Holds the matrices
-  std::vector<kronmult_matrix<precision>> matrices;
-#endif
-
-private:
-  //! \brief Maps the entry enum to the IMEX flag
-  static imex_flag imex(matrix_entry entry)
-  {
-    return flag_map[static_cast<int>(entry)];
-  }
-  //! \brief Maps imex flags to integers
-  static constexpr std::array<imex_flag, 3> flag_map = {
-      imex_flag::unspecified, imex_flag::imex_explicit,
-      imex_flag::imex_implicit};
-
-#ifndef KRON_MODE_GLOBAL
-  //! \brief Cache holding the memory stats, limits bounds etc.
-  memory_usage mem_stats;
-
-  //! \brief Cache holding sparse parameters to avoid recomputing data
-  kron_sparse_cache spcache;
-
-#ifdef ASGARD_USE_CUDA
-  //! \brief Work buffers for the input and output
-  mutable fk::vector<precision, mem_type::owner, resource::device> xdev, ydev;
-#endif
-#ifdef ASGARD_USE_GPU_MEM_LIMIT
-  mutable fk::vector<int, mem_type::owner, resource::device> worka;
-  mutable fk::vector<int, mem_type::owner, resource::device> workb;
-  mutable fk::vector<int, mem_type::owner, resource::device> irowa;
-  mutable fk::vector<int, mem_type::owner, resource::device> irowb;
-  mutable fk::vector<int, mem_type::owner, resource::device> icola;
-  mutable fk::vector<int, mem_type::owner, resource::device> icolb;
-  cudaStream_t load_stream;
-#endif
-#endif
-};
+// /*!
+//  * \brief Holds a list of matrices used for time-stepping.
+//  *
+//  * There are multiple types of matrices based on the time-stepping and the
+//  * different terms being used. Matrices are grouped in one object so they can go
+//  * as a set and reduce the number of matrix making.
+//  */
+// template<typename precision>
+// struct matrix_list
+// {
+//   //! \brief Makes a list of uninitialized matrices
+//   matrix_list()
+// #ifndef KRON_MODE_GLOBAL
+//       : matrices(3)
+// #endif
+//   {
+// #ifndef KRON_MODE_GLOBAL
+//     // make sure we have defined flags for all matrices
+//     expect(matrices.size() == flag_map.size());
+// #ifdef ASGARD_USE_GPU_MEM_LIMIT
+//     load_stream = nullptr;
+// #endif
+// #endif
+//   }
+//   //! \brief Frees the matrix list and any cache vectors
+//   ~matrix_list()
+//   {
+// #ifdef ASGARD_USE_GPU_MEM_LIMIT
+//     if (load_stream != nullptr)
+//     {
+//       auto status = cudaStreamDestroy(load_stream);
+//       expect(status == cudaSuccess);
+//     }
+// #endif
+//   }
+//
+// #ifndef KRON_MODE_GLOBAL
+//   //! \brief Returns an entry indexed by the enum
+//   kronmult_matrix<precision> &operator[](matrix_entry entry)
+//   {
+//     return matrices[static_cast<int>(entry)];
+//   }
+// #endif
+//
+//   //! \brief Apply the given matrix entry
+//   template<resource rec = resource::host>
+//   void apply(matrix_entry entry, precision alpha, precision const x[], precision beta, precision y[])
+//   {
+// #ifdef KRON_MODE_GLOBAL
+//     kglobal.template apply<rec>(entry, alpha, x, beta, y);
+// #else
+//     matrices[static_cast<int>(entry)].template apply<rec>(alpha, x, beta, y);
+// #endif
+//   }
+//   int64_t flops(matrix_entry entry)
+//   {
+// #ifdef KRON_MODE_GLOBAL
+//     return kglobal.flops(entry);
+// #else
+//     return matrices[static_cast<int>(entry)].flops();
+// #endif
+//   }
+//
+//   //! \brief Make the matrix for the given entry
+//   void make(matrix_entry entry, PDE<precision> const &pde,
+//             adapt::distributed_grid<precision> const &grid, options const &opts)
+//   {
+// #ifdef KRON_MODE_GLOBAL
+//     if (not kglobal)
+//     {
+//       kglobal = make_global_kron_matrix(pde, grid, opts);
+//       // the buffers must be set before preset_gpu_gkron()
+//       kglobal.set_workspace_buffers(&workspaces);
+//     }
+//
+//     if (kglobal.local_unset(entry))
+//     {
+//       set_specific_mode(pde, grid, opts, imex(entry), kglobal);
+// #ifdef ASGARD_USE_CUDA
+//       kglobal.preset_gpu_gkron(sp_handle, imex(entry));
+// #endif
+//     }
+// #else
+//     if (not mem_stats)
+//       mem_stats = compute_mem_usage(pde, grid, opts, imex(entry), spcache);
+//
+//     if (not(*this)[entry])
+//       (*this)[entry] = make_kronmult_matrix(pde, grid, opts, mem_stats,
+//                                             imex(entry), spcache);
+//
+// #ifdef ASGARD_USE_CUDA
+//     if ((*this)[entry].input_size() != xdev.size())
+//     {
+//       xdev = fk::vector<precision, mem_type::owner, resource::device>();
+//       xdev = fk::vector<precision, mem_type::owner, resource::device>(
+//           (*this)[entry].input_size());
+//     }
+//     if ((*this)[entry].output_size() != ydev.size())
+//     {
+//       ydev = fk::vector<precision, mem_type::owner, resource::device>();
+//       ydev = fk::vector<precision, mem_type::owner, resource::device>(
+//           (*this)[entry].output_size());
+//     }
+//     (*this)[entry].set_workspace(xdev, ydev);
+// #endif
+// #ifdef ASGARD_USE_GPU_MEM_LIMIT
+//     if (mem_stats.kron_call == memory_usage::multi_calls)
+//     {
+//       // doing multiple calls, prepare streams and workspaces
+//       if (load_stream == nullptr)
+//         cudaStreamCreate(&load_stream);
+//       if (worka.size() < static_cast<int>(mem_stats.work_size))
+//       {
+//         worka = fk::vector<int, mem_type::owner, resource::device>();
+//         workb = fk::vector<int, mem_type::owner, resource::device>();
+//         worka = fk::vector<int, mem_type::owner, resource::device>(
+//             mem_stats.work_size);
+//         workb = fk::vector<int, mem_type::owner, resource::device>(
+//             mem_stats.work_size);
+//         if (not(*this)[entry].is_dense())
+//         {
+//           irowa = fk::vector<int, mem_type::owner, resource::device>();
+//           irowb = fk::vector<int, mem_type::owner, resource::device>();
+//           icola = fk::vector<int, mem_type::owner, resource::device>();
+//           icolb = fk::vector<int, mem_type::owner, resource::device>();
+//           irowa = fk::vector<int, mem_type::owner, resource::device>(
+//               mem_stats.row_work_size);
+//           irowb = fk::vector<int, mem_type::owner, resource::device>(
+//               mem_stats.row_work_size);
+//           icola = fk::vector<int, mem_type::owner, resource::device>(
+//               mem_stats.row_work_size);
+//           icolb = fk::vector<int, mem_type::owner, resource::device>(
+//               mem_stats.row_work_size);
+//         }
+//       }
+//     }
+//     (*this)[entry].set_workspace_ooc(worka, workb, load_stream);
+//     (*this)[entry].set_workspace_ooc_sparse(irowa, irowb, icola, icolb);
+// #endif
+// #endif
+//   }
+//   /*!
+//    * \brief Either makes the matrix or if it exists, just updates only the
+//    *        coefficients
+//    */
+//   void reset_coefficients(matrix_entry entry, PDE<precision> const &pde,
+//                           adapt::distributed_grid<precision> const &grid,
+//                           options const &opts)
+//   {
+// #ifdef KRON_MODE_GLOBAL
+//     if (not kglobal)
+//       make(entry, pde, grid, opts);
+//     else
+//     {
+//       if (kglobal.local_unset(entry))
+//       {
+//         set_specific_mode(pde, grid, opts, imex(entry), kglobal);
+// #ifdef ASGARD_USE_CUDA
+//         kglobal.preset_gpu_gkron(sp_handle, imex(entry));
+// #endif
+//       }
+//       else
+//         update_matrix_coefficients(pde, grid, opts, imex(entry), kglobal);
+//     }
+// #else
+//     if (not(*this)[entry])
+//       make(entry, pde, grid, opts);
+//     else
+//       update_kronmult_coefficients(pde, opts, imex(entry), spcache,
+//                                    (*this)[entry]);
+// #endif
+//   }
+//
+//   //! \brief Clear the specified matrix
+//   void clear(matrix_entry entry)
+//   {
+// #ifdef KRON_MODE_GLOBAL
+//     ignore(entry);
+//     if (kglobal)
+//       kglobal = global_kron_matrix<precision>();
+// #else
+//     if (matrices[static_cast<int>(entry)])
+//       matrices[static_cast<int>(entry)] = kronmult_matrix<precision>();
+// #endif
+//   }
+//   //! \brief Clear all matrices
+//   void clear_all()
+//   {
+// #ifdef KRON_MODE_GLOBAL
+//     if (kglobal)
+//       kglobal = global_kron_matrix<precision>();
+// #else
+//     for (auto &matrix : matrices)
+//       if (matrix)
+//         matrix = kronmult_matrix<precision>();
+//     mem_stats.reset();
+// #endif
+//   }
+//
+// #ifdef KRON_MODE_GLOBAL
+//   //! \brief Holds the global part of the kron product
+//   global_kron_matrix<precision> kglobal;
+//
+//   typename global_kron_matrix<precision>::workspace_type workspaces;
+// #ifdef ASGARD_USE_CUDA
+//   gpu::sparse_handle sp_handle;
+//   gpu::vector<std::byte> gpu_sparse_buffer;
+// #endif
+// #else
+//   //! \brief Holds the matrices
+//   std::vector<kronmult_matrix<precision>> matrices;
+// #endif
+//
+// private:
+//   //! \brief Maps the entry enum to the IMEX flag
+//   static imex_flag imex(matrix_entry entry)
+//   {
+//     return flag_map[static_cast<int>(entry)];
+//   }
+//   //! \brief Maps imex flags to integers
+//   static constexpr std::array<imex_flag, 3> flag_map = {
+//       imex_flag::unspecified, imex_flag::imex_explicit,
+//       imex_flag::imex_implicit};
+//
+// #ifndef KRON_MODE_GLOBAL
+//   //! \brief Cache holding the memory stats, limits bounds etc.
+//   memory_usage mem_stats;
+//
+//   //! \brief Cache holding sparse parameters to avoid recomputing data
+//   kron_sparse_cache spcache;
+//
+// #ifdef ASGARD_USE_CUDA
+//   //! \brief Work buffers for the input and output
+//   mutable fk::vector<precision, mem_type::owner, resource::device> xdev, ydev;
+// #endif
+// #ifdef ASGARD_USE_GPU_MEM_LIMIT
+//   mutable fk::vector<int, mem_type::owner, resource::device> worka;
+//   mutable fk::vector<int, mem_type::owner, resource::device> workb;
+//   mutable fk::vector<int, mem_type::owner, resource::device> irowa;
+//   mutable fk::vector<int, mem_type::owner, resource::device> irowb;
+//   mutable fk::vector<int, mem_type::owner, resource::device> icola;
+//   mutable fk::vector<int, mem_type::owner, resource::device> icolb;
+//   cudaStream_t load_stream;
+// #endif
+// #endif
+// };
 
 #else
 

--- a/src/asgard_kronmult_matrix_tests.cpp
+++ b/src/asgard_kronmult_matrix_tests.cpp
@@ -37,7 +37,7 @@ void test_kronmult_sparse(int dimensions, int n, int num_rows, int num_terms,
     ip++;
   }
 
-  asgard::kronmult_matrix<T> kmat;
+  asgard::local_kronmult_matrix<T> kmat;
 
 #ifdef ASGARD_USE_CUDA
 
@@ -54,7 +54,7 @@ void test_kronmult_sparse(int dimensions, int n, int num_rows, int num_terms,
       col_indx[i * num_rows + j] = j * tensor_size;
     }
   }
-  kmat = asgard::kronmult_matrix<T>(
+  kmat = asgard::local_kronmult_matrix<T>(
       dimensions, n, num_rows, num_rows, num_terms,
       row_indx.clone_onto_device(), col_indx.clone_onto_device(),
       iA.clone_onto_device(), vA.clone_onto_device());
@@ -83,9 +83,9 @@ void test_kronmult_sparse(int dimensions, int n, int num_rows, int num_terms,
   std::vector<asgard::fk::vector<int>> list_iA;
   list_iA.push_back(iA);
 
-  kmat = asgard::kronmult_matrix<T>(dimensions, n, num_rows, num_rows,
-                                    num_terms, std::move(pntr), std::move(indx),
-                                    std::move(list_iA), std::move(vA));
+  kmat = asgard::local_kronmult_matrix<T>(
+      dimensions, n, num_rows, num_rows, num_terms,
+      std::move(pntr), std::move(indx), std::move(list_iA), std::move(vA));
 
 #endif
 
@@ -145,7 +145,7 @@ void test_kronmult_dense(int dimensions, int n, int num_terms,
   asgard::fk::copy_to_device(xdev.data(), data->input_x.data(), xdev.size());
   asgard::fk::copy_to_device(ydev.data(), data->output_y.data(), ydev.size());
 
-  asgard::kronmult_matrix<P> kmat(
+  asgard::local_kronmult_matrix<P> kmat(
       dimensions, n, data->num_rows(), data->num_rows(), num_terms,
       std::move(gpu_terms), std::move(elem), 0, 0, num_1d_blocks);
 

--- a/src/asgard_kronmult_matrix_tests.cpp
+++ b/src/asgard_kronmult_matrix_tests.cpp
@@ -163,7 +163,7 @@ void test_kronmult_dense(int dimensions, int n, int num_terms,
   }
 
 #else
-  asgard::kronmult_matrix<P> kmat(
+  asgard::local_kronmult_matrix<P> kmat(
       dimensions, n, data->num_rows(), data->num_rows(), num_terms,
       std::move(data->coefficients), asgard::fk::vector<int>(data->elem), 0, 0,
       num_1d_blocks);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -248,7 +248,7 @@ int main(int argc, char **argv)
   asgard::node_out() << "--- begin time loop w/ dt " << pde->get_dt()
                      << " ---\n";
 
-  asgard::matrix_list<prec> operator_matrices;
+  asgard::kron_operators<prec> operator_matrices;
 
   for (auto i = start_step; i < opts.num_time_steps; ++i)
   {

--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -89,6 +89,7 @@ enum class imex_flag
   imex_explicit = 1,
   imex_implicit = 2,
 };
+int constexpr num_imex_variants = 3;
 
 template<typename P>
 struct gmres_info

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -195,54 +195,54 @@ bicgstab_euler(const P dt, imex_flag imex,
 
 
 
-#ifdef KRON_MODE_GLOBAL_BLOCK
-template<typename P, resource resrc>
-gmres_info<P>
-simple_gmres_euler(const P dt, matrix_entry mentry,
-                   block_global_kron_matrix<P> const &mat,
-                   fk::vector<P, mem_type::owner, resrc> &x,
-                   fk::vector<P, mem_type::owner, resrc> const &b,
-                   int const restart, int const max_iter, P const tolerance)
-{
-  auto const &pc = mat.template get_diagonal_preconditioner<resrc>();
-
-  return simple_gmres(
-      [&](P const alpha, fk::vector<P, mem_type::view, resrc> const x_in,
-          P const beta, fk::vector<P, mem_type::view, resrc> y) -> void {
-        tools::time_event performance("kronmult - implicit", mat.flops(mentry));
-        mat.template apply<resrc>(mentry, -dt * alpha, x_in.data(), beta, y.data());
-        lib_dispatch::axpy<resrc>(y.size(), alpha, x_in.data(), 1, y.data(), 1);
-      },
-      fk::vector<P, mem_type::view, resrc>(x), b,
-      [&](fk::vector<P, mem_type::view, resrc> &x_in) -> void {
-        tools::time_event performance("kronmult - preconditioner", pc.size());
-        apply_diagonal_precond(pc, dt, x_in);
-      }, restart, max_iter, tolerance);
-}
-template<typename P, resource resrc>
-gmres_info<P>
-bicgstab_euler(const P dt, matrix_entry mentry,
-               block_global_kron_matrix<P> const &mat,
-               fk::vector<P, mem_type::owner, resrc> &x,
-               fk::vector<P, mem_type::owner, resrc> const &b,
-               int const max_iter, P const tolerance)
-{
-  auto const &pc = mat.template get_diagonal_preconditioner<resrc>();
-
-  return bicgstab(
-    [&](P const alpha, fk::vector<P, mem_type::view, resrc> const x_in,
-          P const beta, fk::vector<P, mem_type::view, resrc> y) -> void {
-        tools::time_event performance("kronmult - implicit", mat.flops(mentry));
-        mat.template apply<resrc>(mentry, -dt * alpha, x_in.data(), beta, y.data());
-        lib_dispatch::axpy<resrc>(y.size(), alpha, x_in.data(), 1, y.data(), 1);
-      },
-      fk::vector<P, mem_type::view, resrc>(x), b,
-      [&](fk::vector<P, mem_type::view, resrc> &x_in) -> void {
-        tools::time_event performance("kronmult - preconditioner", pc.size());
-        apply_diagonal_precond(pc, dt, x_in);
-      }, max_iter, tolerance);
-}
-#endif
+// #ifdef KRON_MODE_GLOBAL_BLOCK
+// template<typename P, resource resrc>
+// gmres_info<P>
+// simple_gmres_euler(const P dt, matrix_entry mentry,
+//                    block_global_kron_matrix<P> const &mat,
+//                    fk::vector<P, mem_type::owner, resrc> &x,
+//                    fk::vector<P, mem_type::owner, resrc> const &b,
+//                    int const restart, int const max_iter, P const tolerance)
+// {
+//   auto const &pc = mat.template get_diagonal_preconditioner<resrc>();
+//
+//   return simple_gmres(
+//       [&](P const alpha, fk::vector<P, mem_type::view, resrc> const x_in,
+//           P const beta, fk::vector<P, mem_type::view, resrc> y) -> void {
+//         tools::time_event performance("kronmult - implicit", mat.flops(mentry));
+//         mat.template apply<resrc>(mentry, -dt * alpha, x_in.data(), beta, y.data());
+//         lib_dispatch::axpy<resrc>(y.size(), alpha, x_in.data(), 1, y.data(), 1);
+//       },
+//       fk::vector<P, mem_type::view, resrc>(x), b,
+//       [&](fk::vector<P, mem_type::view, resrc> &x_in) -> void {
+//         tools::time_event performance("kronmult - preconditioner", pc.size());
+//         apply_diagonal_precond(pc, dt, x_in);
+//       }, restart, max_iter, tolerance);
+// }
+// template<typename P, resource resrc>
+// gmres_info<P>
+// bicgstab_euler(const P dt, matrix_entry mentry,
+//                block_global_kron_matrix<P> const &mat,
+//                fk::vector<P, mem_type::owner, resrc> &x,
+//                fk::vector<P, mem_type::owner, resrc> const &b,
+//                int const max_iter, P const tolerance)
+// {
+//   auto const &pc = mat.template get_diagonal_preconditioner<resrc>();
+//
+//   return bicgstab(
+//     [&](P const alpha, fk::vector<P, mem_type::view, resrc> const x_in,
+//           P const beta, fk::vector<P, mem_type::view, resrc> y) -> void {
+//         tools::time_event performance("kronmult - implicit", mat.flops(mentry));
+//         mat.template apply<resrc>(mentry, -dt * alpha, x_in.data(), beta, y.data());
+//         lib_dispatch::axpy<resrc>(y.size(), alpha, x_in.data(), 1, y.data(), 1);
+//       },
+//       fk::vector<P, mem_type::view, resrc>(x), b,
+//       [&](fk::vector<P, mem_type::view, resrc> &x_in) -> void {
+//         tools::time_event performance("kronmult - preconditioner", pc.size());
+//         apply_diagonal_precond(pc, dt, x_in);
+//       }, max_iter, tolerance);
+// }
+// #endif
 
 #else
 // template<typename P, resource resrc>

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -711,6 +711,15 @@ simple_gmres_euler(const double dt, imex_flag imex,
                    fk::vector<double, mem_type::owner, resource::host> const &b,
                    int const restart, int const max_iter, double const tolerance);
 
+#ifdef ASGARD_USE_CUDA
+template gmres_info<double>
+simple_gmres_euler(const double dt, imex_flag imex,
+                   kron_operators<double> const &ops,
+                   fk::vector<double, mem_type::owner, resource::device> &x,
+                   fk::vector<double, mem_type::owner, resource::device> const &b,
+                   int const restart, int const max_iter, double const tolerance);
+#endif
+
 #ifdef KRON_MODE_GLOBAL
 
 // #ifdef KRON_MODE_GLOBAL_BLOCK
@@ -769,6 +778,15 @@ bicgstab(fk::matrix<double> const &A, fk::vector<double> &x,
          fk::vector<double> const &b, fk::matrix<double> const &M,
          int const max_iter, double const tolerance);
 
+#ifdef ASGARD_USE_CUDA
+template gmres_info<double>
+bicgstab_euler(const double dt, imex_flag imex,
+               kron_operators<double> const &ops,
+               fk::vector<double, mem_type::owner, resource::device> &x,
+               fk::vector<double, mem_type::owner, resource::device> const &b,
+               int const max_iter, double const tolerance);
+#endif
+
 #ifdef KRON_MODE_GLOBAL
 
 #ifdef KRON_MODE_GLOBAL_BLOCK
@@ -826,6 +844,21 @@ bicgstab_euler(const float dt, imex_flag imex,
                fk::vector<float, mem_type::owner, resource::host> const &b,
                int const max_iter, float const tolerance);
 
+#ifdef ASGARD_USE_CUDA
+template gmres_info<float>
+simple_gmres_euler(const float dt, imex_flag imex,
+                   kron_operators<float> const &ops,
+                   fk::vector<float, mem_type::owner, resource::device> &x,
+                   fk::vector<float, mem_type::owner, resource::device> const &b,
+                   int const restart, int const max_iter, float const tolerance);
+
+template gmres_info<float>
+bicgstab_euler(const float dt, imex_flag imex,
+               kron_operators<float> const &ops,
+               fk::vector<float, mem_type::owner, resource::device> &x,
+               fk::vector<float, mem_type::owner, resource::device> const &b,
+               int const max_iter, float const tolerance);
+#endif
 
 #ifdef KRON_MODE_GLOBAL
 // template gmres_info<float>

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -112,54 +112,88 @@ void apply_diagonal_precond(gpu::vector<P> const &pc, P dt,
   kronmult::gpu_precon_jacobi(pc.size(), dt, pc.data(), x.data());
 }
 #endif
+#endif
 
 template<typename P, resource resrc>
 gmres_info<P>
-simple_gmres_euler(const P dt, matrix_entry mentry,
-                   global_kron_matrix<P> const &mat,
+simple_gmres_euler(const P dt, imex_flag imex,
+                   kron_operators<P> const &ops,
                    fk::vector<P, mem_type::owner, resrc> &x,
                    fk::vector<P, mem_type::owner, resrc> const &b,
                    int const restart, int const max_iter, P const tolerance)
 {
-  auto const &pc = mat.template get_diagonal_preconditioner<resrc>();
+#ifdef KRON_MODE_GLOBAL
+  auto const &pc = ops.template get_diagonal_preconditioner<resrc>();
+#endif
 
   return simple_gmres(
       [&](P const alpha, fk::vector<P, mem_type::view, resrc> const x_in,
           P const beta, fk::vector<P, mem_type::view, resrc> y) -> void {
-        tools::time_event performance("kronmult - implicit", mat.flops(mentry));
-        mat.template apply<resrc>(mentry, -dt * alpha, x_in.data(), beta, y.data());
+        tools::time_event performance("kronmult - implicit", ops.flops(imex));
+        ops.template apply<resrc>(imex, -dt * alpha, x_in.data(), beta, y.data());
         lib_dispatch::axpy<resrc>(y.size(), alpha, x_in.data(), 1, y.data(), 1);
       },
       fk::vector<P, mem_type::view, resrc>(x), b,
       [&](fk::vector<P, mem_type::view, resrc> &x_in) -> void {
+#ifdef KRON_MODE_GLOBAL
         tools::time_event performance("kronmult - preconditioner", pc.size());
         apply_diagonal_precond(pc, dt, x_in);
+#else
+        ignore(x_in); // no preconditioner for local kronmult
+#endif
       },
       restart, max_iter, tolerance);
 }
 template<typename P, resource resrc>
 gmres_info<P>
-bicgstab_euler(const P dt, matrix_entry mentry,
-               global_kron_matrix<P> const &mat,
+bicgstab_euler(const P dt, imex_flag imex,
+               kron_operators<P> const &ops,
                fk::vector<P, mem_type::owner, resrc> &x,
                fk::vector<P, mem_type::owner, resrc> const &b,
                int const max_iter, P const tolerance)
 {
-  auto const &pc = mat.template get_diagonal_preconditioner<resrc>();
+#ifdef KRON_MODE_GLOBAL
+  auto const &pc = ops.template get_diagonal_preconditioner<resrc>();
+#endif
 
   return bicgstab(
     [&](P const alpha, fk::vector<P, mem_type::view, resrc> const x_in,
           P const beta, fk::vector<P, mem_type::view, resrc> y) -> void {
-        tools::time_event performance("kronmult - implicit", mat.flops(mentry));
-        mat.template apply<resrc>(mentry, -dt * alpha, x_in.data(), beta, y.data());
+        tools::time_event performance("kronmult - implicit", ops.flops(imex));
+        ops.template apply<resrc>(imex, -dt * alpha, x_in.data(), beta, y.data());
         lib_dispatch::axpy<resrc>(y.size(), alpha, x_in.data(), 1, y.data(), 1);
       },
       fk::vector<P, mem_type::view, resrc>(x), b,
       [&](fk::vector<P, mem_type::view, resrc> &x_in) -> void {
+#ifdef KRON_MODE_GLOBAL
         tools::time_event performance("kronmult - preconditioner", pc.size());
         apply_diagonal_precond(pc, dt, x_in);
+#else
+        ignore(x_in); // no preconditioner for local kronmult
+#endif
       }, max_iter, tolerance);
 }
+
+
+#ifdef KRON_MODE_GLOBAL
+// template<typename P>
+// void apply_diagonal_precond(std::vector<P> const &pc, P dt,
+//                             fk::vector<P, mem_type::view, resource::host> &x)
+// {
+// #pragma omp parallel for
+//   for (size_t i = 0; i < pc.size(); i++)
+//     x[i] /= (1.0 - dt * pc[i]);
+// }
+// #ifdef ASGARD_USE_CUDA
+// template<typename P>
+// void apply_diagonal_precond(gpu::vector<P> const &pc, P dt,
+//                             fk::vector<P, mem_type::view, resource::device> &x)
+// {
+//   kronmult::gpu_precon_jacobi(pc.size(), dt, pc.data(), x.data());
+// }
+// #endif
+
+
 
 #ifdef KRON_MODE_GLOBAL_BLOCK
 template<typename P, resource resrc>
@@ -211,40 +245,40 @@ bicgstab_euler(const P dt, matrix_entry mentry,
 #endif
 
 #else
-template<typename P, resource resrc>
-gmres_info<P>
-simple_gmres_euler(const P dt, kronmult_matrix<P> const &mat,
-                   fk::vector<P, mem_type::owner, resrc> &x,
-                   fk::vector<P, mem_type::owner, resrc> const &b,
-                   int const restart, int const max_iter, P const tolerance)
-{
-  return simple_gmres(
-      [&](P const alpha, fk::vector<P, mem_type::view, resrc> const x_in,
-          P const beta, fk::vector<P, mem_type::view, resrc> y) -> void {
-        tools::time_event performance("kronmult - implicit", mat.flops());
-        mat.template apply<resrc>(-dt * alpha, x_in.data(), beta, y.data());
-        lib_dispatch::axpy<resrc>(y.size(), alpha, x_in.data(), 1, y.data(), 1);
-      },
-      fk::vector<P, mem_type::view, resrc>(x), b, no_op_preconditioner<P>(),
-      restart, max_iter, tolerance);
-}
-template<typename P, resource resrc>
-gmres_info<P>
-bicgstab_euler(const P dt, kronmult_matrix<P> const &mat,
-               fk::vector<P, mem_type::owner, resrc> &x,
-               fk::vector<P, mem_type::owner, resrc> const &b,
-               int const max_iter, P const tolerance)
-{
-  return bicgstab(
-      [&](P const alpha, fk::vector<P, mem_type::view, resrc> const x_in,
-          P const beta, fk::vector<P, mem_type::view, resrc> y) -> void {
-        tools::time_event performance("kronmult - implicit", mat.flops());
-        mat.template apply<resrc>(-dt * alpha, x_in.data(), beta, y.data());
-        lib_dispatch::axpy<resrc>(y.size(), alpha, x_in.data(), 1, y.data(), 1);
-      },
-      fk::vector<P, mem_type::view, resrc>(x), b, no_op_preconditioner<P>(),
-      max_iter, tolerance);
-}
+// template<typename P, resource resrc>
+// gmres_info<P>
+// simple_gmres_euler(const P dt, kronmult_matrix<P> const &mat,
+//                    fk::vector<P, mem_type::owner, resrc> &x,
+//                    fk::vector<P, mem_type::owner, resrc> const &b,
+//                    int const restart, int const max_iter, P const tolerance)
+// {
+//   return simple_gmres(
+//       [&](P const alpha, fk::vector<P, mem_type::view, resrc> const x_in,
+//           P const beta, fk::vector<P, mem_type::view, resrc> y) -> void {
+//         tools::time_event performance("kronmult - implicit", mat.flops());
+//         mat.template apply<resrc>(-dt * alpha, x_in.data(), beta, y.data());
+//         lib_dispatch::axpy<resrc>(y.size(), alpha, x_in.data(), 1, y.data(), 1);
+//       },
+//       fk::vector<P, mem_type::view, resrc>(x), b, no_op_preconditioner<P>(),
+//       restart, max_iter, tolerance);
+// }
+// template<typename P, resource resrc>
+// gmres_info<P>
+// bicgstab_euler(const P dt, kronmult_matrix<P> const &mat,
+//                fk::vector<P, mem_type::owner, resrc> &x,
+//                fk::vector<P, mem_type::owner, resrc> const &b,
+//                int const max_iter, P const tolerance)
+// {
+//   return bicgstab(
+//       [&](P const alpha, fk::vector<P, mem_type::view, resrc> const x_in,
+//           P const beta, fk::vector<P, mem_type::view, resrc> y) -> void {
+//         tools::time_event performance("kronmult - implicit", mat.flops());
+//         mat.template apply<resrc>(-dt * alpha, x_in.data(), beta, y.data());
+//         lib_dispatch::axpy<resrc>(y.size(), alpha, x_in.data(), 1, y.data(), 1);
+//       },
+//       fk::vector<P, mem_type::view, resrc>(x), b, no_op_preconditioner<P>(),
+//       max_iter, tolerance);
+// }
 #endif
 
 /*! Generates a default number inner iterations when no use input is given
@@ -670,43 +704,44 @@ simple_gmres(fk::matrix<double> const &A, fk::vector<double> &x,
              fk::vector<double> const &b, fk::matrix<double> const &M,
              int const restart, int const max_iter, double const tolerance);
 
-#ifdef KRON_MODE_GLOBAL
 template gmres_info<double>
-simple_gmres_euler(const double dt, matrix_entry mentry,
-                   global_kron_matrix<double> const &mat,
+simple_gmres_euler(const double dt, imex_flag imex,
+                   kron_operators<double> const &ops,
                    fk::vector<double, mem_type::owner, resource::host> &x,
                    fk::vector<double, mem_type::owner, resource::host> const &b,
                    int const restart, int const max_iter, double const tolerance);
 
-#ifdef KRON_MODE_GLOBAL_BLOCK
-template gmres_info<double>
-simple_gmres_euler(const double dt, matrix_entry mentry,
-                   block_global_kron_matrix<double> const &mat,
-                   fk::vector<double, mem_type::owner, resource::host> &x,
-                   fk::vector<double, mem_type::owner, resource::host> const &b,
-                   int const restart, int const max_iter, double const tolerance);
-#endif
-#ifdef ASGARD_USE_CUDA
-template gmres_info<double>
-simple_gmres_euler(const double dt, matrix_entry mentry,
-                   global_kron_matrix<double> const &mat,
-                   fk::vector<double, mem_type::owner, resource::device> &x,
-                   fk::vector<double, mem_type::owner, resource::device> const &b,
-                   int const restart, int const max_iter, double const tolerance);
-#endif
+#ifdef KRON_MODE_GLOBAL
+
+// #ifdef KRON_MODE_GLOBAL_BLOCK
+// template gmres_info<double>
+// simple_gmres_euler(const double dt, matrix_entry mentry,
+//                    block_global_kron_matrix<double> const &mat,
+//                    fk::vector<double, mem_type::owner, resource::host> &x,
+//                    fk::vector<double, mem_type::owner, resource::host> const &b,
+//                    int const restart, int const max_iter, double const tolerance);
+// #endif
+// #ifdef ASGARD_USE_CUDA
+// template gmres_info<double>
+// simple_gmres_euler(const double dt, matrix_entry mentry,
+//                    global_kron_matrix<double> const &mat,
+//                    fk::vector<double, mem_type::owner, resource::device> &x,
+//                    fk::vector<double, mem_type::owner, resource::device> const &b,
+//                    int const restart, int const max_iter, double const tolerance);
+// #endif
 #else
-template gmres_info<double>
-simple_gmres_euler(const double dt, kronmult_matrix<double> const &mat,
-                   fk::vector<double> &x, fk::vector<double> const &b,
-                   int const restart, int const max_iter,
-                   double const tolerance);
-#ifdef ASGARD_USE_CUDA
-template gmres_info<double> simple_gmres_euler(
-    const double dt, kronmult_matrix<double> const &mat,
-    fk::vector<double, mem_type::owner, resource::device> &x,
-    fk::vector<double, mem_type::owner, resource::device> const &b,
-    int const restart, int const max_iter, double const tolerance);
-#endif
+// template gmres_info<double>
+// simple_gmres_euler(const double dt, kronmult_matrix<double> const &mat,
+//                    fk::vector<double> &x, fk::vector<double> const &b,
+//                    int const restart, int const max_iter,
+//                    double const tolerance);
+// #ifdef ASGARD_USE_CUDA
+// template gmres_info<double> simple_gmres_euler(
+//     const double dt, kronmult_matrix<double> const &mat,
+//     fk::vector<double, mem_type::owner, resource::device> &x,
+//     fk::vector<double, mem_type::owner, resource::device> const &b,
+//     int const restart, int const max_iter, double const tolerance);
+// #endif
 #endif
 
 template int default_gmres_restarts<double>(int num_cols);
@@ -723,47 +758,51 @@ poisson_solver(fk::vector<double> const &source, fk::vector<double> const &A_D,
                double const phi_max, poisson_bc const bc);
 
 template gmres_info<double>
+bicgstab_euler(const double dt, imex_flag imex,
+               kron_operators<double> const &ops,
+               fk::vector<double, mem_type::owner, resource::host> &x,
+               fk::vector<double, mem_type::owner, resource::host> const &b,
+               int const max_iter, double const tolerance);
+
+template gmres_info<double>
 bicgstab(fk::matrix<double> const &A, fk::vector<double> &x,
          fk::vector<double> const &b, fk::matrix<double> const &M,
          int const max_iter, double const tolerance);
 
 #ifdef KRON_MODE_GLOBAL
-template gmres_info<double>
-bicgstab_euler(const double dt, matrix_entry mentry,
-               global_kron_matrix<double> const &mat,
-               fk::vector<double, mem_type::owner, resource::host> &x,
-               fk::vector<double, mem_type::owner, resource::host> const &b,
-               int const max_iter, double const tolerance);
+
 #ifdef KRON_MODE_GLOBAL_BLOCK
-template gmres_info<double>
-bicgstab_euler(const double dt, matrix_entry mentry,
-               block_global_kron_matrix<double> const &mat,
-               fk::vector<double, mem_type::owner, resource::host> &x,
-               fk::vector<double, mem_type::owner, resource::host> const &b,
-               int const max_iter, double const tolerance);
-#endif
-#ifdef ASGARD_USE_CUDA
-template gmres_info<double>
-bicgstab_euler(const double dt, matrix_entry mentry,
-               global_kron_matrix<double> const &mat,
-               fk::vector<double, mem_type::owner, resource::device> &x,
-               fk::vector<double, mem_type::owner, resource::device> const &b,
-               int const max_iter, double const tolerance);
-#endif
+// template gmres_info<double>
+// bicgstab_euler(const double dt, matrix_entry mentry,
+//                block_global_kron_matrix<double> const &mat,
+//                fk::vector<double, mem_type::owner, resource::host> &x,
+//                fk::vector<double, mem_type::owner, resource::host> const &b,
+//                int const max_iter, double const tolerance);
+// #endif
+// #ifdef ASGARD_USE_CUDA
+// template gmres_info<double>
+// bicgstab_euler(const double dt, matrix_entry mentry,
+//                global_kron_matrix<double> const &mat,
+//                fk::vector<double, mem_type::owner, resource::device> &x,
+//                fk::vector<double, mem_type::owner, resource::device> const &b,
+//                int const max_iter, double const tolerance);
+// #endif
 #else
-template gmres_info<double>
-bicgstab_euler(const double dt, kronmult_matrix<double> const &mat,
-               fk::vector<double> &x, fk::vector<double> const &b,
-               int const max_iter,
-               double const tolerance);
-#ifdef ASGARD_USE_CUDA
-template gmres_info<double> bicgstab_euler(
-    const double dt, kronmult_matrix<double> const &mat,
-    fk::vector<double, mem_type::owner, resource::device> &x,
-    fk::vector<double, mem_type::owner, resource::device> const &b,
-    int const max_iter, double const tolerance);
-#endif
-#endif
+// template gmres_info<double>
+// bicgstab_euler(const double dt, kronmult_matrix<double> const &mat,
+//                fk::vector<double> &x, fk::vector<double> const &b,
+//                int const max_iter,
+//                double const tolerance);
+// #ifdef ASGARD_USE_CUDA
+// template gmres_info<double> bicgstab_euler(
+//     const double dt, kronmult_matrix<double> const &mat,
+//     fk::vector<double, mem_type::owner, resource::device> &x,
+//     fk::vector<double, mem_type::owner, resource::device> const &b,
+//     int const max_iter, double const tolerance);
+// #endif
+#endif // KRON_MODE_GLOBAL_BLOCK
+#endif // KRON_MODE_GLOBAL
+
 #endif
 
 #ifdef ASGARD_ENABLE_FLOAT
@@ -773,44 +812,59 @@ simple_gmres(fk::matrix<float> const &A, fk::vector<float> &x,
              fk::vector<float> const &b, fk::matrix<float> const &M,
              int const restart, int const max_iter, float const tolerance);
 
+template gmres_info<float>
+simple_gmres_euler(const float dt, imex_flag imex,
+                   kron_operators<float> const &ops,
+                   fk::vector<float, mem_type::owner, resource::host> &x,
+                   fk::vector<float, mem_type::owner, resource::host> const &b,
+                   int const restart, int const max_iter, float const tolerance);
+
+template gmres_info<float>
+bicgstab_euler(const float dt, imex_flag imex,
+               kron_operators<float> const &ops,
+               fk::vector<float, mem_type::owner, resource::host> &x,
+               fk::vector<float, mem_type::owner, resource::host> const &b,
+               int const max_iter, float const tolerance);
+
+
 #ifdef KRON_MODE_GLOBAL
-template gmres_info<float>
-simple_gmres_euler(const float dt, matrix_entry mentry,
-                   global_kron_matrix<float> const &mat,
-                   fk::vector<float, mem_type::owner, resource::host> &x,
-                   fk::vector<float, mem_type::owner, resource::host> const &b,
-                   int const restart, int const max_iter, float const tolerance);
+// template gmres_info<float>
+// simple_gmres_euler(const float dt, matrix_entry mentry,
+//                    global_kron_matrix<float> const &mat,
+//                    fk::vector<float, mem_type::owner, resource::host> &x,
+//                    fk::vector<float, mem_type::owner, resource::host> const &b,
+//                    int const restart, int const max_iter, float const tolerance);
 
-#ifdef KRON_MODE_GLOBAL_BLOCK
-template gmres_info<float>
-simple_gmres_euler(const float dt, matrix_entry mentry,
-                   block_global_kron_matrix<float> const &mat,
-                   fk::vector<float, mem_type::owner, resource::host> &x,
-                   fk::vector<float, mem_type::owner, resource::host> const &b,
-                   int const restart, int const max_iter, float const tolerance);
-#endif
+// #ifdef KRON_MODE_GLOBAL_BLOCK
+// template gmres_info<float>
+// simple_gmres_euler(const float dt, matrix_entry mentry,
+//                    block_global_kron_matrix<float> const &mat,
+//                    fk::vector<float, mem_type::owner, resource::host> &x,
+//                    fk::vector<float, mem_type::owner, resource::host> const &b,
+//                    int const restart, int const max_iter, float const tolerance);
+// #endif
 
-#ifdef ASGARD_USE_CUDA
-template gmres_info<float>
-simple_gmres_euler(const float dt, matrix_entry mentry,
-                   global_kron_matrix<float> const &mat,
-                   fk::vector<float, mem_type::owner, resource::device> &x,
-                   fk::vector<float, mem_type::owner, resource::device> const &b,
-                   int const restart, int const max_iter, float const tolerance);
-#endif
+// #ifdef ASGARD_USE_CUDA
+// template gmres_info<float>
+// simple_gmres_euler(const float dt, matrix_entry mentry,
+//                    global_kron_matrix<float> const &mat,
+//                    fk::vector<float, mem_type::owner, resource::device> &x,
+//                    fk::vector<float, mem_type::owner, resource::device> const &b,
+//                    int const restart, int const max_iter, float const tolerance);
+// #endif
 #else
-template gmres_info<float>
-simple_gmres_euler(const float dt, kronmult_matrix<float> const &mat,
-                   fk::vector<float> &x, fk::vector<float> const &b,
-                   int const restart, int const max_iter,
-                   float const tolerance);
-#ifdef ASGARD_USE_CUDA
-template gmres_info<float> simple_gmres_euler(
-    const float dt, kronmult_matrix<float> const &mat,
-    fk::vector<float, mem_type::owner, resource::device> &x,
-    fk::vector<float, mem_type::owner, resource::device> const &b,
-    int const restart, int const max_iter, float const tolerance);
-#endif
+// template gmres_info<float>
+// simple_gmres_euler(const float dt, kronmult_matrix<float> const &mat,
+//                    fk::vector<float> &x, fk::vector<float> const &b,
+//                    int const restart, int const max_iter,
+//                    float const tolerance);
+// #ifdef ASGARD_USE_CUDA
+// template gmres_info<float> simple_gmres_euler(
+//     const float dt, kronmult_matrix<float> const &mat,
+//     fk::vector<float, mem_type::owner, resource::device> &x,
+//     fk::vector<float, mem_type::owner, resource::device> const &b,
+//     int const restart, int const max_iter, float const tolerance);
+// #endif
 #endif
 
 template gmres_info<float>
@@ -819,41 +873,41 @@ bicgstab(fk::matrix<float> const &A, fk::vector<float> &x,
          int const max_iter, float const tolerance);
 
 #ifdef KRON_MODE_GLOBAL
-template gmres_info<float>
-bicgstab_euler(const float dt, matrix_entry mentry,
-               global_kron_matrix<float> const &mat,
-               fk::vector<float, mem_type::owner, resource::host> &x,
-               fk::vector<float, mem_type::owner, resource::host> const &b,
-               int const max_iter, float const tolerance);
-#ifdef KRON_MODE_GLOBAL_BLOCK
-template gmres_info<float>
-bicgstab_euler(const float dt, matrix_entry mentry,
-               block_global_kron_matrix<float> const &mat,
-               fk::vector<float, mem_type::owner, resource::host> &x,
-               fk::vector<float, mem_type::owner, resource::host> const &b,
-               int const max_iter, float const tolerance);
-#endif
-#ifdef ASGARD_USE_CUDA
-template gmres_info<float>
-bicgstab_euler(const float dt, matrix_entry mentry,
-               global_kron_matrix<float> const &mat,
-               fk::vector<float, mem_type::owner, resource::device> &x,
-               fk::vector<float, mem_type::owner, resource::device> const &b,
-               int const max_iter, float const tolerance);
-#endif
+// template gmres_info<float>
+// bicgstab_euler(const float dt, matrix_entry mentry,
+//                global_kron_matrix<float> const &mat,
+//                fk::vector<float, mem_type::owner, resource::host> &x,
+//                fk::vector<float, mem_type::owner, resource::host> const &b,
+//                int const max_iter, float const tolerance);
+// #ifdef KRON_MODE_GLOBAL_BLOCK
+// template gmres_info<float>
+// bicgstab_euler(const float dt, matrix_entry mentry,
+//                block_global_kron_matrix<float> const &mat,
+//                fk::vector<float, mem_type::owner, resource::host> &x,
+//                fk::vector<float, mem_type::owner, resource::host> const &b,
+//                int const max_iter, float const tolerance);
+// #endif
+// #ifdef ASGARD_USE_CUDA
+// template gmres_info<float>
+// bicgstab_euler(const float dt, matrix_entry mentry,
+//                global_kron_matrix<float> const &mat,
+//                fk::vector<float, mem_type::owner, resource::device> &x,
+//                fk::vector<float, mem_type::owner, resource::device> const &b,
+//                int const max_iter, float const tolerance);
+// #endif
 #else
-template gmres_info<float>
-bicgstab_euler(const float dt, kronmult_matrix<float> const &mat,
-               fk::vector<float> &x, fk::vector<float> const &b,
-               int const max_iter,
-               float const tolerance);
-#ifdef ASGARD_USE_CUDA
-template gmres_info<float> bicgstab_euler(
-    const float dt, kronmult_matrix<float> const &mat,
-    fk::vector<float, mem_type::owner, resource::device> &x,
-    fk::vector<float, mem_type::owner, resource::device> const &b,
-    int const max_iter, float const tolerance);
-#endif
+// template gmres_info<float>
+// bicgstab_euler(const float dt, kronmult_matrix<float> const &mat,
+//                fk::vector<float> &x, fk::vector<float> const &b,
+//                int const max_iter,
+//                float const tolerance);
+// #ifdef ASGARD_USE_CUDA
+// template gmres_info<float> bicgstab_euler(
+//     const float dt, kronmult_matrix<float> const &mat,
+//     fk::vector<float, mem_type::owner, resource::device> &x,
+//     fk::vector<float, mem_type::owner, resource::device> const &b,
+//     int const max_iter, float const tolerance);
+// #endif
 #endif
 
 template int default_gmres_restarts<float>(int num_cols);

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -96,6 +96,7 @@ bicgstab(fk::matrix<P> const &A, fk::vector<P> &x, fk::vector<P> const &b,
 }
 
 #ifdef KRON_MODE_GLOBAL
+// preconditiner is only available in global mode
 template<typename P>
 void apply_diagonal_precond(std::vector<P> const &pc, P dt,
                             fk::vector<P, mem_type::view, resource::host> &x)
@@ -173,113 +174,6 @@ bicgstab_euler(const P dt, imex_flag imex,
 #endif
       }, max_iter, tolerance);
 }
-
-
-#ifdef KRON_MODE_GLOBAL
-// template<typename P>
-// void apply_diagonal_precond(std::vector<P> const &pc, P dt,
-//                             fk::vector<P, mem_type::view, resource::host> &x)
-// {
-// #pragma omp parallel for
-//   for (size_t i = 0; i < pc.size(); i++)
-//     x[i] /= (1.0 - dt * pc[i]);
-// }
-// #ifdef ASGARD_USE_CUDA
-// template<typename P>
-// void apply_diagonal_precond(gpu::vector<P> const &pc, P dt,
-//                             fk::vector<P, mem_type::view, resource::device> &x)
-// {
-//   kronmult::gpu_precon_jacobi(pc.size(), dt, pc.data(), x.data());
-// }
-// #endif
-
-
-
-// #ifdef KRON_MODE_GLOBAL_BLOCK
-// template<typename P, resource resrc>
-// gmres_info<P>
-// simple_gmres_euler(const P dt, matrix_entry mentry,
-//                    block_global_kron_matrix<P> const &mat,
-//                    fk::vector<P, mem_type::owner, resrc> &x,
-//                    fk::vector<P, mem_type::owner, resrc> const &b,
-//                    int const restart, int const max_iter, P const tolerance)
-// {
-//   auto const &pc = mat.template get_diagonal_preconditioner<resrc>();
-//
-//   return simple_gmres(
-//       [&](P const alpha, fk::vector<P, mem_type::view, resrc> const x_in,
-//           P const beta, fk::vector<P, mem_type::view, resrc> y) -> void {
-//         tools::time_event performance("kronmult - implicit", mat.flops(mentry));
-//         mat.template apply<resrc>(mentry, -dt * alpha, x_in.data(), beta, y.data());
-//         lib_dispatch::axpy<resrc>(y.size(), alpha, x_in.data(), 1, y.data(), 1);
-//       },
-//       fk::vector<P, mem_type::view, resrc>(x), b,
-//       [&](fk::vector<P, mem_type::view, resrc> &x_in) -> void {
-//         tools::time_event performance("kronmult - preconditioner", pc.size());
-//         apply_diagonal_precond(pc, dt, x_in);
-//       }, restart, max_iter, tolerance);
-// }
-// template<typename P, resource resrc>
-// gmres_info<P>
-// bicgstab_euler(const P dt, matrix_entry mentry,
-//                block_global_kron_matrix<P> const &mat,
-//                fk::vector<P, mem_type::owner, resrc> &x,
-//                fk::vector<P, mem_type::owner, resrc> const &b,
-//                int const max_iter, P const tolerance)
-// {
-//   auto const &pc = mat.template get_diagonal_preconditioner<resrc>();
-//
-//   return bicgstab(
-//     [&](P const alpha, fk::vector<P, mem_type::view, resrc> const x_in,
-//           P const beta, fk::vector<P, mem_type::view, resrc> y) -> void {
-//         tools::time_event performance("kronmult - implicit", mat.flops(mentry));
-//         mat.template apply<resrc>(mentry, -dt * alpha, x_in.data(), beta, y.data());
-//         lib_dispatch::axpy<resrc>(y.size(), alpha, x_in.data(), 1, y.data(), 1);
-//       },
-//       fk::vector<P, mem_type::view, resrc>(x), b,
-//       [&](fk::vector<P, mem_type::view, resrc> &x_in) -> void {
-//         tools::time_event performance("kronmult - preconditioner", pc.size());
-//         apply_diagonal_precond(pc, dt, x_in);
-//       }, max_iter, tolerance);
-// }
-// #endif
-
-#else
-// template<typename P, resource resrc>
-// gmres_info<P>
-// simple_gmres_euler(const P dt, kronmult_matrix<P> const &mat,
-//                    fk::vector<P, mem_type::owner, resrc> &x,
-//                    fk::vector<P, mem_type::owner, resrc> const &b,
-//                    int const restart, int const max_iter, P const tolerance)
-// {
-//   return simple_gmres(
-//       [&](P const alpha, fk::vector<P, mem_type::view, resrc> const x_in,
-//           P const beta, fk::vector<P, mem_type::view, resrc> y) -> void {
-//         tools::time_event performance("kronmult - implicit", mat.flops());
-//         mat.template apply<resrc>(-dt * alpha, x_in.data(), beta, y.data());
-//         lib_dispatch::axpy<resrc>(y.size(), alpha, x_in.data(), 1, y.data(), 1);
-//       },
-//       fk::vector<P, mem_type::view, resrc>(x), b, no_op_preconditioner<P>(),
-//       restart, max_iter, tolerance);
-// }
-// template<typename P, resource resrc>
-// gmres_info<P>
-// bicgstab_euler(const P dt, kronmult_matrix<P> const &mat,
-//                fk::vector<P, mem_type::owner, resrc> &x,
-//                fk::vector<P, mem_type::owner, resrc> const &b,
-//                int const max_iter, P const tolerance)
-// {
-//   return bicgstab(
-//       [&](P const alpha, fk::vector<P, mem_type::view, resrc> const x_in,
-//           P const beta, fk::vector<P, mem_type::view, resrc> y) -> void {
-//         tools::time_event performance("kronmult - implicit", mat.flops());
-//         mat.template apply<resrc>(-dt * alpha, x_in.data(), beta, y.data());
-//         lib_dispatch::axpy<resrc>(y.size(), alpha, x_in.data(), 1, y.data(), 1);
-//       },
-//       fk::vector<P, mem_type::view, resrc>(x), b, no_op_preconditioner<P>(),
-//       max_iter, tolerance);
-// }
-#endif
 
 /*! Generates a default number inner iterations when no use input is given
  * \param num_cols Number of columns in the A matrix.
@@ -703,6 +597,10 @@ template gmres_info<double>
 simple_gmres(fk::matrix<double> const &A, fk::vector<double> &x,
              fk::vector<double> const &b, fk::matrix<double> const &M,
              int const restart, int const max_iter, double const tolerance);
+template gmres_info<double>
+bicgstab(fk::matrix<double> const &A, fk::vector<double> &x,
+         fk::vector<double> const &b, fk::matrix<double> const &M,
+         int const max_iter, double const tolerance);
 
 template gmres_info<double>
 simple_gmres_euler(const double dt, imex_flag imex,
@@ -711,6 +609,13 @@ simple_gmres_euler(const double dt, imex_flag imex,
                    fk::vector<double, mem_type::owner, resource::host> const &b,
                    int const restart, int const max_iter, double const tolerance);
 
+template gmres_info<double>
+bicgstab_euler(const double dt, imex_flag imex,
+               kron_operators<double> const &ops,
+               fk::vector<double, mem_type::owner, resource::host> &x,
+               fk::vector<double, mem_type::owner, resource::host> const &b,
+               int const max_iter, double const tolerance);
+
 #ifdef ASGARD_USE_CUDA
 template gmres_info<double>
 simple_gmres_euler(const double dt, imex_flag imex,
@@ -718,39 +623,12 @@ simple_gmres_euler(const double dt, imex_flag imex,
                    fk::vector<double, mem_type::owner, resource::device> &x,
                    fk::vector<double, mem_type::owner, resource::device> const &b,
                    int const restart, int const max_iter, double const tolerance);
-#endif
-
-#ifdef KRON_MODE_GLOBAL
-
-// #ifdef KRON_MODE_GLOBAL_BLOCK
-// template gmres_info<double>
-// simple_gmres_euler(const double dt, matrix_entry mentry,
-//                    block_global_kron_matrix<double> const &mat,
-//                    fk::vector<double, mem_type::owner, resource::host> &x,
-//                    fk::vector<double, mem_type::owner, resource::host> const &b,
-//                    int const restart, int const max_iter, double const tolerance);
-// #endif
-// #ifdef ASGARD_USE_CUDA
-// template gmres_info<double>
-// simple_gmres_euler(const double dt, matrix_entry mentry,
-//                    global_kron_matrix<double> const &mat,
-//                    fk::vector<double, mem_type::owner, resource::device> &x,
-//                    fk::vector<double, mem_type::owner, resource::device> const &b,
-//                    int const restart, int const max_iter, double const tolerance);
-// #endif
-#else
-// template gmres_info<double>
-// simple_gmres_euler(const double dt, kronmult_matrix<double> const &mat,
-//                    fk::vector<double> &x, fk::vector<double> const &b,
-//                    int const restart, int const max_iter,
-//                    double const tolerance);
-// #ifdef ASGARD_USE_CUDA
-// template gmres_info<double> simple_gmres_euler(
-//     const double dt, kronmult_matrix<double> const &mat,
-//     fk::vector<double, mem_type::owner, resource::device> &x,
-//     fk::vector<double, mem_type::owner, resource::device> const &b,
-//     int const restart, int const max_iter, double const tolerance);
-// #endif
+template gmres_info<double>
+bicgstab_euler(const double dt, imex_flag imex,
+               kron_operators<double> const &ops,
+               fk::vector<double, mem_type::owner, resource::device> &x,
+               fk::vector<double, mem_type::owner, resource::device> const &b,
+               int const max_iter, double const tolerance);
 #endif
 
 template int default_gmres_restarts<double>(int num_cols);
@@ -765,70 +643,18 @@ poisson_solver(fk::vector<double> const &source, fk::vector<double> const &A_D,
                fk::vector<double> &E, int const degree, int const N_elements,
                double const x_min, double const x_max, double const phi_min,
                double const phi_max, poisson_bc const bc);
-
-template gmres_info<double>
-bicgstab_euler(const double dt, imex_flag imex,
-               kron_operators<double> const &ops,
-               fk::vector<double, mem_type::owner, resource::host> &x,
-               fk::vector<double, mem_type::owner, resource::host> const &b,
-               int const max_iter, double const tolerance);
-
-template gmres_info<double>
-bicgstab(fk::matrix<double> const &A, fk::vector<double> &x,
-         fk::vector<double> const &b, fk::matrix<double> const &M,
-         int const max_iter, double const tolerance);
-
-#ifdef ASGARD_USE_CUDA
-template gmres_info<double>
-bicgstab_euler(const double dt, imex_flag imex,
-               kron_operators<double> const &ops,
-               fk::vector<double, mem_type::owner, resource::device> &x,
-               fk::vector<double, mem_type::owner, resource::device> const &b,
-               int const max_iter, double const tolerance);
-#endif
-
-#ifdef KRON_MODE_GLOBAL
-
-#ifdef KRON_MODE_GLOBAL_BLOCK
-// template gmres_info<double>
-// bicgstab_euler(const double dt, matrix_entry mentry,
-//                block_global_kron_matrix<double> const &mat,
-//                fk::vector<double, mem_type::owner, resource::host> &x,
-//                fk::vector<double, mem_type::owner, resource::host> const &b,
-//                int const max_iter, double const tolerance);
-// #endif
-// #ifdef ASGARD_USE_CUDA
-// template gmres_info<double>
-// bicgstab_euler(const double dt, matrix_entry mentry,
-//                global_kron_matrix<double> const &mat,
-//                fk::vector<double, mem_type::owner, resource::device> &x,
-//                fk::vector<double, mem_type::owner, resource::device> const &b,
-//                int const max_iter, double const tolerance);
-// #endif
-#else
-// template gmres_info<double>
-// bicgstab_euler(const double dt, kronmult_matrix<double> const &mat,
-//                fk::vector<double> &x, fk::vector<double> const &b,
-//                int const max_iter,
-//                double const tolerance);
-// #ifdef ASGARD_USE_CUDA
-// template gmres_info<double> bicgstab_euler(
-//     const double dt, kronmult_matrix<double> const &mat,
-//     fk::vector<double, mem_type::owner, resource::device> &x,
-//     fk::vector<double, mem_type::owner, resource::device> const &b,
-//     int const max_iter, double const tolerance);
-// #endif
-#endif // KRON_MODE_GLOBAL_BLOCK
-#endif // KRON_MODE_GLOBAL
-
-#endif
+#endif // ASGARD_ENABLE_DOUBLE
 
 #ifdef ASGARD_ENABLE_FLOAT
-
 template gmres_info<float>
 simple_gmres(fk::matrix<float> const &A, fk::vector<float> &x,
              fk::vector<float> const &b, fk::matrix<float> const &M,
              int const restart, int const max_iter, float const tolerance);
+
+template gmres_info<float>
+bicgstab(fk::matrix<float> const &A, fk::vector<float> &x,
+         fk::vector<float> const &b, fk::matrix<float> const &M,
+         int const max_iter, float const tolerance);
 
 template gmres_info<float>
 simple_gmres_euler(const float dt, imex_flag imex,
@@ -860,89 +686,6 @@ bicgstab_euler(const float dt, imex_flag imex,
                int const max_iter, float const tolerance);
 #endif
 
-#ifdef KRON_MODE_GLOBAL
-// template gmres_info<float>
-// simple_gmres_euler(const float dt, matrix_entry mentry,
-//                    global_kron_matrix<float> const &mat,
-//                    fk::vector<float, mem_type::owner, resource::host> &x,
-//                    fk::vector<float, mem_type::owner, resource::host> const &b,
-//                    int const restart, int const max_iter, float const tolerance);
-
-// #ifdef KRON_MODE_GLOBAL_BLOCK
-// template gmres_info<float>
-// simple_gmres_euler(const float dt, matrix_entry mentry,
-//                    block_global_kron_matrix<float> const &mat,
-//                    fk::vector<float, mem_type::owner, resource::host> &x,
-//                    fk::vector<float, mem_type::owner, resource::host> const &b,
-//                    int const restart, int const max_iter, float const tolerance);
-// #endif
-
-// #ifdef ASGARD_USE_CUDA
-// template gmres_info<float>
-// simple_gmres_euler(const float dt, matrix_entry mentry,
-//                    global_kron_matrix<float> const &mat,
-//                    fk::vector<float, mem_type::owner, resource::device> &x,
-//                    fk::vector<float, mem_type::owner, resource::device> const &b,
-//                    int const restart, int const max_iter, float const tolerance);
-// #endif
-#else
-// template gmres_info<float>
-// simple_gmres_euler(const float dt, kronmult_matrix<float> const &mat,
-//                    fk::vector<float> &x, fk::vector<float> const &b,
-//                    int const restart, int const max_iter,
-//                    float const tolerance);
-// #ifdef ASGARD_USE_CUDA
-// template gmres_info<float> simple_gmres_euler(
-//     const float dt, kronmult_matrix<float> const &mat,
-//     fk::vector<float, mem_type::owner, resource::device> &x,
-//     fk::vector<float, mem_type::owner, resource::device> const &b,
-//     int const restart, int const max_iter, float const tolerance);
-// #endif
-#endif
-
-template gmres_info<float>
-bicgstab(fk::matrix<float> const &A, fk::vector<float> &x,
-         fk::vector<float> const &b, fk::matrix<float> const &M,
-         int const max_iter, float const tolerance);
-
-#ifdef KRON_MODE_GLOBAL
-// template gmres_info<float>
-// bicgstab_euler(const float dt, matrix_entry mentry,
-//                global_kron_matrix<float> const &mat,
-//                fk::vector<float, mem_type::owner, resource::host> &x,
-//                fk::vector<float, mem_type::owner, resource::host> const &b,
-//                int const max_iter, float const tolerance);
-// #ifdef KRON_MODE_GLOBAL_BLOCK
-// template gmres_info<float>
-// bicgstab_euler(const float dt, matrix_entry mentry,
-//                block_global_kron_matrix<float> const &mat,
-//                fk::vector<float, mem_type::owner, resource::host> &x,
-//                fk::vector<float, mem_type::owner, resource::host> const &b,
-//                int const max_iter, float const tolerance);
-// #endif
-// #ifdef ASGARD_USE_CUDA
-// template gmres_info<float>
-// bicgstab_euler(const float dt, matrix_entry mentry,
-//                global_kron_matrix<float> const &mat,
-//                fk::vector<float, mem_type::owner, resource::device> &x,
-//                fk::vector<float, mem_type::owner, resource::device> const &b,
-//                int const max_iter, float const tolerance);
-// #endif
-#else
-// template gmres_info<float>
-// bicgstab_euler(const float dt, kronmult_matrix<float> const &mat,
-//                fk::vector<float> &x, fk::vector<float> const &b,
-//                int const max_iter,
-//                float const tolerance);
-// #ifdef ASGARD_USE_CUDA
-// template gmres_info<float> bicgstab_euler(
-//     const float dt, kronmult_matrix<float> const &mat,
-//     fk::vector<float, mem_type::owner, resource::device> &x,
-//     fk::vector<float, mem_type::owner, resource::device> const &b,
-//     int const max_iter, float const tolerance);
-// #endif
-#endif
-
 template int default_gmres_restarts<float>(int num_cols);
 
 template void setup_poisson(const int N_elements, float const x_min,
@@ -955,7 +698,6 @@ poisson_solver(fk::vector<float> const &source, fk::vector<float> const &A_D,
                fk::vector<float> &E, int const degree, int const N_elements,
                float const x_min, float const x_max, float const phi_min,
                float const phi_max, poisson_bc const bc);
-
-#endif
+#endif // ASGARD_ENABLE_FLOAT
 
 } // namespace asgard::solver

--- a/src/solver.hpp
+++ b/src/solver.hpp
@@ -27,12 +27,11 @@ bicgstab(fk::matrix<P> const &A, fk::vector<P> &x, fk::vector<P> const &b,
          fk::matrix<P> const &M, int const max_iter,
          P const tolerance);
 
-#ifdef KRON_MODE_GLOBAL
 // solves ( I - dt * mat ) * x = b
 template<typename P, resource resrc>
 gmres_info<P>
-simple_gmres_euler(const P dt, matrix_entry mentry,
-                   global_kron_matrix<P> const &mat,
+simple_gmres_euler(const P dt, imex_flag imex,
+                   kron_operators<P> const &ops,
                    fk::vector<P, mem_type::owner, resrc> &x,
                    fk::vector<P, mem_type::owner, resrc> const &b,
                    int const restart, int const max_iter, P const tolerance);
@@ -40,11 +39,16 @@ simple_gmres_euler(const P dt, matrix_entry mentry,
 // solves ( I - dt * mat ) * x = b
 template<typename P, resource resrc>
 gmres_info<P>
-bicgstab_euler(const P dt, matrix_entry mentry,
-               global_kron_matrix<P> const &mat,
+bicgstab_euler(const P dt, imex_flag imex,
+               kron_operators<P> const &ops,
                fk::vector<P, mem_type::owner, resrc> &x,
                fk::vector<P, mem_type::owner, resrc> const &b,
                int const max_iter, P const tolerance);
+
+
+
+#ifdef KRON_MODE_GLOBAL
+
 
 #ifdef KRON_MODE_GLOBAL_BLOCK
 template<typename P, resource resrc>

--- a/src/solver.hpp
+++ b/src/solver.hpp
@@ -50,39 +50,39 @@ bicgstab_euler(const P dt, imex_flag imex,
 #ifdef KRON_MODE_GLOBAL
 
 
-#ifdef KRON_MODE_GLOBAL_BLOCK
-template<typename P, resource resrc>
-gmres_info<P>
-simple_gmres_euler(const P dt, matrix_entry mentry,
-                   block_global_kron_matrix<P> const &mat,
-                   fk::vector<P, mem_type::owner, resrc> &x,
-                   fk::vector<P, mem_type::owner, resrc> const &b,
-                   int const restart, int const max_iter, P const tolerance);
-
-template<typename P, resource resrc>
-gmres_info<P>
-bicgstab_euler(const P dt, matrix_entry mentry,
-               block_global_kron_matrix<P> const &mat,
-               fk::vector<P, mem_type::owner, resrc> &x,
-               fk::vector<P, mem_type::owner, resrc> const &b,
-               int const max_iter, P const tolerance);
-#endif
+// #ifdef KRON_MODE_GLOBAL_BLOCK
+// template<typename P, resource resrc>
+// gmres_info<P>
+// simple_gmres_euler(const P dt, matrix_entry mentry,
+//                    block_global_kron_matrix<P> const &mat,
+//                    fk::vector<P, mem_type::owner, resrc> &x,
+//                    fk::vector<P, mem_type::owner, resrc> const &b,
+//                    int const restart, int const max_iter, P const tolerance);
+//
+// template<typename P, resource resrc>
+// gmres_info<P>
+// bicgstab_euler(const P dt, matrix_entry mentry,
+//                block_global_kron_matrix<P> const &mat,
+//                fk::vector<P, mem_type::owner, resrc> &x,
+//                fk::vector<P, mem_type::owner, resrc> const &b,
+//                int const max_iter, P const tolerance);
+// #endif
 
 #else
 // solves ( I - dt * mat ) * x = b
-template<typename P, resource resrc>
-gmres_info<P>
-simple_gmres_euler(const P dt, kronmult_matrix<P> const &mat,
-                   fk::vector<P, mem_type::owner, resrc> &x,
-                   fk::vector<P, mem_type::owner, resrc> const &b,
-                   int const restart, int const max_iter, P const tolerance);
-// solves ( I - dt * mat ) * x = b
-template<typename P, resource resrc>
-gmres_info<P>
-bicgstab_euler(const P dt, kronmult_matrix<P> const &mat,
-               fk::vector<P, mem_type::owner, resrc> &x,
-               fk::vector<P, mem_type::owner, resrc> const &b,
-               int const max_iter, P const tolerance);
+// template<typename P, resource resrc>
+// gmres_info<P>
+// simple_gmres_euler(const P dt, kronmult_matrix<P> const &mat,
+//                    fk::vector<P, mem_type::owner, resrc> &x,
+//                    fk::vector<P, mem_type::owner, resrc> const &b,
+//                    int const restart, int const max_iter, P const tolerance);
+// // solves ( I - dt * mat ) * x = b
+// template<typename P, resource resrc>
+// gmres_info<P>
+// bicgstab_euler(const P dt, kronmult_matrix<P> const &mat,
+//                fk::vector<P, mem_type::owner, resrc> &x,
+//                fk::vector<P, mem_type::owner, resrc> const &b,
+//                int const max_iter, P const tolerance);
 #endif
 
 template<typename P>

--- a/src/solver.hpp
+++ b/src/solver.hpp
@@ -45,46 +45,6 @@ bicgstab_euler(const P dt, imex_flag imex,
                fk::vector<P, mem_type::owner, resrc> const &b,
                int const max_iter, P const tolerance);
 
-
-
-#ifdef KRON_MODE_GLOBAL
-
-
-// #ifdef KRON_MODE_GLOBAL_BLOCK
-// template<typename P, resource resrc>
-// gmres_info<P>
-// simple_gmres_euler(const P dt, matrix_entry mentry,
-//                    block_global_kron_matrix<P> const &mat,
-//                    fk::vector<P, mem_type::owner, resrc> &x,
-//                    fk::vector<P, mem_type::owner, resrc> const &b,
-//                    int const restart, int const max_iter, P const tolerance);
-//
-// template<typename P, resource resrc>
-// gmres_info<P>
-// bicgstab_euler(const P dt, matrix_entry mentry,
-//                block_global_kron_matrix<P> const &mat,
-//                fk::vector<P, mem_type::owner, resrc> &x,
-//                fk::vector<P, mem_type::owner, resrc> const &b,
-//                int const max_iter, P const tolerance);
-// #endif
-
-#else
-// solves ( I - dt * mat ) * x = b
-// template<typename P, resource resrc>
-// gmres_info<P>
-// simple_gmres_euler(const P dt, kronmult_matrix<P> const &mat,
-//                    fk::vector<P, mem_type::owner, resrc> &x,
-//                    fk::vector<P, mem_type::owner, resrc> const &b,
-//                    int const restart, int const max_iter, P const tolerance);
-// // solves ( I - dt * mat ) * x = b
-// template<typename P, resource resrc>
-// gmres_info<P>
-// bicgstab_euler(const P dt, kronmult_matrix<P> const &mat,
-//                fk::vector<P, mem_type::owner, resrc> &x,
-//                fk::vector<P, mem_type::owner, resrc> const &b,
-//                int const max_iter, P const tolerance);
-#endif
-
 template<typename P>
 int default_gmres_restarts(int num_cols);
 

--- a/src/solver_tests.cpp
+++ b/src/solver_tests.cpp
@@ -127,13 +127,6 @@ void test_kronmult(parser const &parse, P const tol_factor)
     P const tolerance  = std::is_same_v<float, P> ? 1e-6 : 1e-12;
     solver::simple_gmres_euler(dt, imex_flag::unspecified, operator_matrices, x,
                                b, restart, max_iter, tolerance);
-// #ifdef KRON_MODE_GLOBAL
-//     solver::simple_gmres_euler(dt, matrix_entry::regular, operator_matrices.kglobal, x,
-//                                b, restart, max_iter, tolerance);
-// #else
-//     solver::simple_gmres_euler(dt, operator_matrices[matrix_entry::regular], x,
-//                                b, restart, max_iter, tolerance);
-// #endif
     return x;
   }();
 
@@ -147,13 +140,6 @@ void test_kronmult(parser const &parse, P const tol_factor)
     P const tolerance  = std::is_same_v<float, P> ? 1e-6 : 1e-12;
     solver::bicgstab_euler(dt, imex_flag::unspecified, operator_matrices, x,
                            b, max_iter, tolerance);
-// #ifdef KRON_MODE_GLOBAL
-//     solver::bicgstab_euler(dt, matrix_entry::regular, operator_matrices.kglobal, x,
-//                            b, max_iter, tolerance);
-// #else
-//     solver::bicgstab_euler(dt, operator_matrices[matrix_entry::regular], x,
-//                            b, max_iter, tolerance);
-// #endif
     return x;
   }();
 
@@ -171,13 +157,6 @@ void test_kronmult(parser const &parse, P const tol_factor)
     P const tolerance  = std::is_same_v<float, P> ? 1e-6 : 1e-12;
     solver::simple_gmres_euler(dt, imex_flag::unspecified, operator_matrices,
                                x_d, b_d, restart, max_iter, tolerance);
-// #ifdef KRON_MODE_GLOBAL
-//     solver::simple_gmres_euler(dt, matrix_entry::regular, operator_matrices.kglobal,
-//                                x_d, b_d, restart, max_iter, tolerance);
-// #else
-//     solver::simple_gmres_euler(dt, operator_matrices[matrix_entry::regular],
-//                                x_d, b_d, restart, max_iter, tolerance);
-// #endif
     return x_d.clone_onto_host();
   }();
 
@@ -193,13 +172,6 @@ void test_kronmult(parser const &parse, P const tol_factor)
     P const tolerance  = std::is_same_v<float, P> ? 1e-6 : 1e-12;
     solver::bicgstab_euler(dt, imex_flag::unspecified, operator_matrices,
                            x_d, b_d, max_iter, tolerance);
-// #ifdef KRON_MODE_GLOBAL
-//     solver::bicgstab_euler(dt, matrix_entry::regular, operator_matrices.kglobal,
-//                            x_d, b_d, max_iter, tolerance);
-// #else
-//     solver::bicgstab_euler(dt, operator_matrices[matrix_entry::regular],
-//                            x_d, b_d, max_iter, tolerance);
-// #endif
     return x_d.clone_onto_host();
   }();
 

--- a/src/solver_tests.cpp
+++ b/src/solver_tests.cpp
@@ -113,9 +113,9 @@ void test_kronmult(parser const &parse, P const tol_factor)
 
   rmse_comparison(gold, bicgstab, tol_factor);
 
-  asgard::matrix_list<P> operator_matrices;
+  asgard::kron_operators<P> operator_matrices;
   asgard::adapt::distributed_grid adaptive_grid(*pde, opts);
-  operator_matrices.make(matrix_entry::regular, *pde, adaptive_grid, opts);
+  operator_matrices.make(imex_flag::unspecified, *pde, adaptive_grid, opts);
   P const dt = pde->get_dt();
 
   // perform matrix-free gmres
@@ -125,13 +125,15 @@ void test_kronmult(parser const &parse, P const tol_factor)
     int const restart  = parser::DEFAULT_GMRES_INNER_ITERATIONS;
     int const max_iter = parser::DEFAULT_GMRES_OUTER_ITERATIONS;
     P const tolerance  = std::is_same_v<float, P> ? 1e-6 : 1e-12;
-#ifdef KRON_MODE_GLOBAL
-    solver::simple_gmres_euler(dt, matrix_entry::regular, operator_matrices.kglobal, x,
+    solver::simple_gmres_euler(dt, imex_flag::unspecified, operator_matrices, x,
                                b, restart, max_iter, tolerance);
-#else
-    solver::simple_gmres_euler(dt, operator_matrices[matrix_entry::regular], x,
-                               b, restart, max_iter, tolerance);
-#endif
+// #ifdef KRON_MODE_GLOBAL
+//     solver::simple_gmres_euler(dt, matrix_entry::regular, operator_matrices.kglobal, x,
+//                                b, restart, max_iter, tolerance);
+// #else
+//     solver::simple_gmres_euler(dt, operator_matrices[matrix_entry::regular], x,
+//                                b, restart, max_iter, tolerance);
+// #endif
     return x;
   }();
 
@@ -143,13 +145,15 @@ void test_kronmult(parser const &parse, P const tol_factor)
     fk::vector<P> x(gold);
     int const max_iter = parser::DEFAULT_GMRES_OUTER_ITERATIONS;
     P const tolerance  = std::is_same_v<float, P> ? 1e-6 : 1e-12;
-#ifdef KRON_MODE_GLOBAL
-    solver::bicgstab_euler(dt, matrix_entry::regular, operator_matrices.kglobal, x,
+    solver::bicgstab_euler(dt, imex_flag::unspecified, operator_matrices, x,
                            b, max_iter, tolerance);
-#else
-    solver::bicgstab_euler(dt, operator_matrices[matrix_entry::regular], x,
-                           b, max_iter, tolerance);
-#endif
+// #ifdef KRON_MODE_GLOBAL
+//     solver::bicgstab_euler(dt, matrix_entry::regular, operator_matrices.kglobal, x,
+//                            b, max_iter, tolerance);
+// #else
+//     solver::bicgstab_euler(dt, operator_matrices[matrix_entry::regular], x,
+//                            b, max_iter, tolerance);
+// #endif
     return x;
   }();
 
@@ -165,13 +169,15 @@ void test_kronmult(parser const &parse, P const tol_factor)
     int const restart  = parser::DEFAULT_GMRES_INNER_ITERATIONS;
     int const max_iter = parser::DEFAULT_GMRES_OUTER_ITERATIONS;
     P const tolerance  = std::is_same_v<float, P> ? 1e-6 : 1e-12;
-#ifdef KRON_MODE_GLOBAL
-    solver::simple_gmres_euler(dt, matrix_entry::regular, operator_matrices.kglobal,
+    solver::simple_gmres_euler(dt, imex_flag::unspecified, operator_matrices,
                                x_d, b_d, restart, max_iter, tolerance);
-#else
-    solver::simple_gmres_euler(dt, operator_matrices[matrix_entry::regular],
-                               x_d, b_d, restart, max_iter, tolerance);
-#endif
+// #ifdef KRON_MODE_GLOBAL
+//     solver::simple_gmres_euler(dt, matrix_entry::regular, operator_matrices.kglobal,
+//                                x_d, b_d, restart, max_iter, tolerance);
+// #else
+//     solver::simple_gmres_euler(dt, operator_matrices[matrix_entry::regular],
+//                                x_d, b_d, restart, max_iter, tolerance);
+// #endif
     return x_d.clone_onto_host();
   }();
 
@@ -185,13 +191,15 @@ void test_kronmult(parser const &parse, P const tol_factor)
         b.clone_onto_device();
     int const max_iter = parser::DEFAULT_GMRES_OUTER_ITERATIONS;
     P const tolerance  = std::is_same_v<float, P> ? 1e-6 : 1e-12;
-#ifdef KRON_MODE_GLOBAL
-    solver::bicgstab_euler(dt, matrix_entry::regular, operator_matrices.kglobal,
+    solver::bicgstab_euler(dt, imex_flag::unspecified, operator_matrices,
                            x_d, b_d, max_iter, tolerance);
-#else
-    solver::bicgstab_euler(dt, operator_matrices[matrix_entry::regular],
-                           x_d, b_d, max_iter, tolerance);
-#endif
+// #ifdef KRON_MODE_GLOBAL
+//     solver::bicgstab_euler(dt, matrix_entry::regular, operator_matrices.kglobal,
+//                            x_d, b_d, max_iter, tolerance);
+// #else
+//     solver::bicgstab_euler(dt, operator_matrices[matrix_entry::regular],
+//                            x_d, b_d, max_iter, tolerance);
+// #endif
     return x_d.clone_onto_host();
   }();
 

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -213,9 +213,9 @@ explicit_advance(PDE<P> const &pde, kron_operators<P> &operator_matrices,
   // -- RK step 1
   fk::vector<P> fx(row_size);
   {
-    tools::time_event performance("kronmult");
+    tools::time_event performance(
+        "kronmult", operator_matrices.flops(imex_flag::unspecified));
     operator_matrices.apply(imex_flag::unspecified, 1.0, x.data(), 0.0, fx.data());
-    performance.flops = operator_matrices.flops(imex_flag::unspecified);
   }
   reduce_results(fx, reduced_fx, plan, get_rank());
 
@@ -267,9 +267,9 @@ explicit_advance(PDE<P> const &pde, kron_operators<P> &operator_matrices,
 
   // -- RK step 3
   {
-    tools::time_event performance("kronmult");
+    tools::time_event performance(
+        "kronmult", operator_matrices.flops(imex_flag::unspecified));
     operator_matrices.apply(imex_flag::unspecified, 1.0, x.data(), 0.0, fx.data());
-    performance.flops = operator_matrices.flops(imex_flag::unspecified);
   }
   reduce_results(fx, reduced_fx, plan, get_rank());
 
@@ -439,15 +439,6 @@ implicit_advance(PDE<P> &pde, kron_operators<P> &operator_matrices,
     pde.gmres_outputs[0] = solver::simple_gmres_euler<P, resource::host>(
         pde.get_dt(), imex_flag::unspecified, operator_matrices,
         fx, x, restart, max_iter, tolerance);
-// #ifdef KRON_MODE_GLOBAL
-//     pde.gmres_outputs[0] = solver::simple_gmres_euler<P, resource::host>(
-//         pde.get_dt(), imex_flag::unspecified, operator_matrices.kglobal,
-//         fx, x, restart, max_iter, tolerance);
-// #else
-//     pde.gmres_outputs[0] = solver::simple_gmres_euler(
-//         pde.get_dt(), operator_matrices[imex_flag::unspecified],
-//         fx, x, restart, max_iter, tolerance);
-// #endif
     return fx;
   }
   else if (solver == solve_opts::bicgstab)
@@ -461,15 +452,6 @@ implicit_advance(PDE<P> &pde, kron_operators<P> &operator_matrices,
     pde.gmres_outputs[0] = solver::bicgstab_euler<P, resource::host>(
         pde.get_dt(), imex_flag::unspecified, operator_matrices,
         fx, x, max_iter, tolerance);
-// #ifdef KRON_MODE_GLOBAL
-//     pde.gmres_outputs[0] = solver::bicgstab_euler<P, resource::host>(
-//         pde.get_dt(), matrix_entry::regular, operator_matrices.kglobal,
-//         fx, x, max_iter, tolerance);
-// #else
-//     pde.gmres_outputs[0] = solver::bicgstab_euler(
-//         pde.get_dt(), operator_matrices[imex_flag::unspecified],
-//         fx, x, max_iter, tolerance);
-// #endif
     return fx;
   }
   return x;
@@ -821,26 +803,18 @@ imex_advance(PDE<P> &pde, kron_operators<P> &operator_matrices,
   fk::vector<P, mem_type::owner, imex_resrc> fx(f.size());
 
   {
-//#ifdef KRON_MODE_GLOBAL
-    tools::time_event kronm_("kronmult - explicit", operator_matrices.flops(imex_flag::imex_explicit));
+    tools::time_event kronm_(
+        "kronmult - explicit", operator_matrices.flops(imex_flag::imex_explicit));
     operator_matrices.template apply<imex_resrc>(imex_flag::imex_explicit, 1.0, f.data(), 0.0, fx.data());
-// #else
-//     tools::time_event kronm_(
-//         "kronmult - explicit",
-//         operator_matrices[imex_flag::imex_explicit].flops());
-//     operator_matrices[matrix_entry::imex_explicit].template apply<imex_resrc>(
-//         1.0, f.data(), 0.0, fx.data());
-// #endif
   }
 
 #ifndef ASGARD_USE_CUDA
   reduce_results(fx, reduced_fx, plan, get_rank());
 
-  // fk::vector<P, mem_type::owner, resource::host> f_1s(f_0.size());
   exchange_results(reduced_fx, fx, elem_size, plan, get_rank());
   fm::axpy(fx, f, dt); // f here is f_1s
 #else
-  fm::axpy(fx, f, dt); // f here is f_1s
+  fm::axpy(fx, f, dt);   // f here is f_1s
 #endif
 
   tools::timer.stop("explicit_1");
@@ -885,30 +859,12 @@ imex_advance(PDE<P> &pde, kron_operators<P> &operator_matrices,
       pde.gmres_outputs[0] = solver::simple_gmres_euler(
           pde.get_dt(), imex_flag::imex_implicit, operator_matrices,
           f_1, f, restart, max_iter, tolerance);
-// #ifdef KRON_MODE_GLOBAL
-//       pde.gmres_outputs[0] = solver::simple_gmres_euler(
-//           pde.get_dt(), matrix_entry::imex_implicit, operator_matrices.kglobal,
-//           f_1, f, restart, max_iter, tolerance);
-// #else
-//       pde.gmres_outputs[0] = solver::simple_gmres_euler(
-//           pde.get_dt(), operator_matrices[matrix_entry::imex_implicit],
-//           f_1, f, restart, max_iter, tolerance);
-// #endif
     }
     else if (solver == solve_opts::bicgstab)
     {
       pde.gmres_outputs[0] = solver::bicgstab_euler(
           pde.get_dt(), imex_flag::imex_implicit, operator_matrices,
           f_1, f, max_iter, tolerance);
-// #ifdef KRON_MODE_GLOBAL
-//       pde.gmres_outputs[0] = solver::bicgstab_euler(
-//           pde.get_dt(), matrix_entry::imex_implicit, operator_matrices.kglobal,
-//           f_1, f, max_iter, tolerance);
-// #else
-//       pde.gmres_outputs[0] = solver::bicgstab_euler(
-//           pde.get_dt(), operator_matrices[matrix_entry::imex_implicit],
-//           f_1, f, max_iter, tolerance);
-// #endif
     }
     else
     {
@@ -941,17 +897,9 @@ imex_advance(PDE<P> &pde, kron_operators<P> &operator_matrices,
 
   // Explicit step f_2s = 0.5*f_0 + 0.5*(f_1 + dt A f_1)
   {
-    tools::time_event kronm_("kronmult - explicit", operator_matrices.flops(imex_flag::imex_explicit));
+    tools::time_event kronm_(
+        "kronmult - explicit", operator_matrices.flops(imex_flag::imex_explicit));
     operator_matrices.template apply<imex_resrc>(imex_flag::imex_explicit, 1.0, f_1.data(), 0.0, fx.data());
-// #ifdef KRON_MODE_GLOBAL
-//
-// #else
-//     tools::time_event kronm_(
-//         "kronmult - explicit",
-//         operator_matrices[matrix_entry::imex_explicit].flops());
-//     operator_matrices[matrix_entry::imex_explicit].template apply<imex_resrc>(
-//         1.0, f_1.data(), 0.0, fx.data());
-// #endif
   }
 
 #ifndef ASGARD_USE_CUDA
@@ -1010,30 +958,12 @@ imex_advance(PDE<P> &pde, kron_operators<P> &operator_matrices,
       pde.gmres_outputs[1] = solver::simple_gmres_euler(
           P{0.5} * pde.get_dt(), imex_flag::imex_implicit, operator_matrices,
           f_2, f, restart, max_iter, tolerance);
-// #ifdef KRON_MODE_GLOBAL
-//       pde.gmres_outputs[1] = solver::simple_gmres_euler(
-//           P{0.5} * pde.get_dt(), matrix_entry::imex_implicit, operator_matrices.kglobal,
-//           f_2, f, restart, max_iter, tolerance);
-// #else
-//       pde.gmres_outputs[1] = solver::simple_gmres_euler(
-//           P{0.5} * pde.get_dt(), operator_matrices[matrix_entry::imex_implicit],
-//           f_2, f, restart, max_iter, tolerance);
-// #endif
     }
     else if (solver == solve_opts::bicgstab)
     {
       pde.gmres_outputs[1] = solver::bicgstab_euler(
           P{0.5} * pde.get_dt(), imex_flag::imex_implicit, operator_matrices,
           f_2, f, max_iter, tolerance);
-// #ifdef KRON_MODE_GLOBAL
-//       pde.gmres_outputs[1] = solver::bicgstab_euler(
-//           P{0.5} * pde.get_dt(), matrix_entry::imex_implicit, operator_matrices.kglobal,
-//           f_2, f, max_iter, tolerance);
-// #else
-//       pde.gmres_outputs[1] = solver::bicgstab_euler(
-//           P{0.5} * pde.get_dt(), operator_matrices[matrix_entry::imex_implicit],
-//           f_2, f, max_iter, tolerance);
-// #endif
     }
     else
     {

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -82,7 +82,7 @@ adaptive_advance(method const step_method, PDE<P> &pde,
 
   // clear the matrices if the coarsening removed indexes
   if (old_size != adaptive_grid.size())
-    operator_matrices.clear_all();
+    operator_matrices.clear();
 
   // save coarsen stats
   pde.adapt_info.initial_dof = old_size;
@@ -146,7 +146,7 @@ adaptive_advance(method const step_method, PDE<P> &pde,
     else
     {
       // added more indexes, matrices will have to be remade
-      operator_matrices.clear_all();
+      operator_matrices.clear();
 
       y = adaptive_grid.redistribute_solution(y, old_plan, old_size);
 

--- a/src/time_advance.cpp
+++ b/src/time_advance.cpp
@@ -45,7 +45,7 @@ get_sources(PDE<P> const &pde, adapt::distributed_grid<P> const &grid,
 template<typename P>
 fk::vector<P>
 adaptive_advance(method const step_method, PDE<P> &pde,
-                 matrix_list<P> &operator_matrices,
+                 kron_operators<P> &operator_matrices,
                  adapt::distributed_grid<P> &adaptive_grid,
                  basis::wavelet_transform<P, resource::host> const &transformer,
                  options const &program_opts, fk::vector<P> const &x_orig,
@@ -169,7 +169,7 @@ adaptive_advance(method const step_method, PDE<P> &pde,
 // vector x. on exit, the next solution vector is stored in x.
 template<typename P>
 fk::vector<P>
-explicit_advance(PDE<P> const &pde, matrix_list<P> &operator_matrices,
+explicit_advance(PDE<P> const &pde, kron_operators<P> &operator_matrices,
                  adapt::distributed_grid<P> const &adaptive_grid,
                  basis::wavelet_transform<P, resource::host> const &transformer,
                  options const &program_opts,
@@ -187,8 +187,7 @@ explicit_advance(PDE<P> const &pde, matrix_list<P> &operator_matrices,
   expect(col_size < INT_MAX);
   expect(row_size < INT_MAX);
 
-  operator_matrices.make(matrix_entry::regular, pde, adaptive_grid,
-                         program_opts);
+  operator_matrices.make(imex_flag::unspecified, pde, adaptive_grid, program_opts);
 
   // time advance working vectors
   // input vector for apply_A
@@ -215,8 +214,8 @@ explicit_advance(PDE<P> const &pde, matrix_list<P> &operator_matrices,
   fk::vector<P> fx(row_size);
   {
     tools::time_event performance("kronmult");
-    operator_matrices.apply(matrix_entry::regular, 1.0, x.data(), 0.0, fx.data());
-    performance.flops = operator_matrices.flops(matrix_entry::regular);
+    operator_matrices.apply(imex_flag::unspecified, 1.0, x.data(), 0.0, fx.data());
+    performance.flops = operator_matrices.flops(imex_flag::unspecified);
   }
   reduce_results(fx, reduced_fx, plan, get_rank());
 
@@ -239,8 +238,8 @@ explicit_advance(PDE<P> const &pde, matrix_list<P> &operator_matrices,
 
   {
     tools::time_event performance(
-        "kronmult", operator_matrices.flops(matrix_entry::regular));
-    operator_matrices.apply(matrix_entry::regular, 1.0, x.data(), 0.0, fx.data());
+        "kronmult", operator_matrices.flops(imex_flag::unspecified));
+    operator_matrices.apply(imex_flag::unspecified, 1.0, x.data(), 0.0, fx.data());
   }
   reduce_results(fx, reduced_fx, plan, get_rank());
 
@@ -269,8 +268,8 @@ explicit_advance(PDE<P> const &pde, matrix_list<P> &operator_matrices,
   // -- RK step 3
   {
     tools::time_event performance("kronmult");
-    operator_matrices.apply(matrix_entry::regular, 1.0, x.data(), 0.0, fx.data());
-    performance.flops = operator_matrices.flops(matrix_entry::regular);
+    operator_matrices.apply(imex_flag::unspecified, 1.0, x.data(), 0.0, fx.data());
+    performance.flops = operator_matrices.flops(imex_flag::unspecified);
   }
   reduce_results(fx, reduced_fx, plan, get_rank());
 
@@ -306,7 +305,7 @@ explicit_advance(PDE<P> const &pde, matrix_list<P> &operator_matrices,
 // vector x. on exit, the next solution vector is stored in fx.
 template<typename P>
 fk::vector<P>
-implicit_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
+implicit_advance(PDE<P> &pde, kron_operators<P> &operator_matrices,
                  adapt::distributed_grid<P> const &adaptive_grid,
                  basis::wavelet_transform<P, resource::host> const &transformer,
                  options const &program_opts,
@@ -430,41 +429,47 @@ implicit_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   }
   else if (solver == solve_opts::gmres)
   {
-    operator_matrices.make(matrix_entry::regular, pde, adaptive_grid,
+    operator_matrices.make(imex_flag::unspecified, pde, adaptive_grid,
                            program_opts);
     P const tolerance  = program_opts.gmres_tolerance;
     int const restart  = program_opts.gmres_inner_iterations;
     int const max_iter = program_opts.gmres_outer_iterations;
     fk::vector<P> fx(x);
     // TODO: do something better to save gmres output to pde
-#ifdef KRON_MODE_GLOBAL
     pde.gmres_outputs[0] = solver::simple_gmres_euler<P, resource::host>(
-        pde.get_dt(), matrix_entry::regular, operator_matrices.kglobal,
+        pde.get_dt(), imex_flag::unspecified, operator_matrices,
         fx, x, restart, max_iter, tolerance);
-#else
-    pde.gmres_outputs[0] = solver::simple_gmres_euler(
-        pde.get_dt(), operator_matrices[matrix_entry::regular],
-        fx, x, restart, max_iter, tolerance);
-#endif
+// #ifdef KRON_MODE_GLOBAL
+//     pde.gmres_outputs[0] = solver::simple_gmres_euler<P, resource::host>(
+//         pde.get_dt(), imex_flag::unspecified, operator_matrices.kglobal,
+//         fx, x, restart, max_iter, tolerance);
+// #else
+//     pde.gmres_outputs[0] = solver::simple_gmres_euler(
+//         pde.get_dt(), operator_matrices[imex_flag::unspecified],
+//         fx, x, restart, max_iter, tolerance);
+// #endif
     return fx;
   }
   else if (solver == solve_opts::bicgstab)
   {
-    operator_matrices.make(matrix_entry::regular, pde, adaptive_grid,
+    operator_matrices.make(imex_flag::unspecified, pde, adaptive_grid,
                            program_opts);
     P const tolerance  = program_opts.gmres_tolerance;
     int const max_iter = program_opts.gmres_outer_iterations;
     fk::vector<P> fx(x);
     // TODO: do something better to save gmres output to pde
-#ifdef KRON_MODE_GLOBAL
     pde.gmres_outputs[0] = solver::bicgstab_euler<P, resource::host>(
-        pde.get_dt(), matrix_entry::regular, operator_matrices.kglobal,
+        pde.get_dt(), imex_flag::unspecified, operator_matrices,
         fx, x, max_iter, tolerance);
-#else
-    pde.gmres_outputs[0] = solver::bicgstab_euler(
-        pde.get_dt(), operator_matrices[matrix_entry::regular],
-        fx, x, max_iter, tolerance);
-#endif
+// #ifdef KRON_MODE_GLOBAL
+//     pde.gmres_outputs[0] = solver::bicgstab_euler<P, resource::host>(
+//         pde.get_dt(), matrix_entry::regular, operator_matrices.kglobal,
+//         fx, x, max_iter, tolerance);
+// #else
+//     pde.gmres_outputs[0] = solver::bicgstab_euler(
+//         pde.get_dt(), operator_matrices[imex_flag::unspecified],
+//         fx, x, max_iter, tolerance);
+// #endif
     return fx;
   }
   return x;
@@ -492,7 +497,7 @@ asgard::options make_options(std::vector<std::string> const arguments)
 // current solution vector x. on exit, the next solution vector is stored in fx.
 template<typename P>
 fk::vector<P>
-imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
+imex_advance(PDE<P> &pde, kron_operators<P> &operator_matrices,
              adapt::distributed_grid<P> const &adaptive_grid,
              basis::wavelet_transform<P, resource::host> const &transformer,
              options const &program_opts,
@@ -808,7 +813,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
     do_poisson_update(f);
   }
 
-  operator_matrices.reset_coefficients(matrix_entry::imex_explicit, pde,
+  operator_matrices.reset_coefficients(imex_flag::imex_explicit, pde,
                                        adaptive_grid, program_opts);
 
   // Explicit step f_1s = f_0 + dt A f_0
@@ -816,16 +821,16 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
   fk::vector<P, mem_type::owner, imex_resrc> fx(f.size());
 
   {
-#ifdef KRON_MODE_GLOBAL
-    tools::time_event kronm_("kronmult - explicit", operator_matrices.flops(matrix_entry::imex_explicit));
-    operator_matrices.template apply<imex_resrc>(matrix_entry::imex_explicit, 1.0, f.data(), 0.0, fx.data());
-#else
-    tools::time_event kronm_(
-        "kronmult - explicit",
-        operator_matrices[matrix_entry::imex_explicit].flops());
-    operator_matrices[matrix_entry::imex_explicit].template apply<imex_resrc>(
-        1.0, f.data(), 0.0, fx.data());
-#endif
+//#ifdef KRON_MODE_GLOBAL
+    tools::time_event kronm_("kronmult - explicit", operator_matrices.flops(imex_flag::imex_explicit));
+    operator_matrices.template apply<imex_resrc>(imex_flag::imex_explicit, 1.0, f.data(), 0.0, fx.data());
+// #else
+//     tools::time_event kronm_(
+//         "kronmult - explicit",
+//         operator_matrices[imex_flag::imex_explicit].flops());
+//     operator_matrices[matrix_entry::imex_explicit].template apply<imex_resrc>(
+//         1.0, f.data(), 0.0, fx.data());
+// #endif
   }
 
 #ifndef ASGARD_USE_CUDA
@@ -856,7 +861,7 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
     generate_all_coefficients<P>(pde, transformer);
 
     // f2 now
-    operator_matrices.reset_coefficients(matrix_entry::imex_implicit, pde,
+    operator_matrices.reset_coefficients(imex_flag::imex_implicit, pde,
                                          adaptive_grid, program_opts);
 
     // use previous refined solution as initial guess to GMRES if it exists
@@ -877,27 +882,33 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
     }
     if (solver == solve_opts::gmres)
     {
-#ifdef KRON_MODE_GLOBAL
       pde.gmres_outputs[0] = solver::simple_gmres_euler(
-          pde.get_dt(), matrix_entry::imex_implicit, operator_matrices.kglobal,
+          pde.get_dt(), imex_flag::imex_implicit, operator_matrices,
           f_1, f, restart, max_iter, tolerance);
-#else
-      pde.gmres_outputs[0] = solver::simple_gmres_euler(
-          pde.get_dt(), operator_matrices[matrix_entry::imex_implicit],
-          f_1, f, restart, max_iter, tolerance);
-#endif
+// #ifdef KRON_MODE_GLOBAL
+//       pde.gmres_outputs[0] = solver::simple_gmres_euler(
+//           pde.get_dt(), matrix_entry::imex_implicit, operator_matrices.kglobal,
+//           f_1, f, restart, max_iter, tolerance);
+// #else
+//       pde.gmres_outputs[0] = solver::simple_gmres_euler(
+//           pde.get_dt(), operator_matrices[matrix_entry::imex_implicit],
+//           f_1, f, restart, max_iter, tolerance);
+// #endif
     }
     else if (solver == solve_opts::bicgstab)
     {
-#ifdef KRON_MODE_GLOBAL
       pde.gmres_outputs[0] = solver::bicgstab_euler(
-          pde.get_dt(), matrix_entry::imex_implicit, operator_matrices.kglobal,
+          pde.get_dt(), imex_flag::imex_implicit, operator_matrices,
           f_1, f, max_iter, tolerance);
-#else
-      pde.gmres_outputs[0] = solver::bicgstab_euler(
-          pde.get_dt(), operator_matrices[matrix_entry::imex_implicit],
-          f_1, f, max_iter, tolerance);
-#endif
+// #ifdef KRON_MODE_GLOBAL
+//       pde.gmres_outputs[0] = solver::bicgstab_euler(
+//           pde.get_dt(), matrix_entry::imex_implicit, operator_matrices.kglobal,
+//           f_1, f, max_iter, tolerance);
+// #else
+//       pde.gmres_outputs[0] = solver::bicgstab_euler(
+//           pde.get_dt(), operator_matrices[matrix_entry::imex_implicit],
+//           f_1, f, max_iter, tolerance);
+// #endif
     }
     else
     {
@@ -925,21 +936,22 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
     do_poisson_update(f_1);
   }
 
-  operator_matrices.reset_coefficients(matrix_entry::imex_explicit, pde,
+  operator_matrices.reset_coefficients(imex_flag::imex_explicit, pde,
                                        adaptive_grid, program_opts);
 
   // Explicit step f_2s = 0.5*f_0 + 0.5*(f_1 + dt A f_1)
   {
-#ifdef KRON_MODE_GLOBAL
-    tools::time_event kronm_("kronmult - explicit", operator_matrices.flops(matrix_entry::imex_explicit));
-    operator_matrices.template apply<imex_resrc>(matrix_entry::imex_explicit, 1.0, f_1.data(), 0.0, fx.data());
-#else
-    tools::time_event kronm_(
-        "kronmult - explicit",
-        operator_matrices[matrix_entry::imex_explicit].flops());
-    operator_matrices[matrix_entry::imex_explicit].template apply<imex_resrc>(
-        1.0, f_1.data(), 0.0, fx.data());
-#endif
+    tools::time_event kronm_("kronmult - explicit", operator_matrices.flops(imex_flag::imex_explicit));
+    operator_matrices.template apply<imex_resrc>(imex_flag::imex_explicit, 1.0, f_1.data(), 0.0, fx.data());
+// #ifdef KRON_MODE_GLOBAL
+//
+// #else
+//     tools::time_event kronm_(
+//         "kronmult - explicit",
+//         operator_matrices[matrix_entry::imex_explicit].flops());
+//     operator_matrices[matrix_entry::imex_explicit].template apply<imex_resrc>(
+//         1.0, f_1.data(), 0.0, fx.data());
+// #endif
   }
 
 #ifndef ASGARD_USE_CUDA
@@ -990,32 +1002,38 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
       }
     }
 
-    operator_matrices.reset_coefficients(matrix_entry::imex_implicit, pde,
+    operator_matrices.reset_coefficients(imex_flag::imex_implicit, pde,
                                          adaptive_grid, program_opts);
 
     if (solver == solve_opts::gmres)
     {
-#ifdef KRON_MODE_GLOBAL
       pde.gmres_outputs[1] = solver::simple_gmres_euler(
-          P{0.5} * pde.get_dt(), matrix_entry::imex_implicit, operator_matrices.kglobal,
+          P{0.5} * pde.get_dt(), imex_flag::imex_implicit, operator_matrices,
           f_2, f, restart, max_iter, tolerance);
-#else
-      pde.gmres_outputs[1] = solver::simple_gmres_euler(
-          P{0.5} * pde.get_dt(), operator_matrices[matrix_entry::imex_implicit],
-          f_2, f, restart, max_iter, tolerance);
-#endif
+// #ifdef KRON_MODE_GLOBAL
+//       pde.gmres_outputs[1] = solver::simple_gmres_euler(
+//           P{0.5} * pde.get_dt(), matrix_entry::imex_implicit, operator_matrices.kglobal,
+//           f_2, f, restart, max_iter, tolerance);
+// #else
+//       pde.gmres_outputs[1] = solver::simple_gmres_euler(
+//           P{0.5} * pde.get_dt(), operator_matrices[matrix_entry::imex_implicit],
+//           f_2, f, restart, max_iter, tolerance);
+// #endif
     }
     else if (solver == solve_opts::bicgstab)
     {
-#ifdef KRON_MODE_GLOBAL
       pde.gmres_outputs[1] = solver::bicgstab_euler(
-          P{0.5} * pde.get_dt(), matrix_entry::imex_implicit, operator_matrices.kglobal,
+          P{0.5} * pde.get_dt(), imex_flag::imex_implicit, operator_matrices,
           f_2, f, max_iter, tolerance);
-#else
-      pde.gmres_outputs[1] = solver::bicgstab_euler(
-          P{0.5} * pde.get_dt(), operator_matrices[matrix_entry::imex_implicit],
-          f_2, f, max_iter, tolerance);
-#endif
+// #ifdef KRON_MODE_GLOBAL
+//       pde.gmres_outputs[1] = solver::bicgstab_euler(
+//           P{0.5} * pde.get_dt(), matrix_entry::imex_implicit, operator_matrices.kglobal,
+//           f_2, f, max_iter, tolerance);
+// #else
+//       pde.gmres_outputs[1] = solver::bicgstab_euler(
+//           P{0.5} * pde.get_dt(), operator_matrices[matrix_entry::imex_implicit],
+//           f_2, f, max_iter, tolerance);
+// #endif
     }
     else
     {
@@ -1049,14 +1067,14 @@ imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
 #ifdef ASGARD_ENABLE_DOUBLE
 template fk::vector<double> adaptive_advance(
     method const step_method, PDE<double> &pde,
-    matrix_list<double> &operator_matrix,
+    kron_operators<double> &operator_matrix,
     adapt::distributed_grid<double> &adaptive_grid,
     basis::wavelet_transform<double, resource::host> const &transformer,
     options const &program_opts, fk::vector<double> const &x, double const time,
     bool const update_system);
 
 template fk::vector<double> explicit_advance(
-    PDE<double> const &pde, matrix_list<double> &operator_matrix,
+    PDE<double> const &pde, kron_operators<double> &operator_matrix,
     adapt::distributed_grid<double> const &adaptive_grid,
     basis::wavelet_transform<double, resource::host> const &transformer,
     options const &program_opts,
@@ -1065,7 +1083,7 @@ template fk::vector<double> explicit_advance(
     fk::vector<double> const &x, double const time);
 
 template fk::vector<double> implicit_advance(
-    PDE<double> &pde, matrix_list<double> &operator_matrix,
+    PDE<double> &pde, kron_operators<double> &operator_matrix,
     adapt::distributed_grid<double> const &adaptive_grid,
     basis::wavelet_transform<double, resource::host> const &transformer,
     options const &program_opts,
@@ -1075,7 +1093,7 @@ template fk::vector<double> implicit_advance(
     bool const update_system);
 
 template fk::vector<double> imex_advance(
-    PDE<double> &pde, matrix_list<double> &operator_matrix,
+    PDE<double> &pde, kron_operators<double> &operator_matrix,
     adapt::distributed_grid<double> const &adaptive_grid,
     basis::wavelet_transform<double, resource::host> const &transformer,
     options const &program_opts,
@@ -1090,14 +1108,14 @@ template fk::vector<double> imex_advance(
 
 template fk::vector<float> adaptive_advance(
     method const step_method, PDE<float> &pde,
-    matrix_list<float> &operator_matrix,
+    kron_operators<float> &operator_matrix,
     adapt::distributed_grid<float> &adaptive_grid,
     basis::wavelet_transform<float, resource::host> const &transformer,
     options const &program_opts, fk::vector<float> const &x, float const time,
     bool const update_system);
 
 template fk::vector<float> explicit_advance(
-    PDE<float> const &pde, matrix_list<float> &operator_matrix,
+    PDE<float> const &pde, kron_operators<float> &operator_matrix,
     adapt::distributed_grid<float> const &adaptive_grid,
     basis::wavelet_transform<float, resource::host> const &transformer,
     options const &program_opts,
@@ -1106,7 +1124,7 @@ template fk::vector<float> explicit_advance(
     fk::vector<float> const &x, float const time);
 
 template fk::vector<float> implicit_advance(
-    PDE<float> &pde, matrix_list<float> &operator_matrix,
+    PDE<float> &pde, kron_operators<float> &operator_matrix,
     adapt::distributed_grid<float> const &adaptive_grid,
     basis::wavelet_transform<float, resource::host> const &transformer,
     options const &program_opts,
@@ -1115,7 +1133,7 @@ template fk::vector<float> implicit_advance(
     fk::vector<float> const &x, float const time, bool const update_system);
 
 template fk::vector<float>
-imex_advance(PDE<float> &pde, matrix_list<float> &operator_matrix,
+imex_advance(PDE<float> &pde, kron_operators<float> &operator_matrix,
              adapt::distributed_grid<float> const &adaptive_grid,
              basis::wavelet_transform<float, resource::host> const &transformer,
              options const &program_opts,

--- a/src/time_advance.hpp
+++ b/src/time_advance.hpp
@@ -25,7 +25,7 @@ static constexpr resource imex_resrc = resource::host;
 template<typename P>
 fk::vector<P>
 adaptive_advance(method const step_method, PDE<P> &pde,
-                 matrix_list<P> &operator_matrices,
+                 kron_operators<P> &operator_matrices,
                  adapt::distributed_grid<P> &adaptive_grid,
                  basis::wavelet_transform<P, resource::host> const &transformer,
                  options const &program_opts, fk::vector<P> const &x,
@@ -36,7 +36,7 @@ adaptive_advance(method const step_method, PDE<P> &pde,
 // on exit, the next solution vector is stored in x.
 template<typename P>
 fk::vector<P>
-explicit_advance(PDE<P> const &pde, matrix_list<P> &operator_matrices,
+explicit_advance(PDE<P> const &pde, kron_operators<P> &operator_matrices,
                  adapt::distributed_grid<P> const &adaptive_grid,
                  basis::wavelet_transform<P, resource::host> const &transformer,
                  options const &program_opts,
@@ -46,7 +46,7 @@ explicit_advance(PDE<P> const &pde, matrix_list<P> &operator_matrices,
 
 template<typename P>
 fk::vector<P>
-implicit_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
+implicit_advance(PDE<P> &pde, kron_operators<P> &operator_matrices,
                  adapt::distributed_grid<P> const &adaptive_grid,
                  basis::wavelet_transform<P, resource::host> const &transformer,
                  options const &program_opts,
@@ -57,7 +57,7 @@ implicit_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
 
 template<typename P>
 fk::vector<P>
-imex_advance(PDE<P> &pde, matrix_list<P> &operator_matrices,
+imex_advance(PDE<P> &pde, kron_operators<P> &operator_matrices,
              adapt::distributed_grid<P> const &adaptive_grid,
              basis::wavelet_transform<P, resource::host> const &transformer,
              options const &program_opts,

--- a/src/time_advance_tests.cpp
+++ b/src/time_advance_tests.cpp
@@ -1871,22 +1871,24 @@ void test_memory_mode(imex_flag imex)
   kron_sparse_cache spcache_null1, spcache_one;
   memory_usage memory_one =
       compute_mem_usage(*pde, grid, opts, imex, spcache_null1);
-  auto mat_one              = make_kronmult_matrix(*pde, grid, opts, memory_one,
-                                      imex_flag::unspecified, spcache_null1);
+
+  auto mat_one = make_local_kronmult_matrix(
+      *pde, grid, opts, memory_one, imex_flag::unspecified, spcache_null1);
   memory_usage spmemory_one = compute_mem_usage(
       *pde, grid, opts, imex, spcache_one, 6, 2147483646, force_sparse);
-  auto spmat_one = make_kronmult_matrix(*pde, grid, opts, spmemory_one, imex,
-                                        spcache_one, force_sparse);
+  auto spmat_one = make_local_kronmult_matrix(
+      *pde, grid, opts, spmemory_one, imex, spcache_one, force_sparse);
 
   kron_sparse_cache spcache_null2, spcache_multi;
   memory_usage memory_multi =
       compute_mem_usage(*pde, grid, opts, imex, spcache_null2, 0, 8000);
-  auto mat_multi =
-      make_kronmult_matrix(*pde, grid, opts, memory_multi, imex, spcache_null2);
+
+  auto mat_multi = make_local_kronmult_matrix(
+      *pde, grid, opts, memory_multi, imex, spcache_null2);
   memory_usage spmemory_multi = compute_mem_usage(
       *pde, grid, opts, imex, spcache_multi, 6, 8000, force_sparse);
-  auto spmat_multi = make_kronmult_matrix(*pde, grid, opts, spmemory_multi,
-                                          imex, spcache_multi, force_sparse);
+  auto spmat_multi = make_local_kronmult_matrix(
+      *pde, grid, opts, spmemory_multi, imex, spcache_multi, force_sparse);
 
   REQUIRE(mat_one.is_onecall());
   REQUIRE(spmat_one.is_onecall());

--- a/src/time_advance_tests.cpp
+++ b/src/time_advance_tests.cpp
@@ -84,7 +84,7 @@ void time_advance_test(parser const &parse,
 
   fk::vector<P> f_val(initial_condition);
 
-  asgard::matrix_list<P> operator_matrices;
+  asgard::kron_operators<P> operator_matrices;
 
   // -- time loop
   for (auto i = 0; i < opts.num_time_steps; ++i)
@@ -1360,7 +1360,7 @@ TEMPLATE_TEST_CASE("IMEX time advance - landau", "[imex]", test_precs)
   generate_dimension_mass_mat(*pde, transformer);
 
   fk::vector<TestType> f_val(initial_condition);
-  asgard::matrix_list<TestType> operator_matrices;
+  asgard::kron_operators<TestType> operator_matrices;
 
   TestType E_pot_initial = 0.0;
   TestType E_kin_initial = 0.0;
@@ -1459,7 +1459,7 @@ TEMPLATE_TEST_CASE("IMEX time advance - twostream", "[imex]", double)
   generate_dimension_mass_mat(*pde, transformer);
 
   fk::vector<TestType> f_val(initial_condition);
-  asgard::matrix_list<TestType> operator_matrices;
+  asgard::kron_operators<TestType> operator_matrices;
 
   TestType E_pot_initial = 0.0;
   TestType E_kin_initial = 0.0;
@@ -1592,7 +1592,7 @@ TEMPLATE_TEST_CASE("IMEX time advance - twostream - ASG", "[imex][adapt]",
   generate_dimension_mass_mat(*pde, transformer);
 
   fk::vector<TestType> f_val(initial_condition);
-  asgard::matrix_list<TestType> operator_matrices;
+  asgard::kron_operators<TestType> operator_matrices;
 
   TestType E_pot_initial = 0.0;
   TestType E_kin_initial = 0.0;
@@ -1736,7 +1736,7 @@ TEMPLATE_TEST_CASE("IMEX time advance - relaxation1x1v", "[imex]", test_precs)
   generate_dimension_mass_mat(*pde, transformer);
 
   fk::vector<TestType> f_val(initial_condition);
-  asgard::matrix_list<TestType> operator_matrices;
+  asgard::kron_operators<TestType> operator_matrices;
 
   // -- time loop
   for (int i = 0; i < opts.num_time_steps; ++i)


### PR DESCRIPTION
Mostly moving things around but the kronmult mess is better organized now.

All 3 main methods define the same operator struct
```
template<typename precision>
struct kron_operators
```
That has identical methods for apply, clear, reset-coefficient, get-flops ...

* time-advance and solvers no longer have the "know" which kronmult is in use, there are no kronmult specific directives
    * the solver preconditioner is the exception, that's not implemented in local krnonmult (yet)
* the variations of local/global matrices are no longer interlaced with #ifndef commands
* the code specific to each mode is organized together
* this intrudes into the solver but should be the last kronmult PR to do so