### PR TITLE
removed the remnant of exact-time

### DIFF
--- a/src/adapt.hpp
+++ b/src/adapt.hpp
@@ -52,7 +52,7 @@ public:
   {
     return this->get_initial_condition(
         pde.get_dimensions(),
-        pde.has_analytic_soln() ? pde.exact_time()(0.0) : static_cast<P>(1.0),
+        pde.has_exact_time() ? pde.exact_time(0.0) : static_cast<P>(1.0),
         pde.num_terms(), pde.get_terms(), transformer, cli_opts);
   }
 

--- a/src/pde/pde_advection1.hpp
+++ b/src/pde/pde_advection1.hpp
@@ -19,7 +19,7 @@ class PDE_advection_1d : public PDE<P>
 public:
   PDE_advection_1d(parser const &cli_input)
       : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
-               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               terms_, sources_, exact_vector_funcs_,
                get_dt_, do_poisson_solve_, has_analytic_soln_)
   {}
 
@@ -65,16 +65,9 @@ private:
     return fx;
   }
 
-  static P exact_time(P const time)
-  {
-    ignore(time);
-    return 1.0;
-  }
-
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {
       exact_solution_dim0};
 
-  inline static scalar_func<P> const exact_scalar_func_ = exact_time;
   // =========================================================================
 
   // Sources =================================================================

--- a/src/pde/pde_collisional_landau.hpp
+++ b/src/pde/pde_collisional_landau.hpp
@@ -16,7 +16,7 @@ class PDE_collisional_landau : public PDE<P>
 public:
   PDE_collisional_landau(parser const &cli_input)
       : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
-               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               terms_, sources_, exact_vector_funcs_,
                get_dt_, do_poisson_solve_, has_analytic_soln_, moments_,
                do_collision_operator_)
   {
@@ -479,7 +479,6 @@ private:
                                             terms_7, terms_8, terms_9};
 
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {};
-  inline static scalar_func<P> const exact_scalar_func_               = {};
 
   static P get_dt_(dimension<P> const &dim)
   {

--- a/src/pde/pde_collisional_landau_1x2v.hpp
+++ b/src/pde/pde_collisional_landau_1x2v.hpp
@@ -16,7 +16,7 @@ class PDE_collisional_landau_1x2v : public PDE<P>
 public:
   PDE_collisional_landau_1x2v(parser const &cli_input)
       : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
-               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               terms_, sources_, exact_vector_funcs_,
                get_dt_, do_poisson_solve_, has_analytic_soln_, moments_,
                do_collision_operator_)
   {
@@ -502,8 +502,6 @@ private:
       terms_im_2, terms_im_3, terms_im_4, terms_im_5, terms_im_6};
 
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {};
-
-  inline static scalar_func<P> const exact_scalar_func_ = {};
 
   static P get_dt_(dimension<P> const &dim)
   {

--- a/src/pde/pde_collisional_landau_1x3v.hpp
+++ b/src/pde/pde_collisional_landau_1x3v.hpp
@@ -16,7 +16,7 @@ class PDE_collisional_landau_1x3v : public PDE<P>
 public:
   PDE_collisional_landau_1x3v(parser const &cli_input)
       : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
-               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               terms_, sources_, exact_vector_funcs_,
                get_dt_, do_poisson_solve_, has_analytic_soln_, moments_,
                do_collision_operator_)
   {
@@ -554,8 +554,6 @@ private:
       terms_im_7, terms_im_8, terms_im_9};
 
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {};
-
-  inline static scalar_func<P> const exact_scalar_func_ = {};
 
   static P get_dt_(dimension<P> const &dim)
   {

--- a/src/pde/pde_continuity1.hpp
+++ b/src/pde/pde_continuity1.hpp
@@ -38,7 +38,7 @@ class PDE_continuity_1d : public PDE<P>
 public:
   PDE_continuity_1d(parser const &cli_input)
       : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
-               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               terms_, sources_, exact_vector_funcs_,
                get_dt_, do_poisson_solve_, has_analytic_soln_)
   {}
 
@@ -78,13 +78,9 @@ private:
     return fx;
   }
 
-  static P exact_time(P const time) { return std::sin(time); }
-
-  static fk::vector<P> exact_time_v(fk::vector<P> x, P const time)
+  static fk::vector<P> exact_time(fk::vector<P>, P const time)
   {
-    x.resize(1);
-    x[0] = exact_time(time);
-    return x;
+    return {std::sin(time),};
   }
 
   // specify source functions...
@@ -166,8 +162,6 @@ private:
 
   // define exact soln functions
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {
-      exact_solution_dim0, exact_time_v};
-
-  inline static scalar_func<P> const exact_scalar_func_ = exact_time;
+      exact_solution_dim0, exact_time};
 };
 } // namespace asgard

--- a/src/pde/pde_continuity1.hpp
+++ b/src/pde/pde_continuity1.hpp
@@ -80,7 +80,9 @@ private:
 
   static fk::vector<P> exact_time(fk::vector<P>, P const time)
   {
-    return {std::sin(time),};
+    return {
+        std::sin(time),
+    };
   }
 
   // specify source functions...

--- a/src/pde/pde_continuity2.hpp
+++ b/src/pde/pde_continuity2.hpp
@@ -27,7 +27,7 @@ class PDE_continuity_2d : public PDE<P>
 public:
   PDE_continuity_2d(parser const &cli_input)
       : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
-               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               terms_, sources_, exact_vector_funcs_,
                get_dt_, do_poisson_solve_, has_analytic_soln_)
   {}
 
@@ -84,13 +84,9 @@ private:
     return fx;
   }
 
-  static P exact_time(P const time) { return std::sin(2.0 * time); }
-
-  static fk::vector<P> exact_time_v(fk::vector<P> x, P const time)
+  static fk::vector<P> exact_time(fk::vector<P>, P const time)
   {
-    x.resize(1);
-    x[0] = exact_time(time);
-    return x;
+    return {std::sin(2.0 * time),};
   }
 
   // specify source functions...
@@ -261,8 +257,6 @@ private:
 
   // define exact soln
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {
-      exact_solution_dim0, exact_solution_dim1, exact_time_v};
-
-  inline static scalar_func<P> const exact_scalar_func_ = exact_time;
+      exact_solution_dim0, exact_solution_dim1, exact_time};
 };
 } // namespace asgard

--- a/src/pde/pde_continuity2.hpp
+++ b/src/pde/pde_continuity2.hpp
@@ -87,7 +87,7 @@ private:
   static fk::vector<P> exact_time(fk::vector<P>, P const time)
   {
     return {
-        std::sin(2.0 * time),
+        std::sin(P{2.0} * time),
     };
   }
 

--- a/src/pde/pde_continuity2.hpp
+++ b/src/pde/pde_continuity2.hpp
@@ -86,7 +86,9 @@ private:
 
   static fk::vector<P> exact_time(fk::vector<P>, P const time)
   {
-    return {std::sin(2.0 * time),};
+    return {
+        std::sin(2.0 * time),
+    };
   }
 
   // specify source functions...

--- a/src/pde/pde_continuity3.hpp
+++ b/src/pde/pde_continuity3.hpp
@@ -97,7 +97,7 @@ private:
   static fk::vector<P> exact_time(fk::vector<P>, P const time)
   {
     return {
-        std::sin(2.0 * time),
+        std::sin(P{2.0} * time),
     };
   }
 

--- a/src/pde/pde_continuity3.hpp
+++ b/src/pde/pde_continuity3.hpp
@@ -30,7 +30,7 @@ class PDE_continuity_3d : public PDE<P>
 public:
   PDE_continuity_3d(parser const &cli_input)
       : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
-               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               terms_, sources_, exact_vector_funcs_,
                get_dt_, do_poisson_solve_, has_analytic_soln_)
   {}
 
@@ -94,13 +94,9 @@ private:
     return fx;
   }
 
-  static P exact_time(P const time) { return std::sin(2.0 * time); }
-
-  static fk::vector<P> exact_time_v(fk::vector<P> x, P const time)
+  static fk::vector<P> exact_time(fk::vector<P>, P const time)
   {
-    x.resize(1);
-    x[0] = exact_time(time);
-    return x;
+    return {std::sin(2.0 * time),};
   }
 
   // specify source functions...
@@ -355,8 +351,6 @@ private:
 
   // define exact soln
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {
-      exact_solution_dim0, exact_solution_dim1, exact_solution_dim2, exact_time_v};
-
-  inline static scalar_func<P> const exact_scalar_func_ = exact_time;
+      exact_solution_dim0, exact_solution_dim1, exact_solution_dim2, exact_time};
 };
 } // namespace asgard

--- a/src/pde/pde_continuity3.hpp
+++ b/src/pde/pde_continuity3.hpp
@@ -96,7 +96,9 @@ private:
 
   static fk::vector<P> exact_time(fk::vector<P>, P const time)
   {
-    return {std::sin(2.0 * time),};
+    return {
+        std::sin(2.0 * time),
+    };
   }
 
   // specify source functions...

--- a/src/pde/pde_continuity6.hpp
+++ b/src/pde/pde_continuity6.hpp
@@ -124,19 +124,17 @@ private:
     return fx;
   }
 
-  static P exact_time(P const time) { return std::sin(targ * time); }
-
-  static fk::vector<P> exact_time_v(fk::vector<P> x, P const time)
+  static fk::vector<P> exact_time(fk::vector<P>, P const time)
   {
-    x.resize(1);
-    x[0] = exact_time(time);
-    return x;
+    return {
+        std::sin(targ * time),
+    };
   }
 
   // define exact soln
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {
       exact_solution_x, exact_solution_y, exact_solution_z,
-      exact_solution_vx, exact_solution_vy, exact_solution_vz, exact_time_v};
+      exact_solution_vx, exact_solution_vy, exact_solution_vz, exact_time};
 
   // specify source functions...
 

--- a/src/pde/pde_continuity6.hpp
+++ b/src/pde/pde_continuity6.hpp
@@ -27,7 +27,7 @@ class PDE_continuity_6d : public PDE<P>
 public:
   PDE_continuity_6d(parser const &cli_input)
       : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
-               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               terms_, sources_, exact_vector_funcs_,
                get_dt_, do_poisson_solve_, has_analytic_soln_)
   {}
 
@@ -797,7 +797,5 @@ private:
   /* this corresponds to the aggregation of TERM_ND objects in matlab */
   inline static term_set<P> const terms_ = {terms0_, terms1_, terms2_,
                                             terms3_, terms4_, terms5_};
-
-  inline static scalar_func<P> const exact_scalar_func_ = exact_time;
 };
 } // namespace asgard

--- a/src/pde/pde_diffusion1.hpp
+++ b/src/pde/pde_diffusion1.hpp
@@ -14,7 +14,7 @@ class PDE_diffusion_1d : public PDE<P>
 public:
   PDE_diffusion_1d(parser const &cli_input)
       : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
-               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               terms_, sources_, exact_vector_funcs_,
                get_dt_, do_poisson_solve_, has_analytic_soln_)
   {}
 
@@ -158,18 +158,13 @@ private:
     return fx;
   }
 
-  static fk::vector<P> exact_time(fk::vector<P> x, P const time)
+  static fk::vector<P> exact_time(fk::vector<P>, P const time)
   {
-    x.resize(1);
-    x[0] = source_0_t(time);
-    return x;
+    return {source_0_t(time),};
   }
 
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {
       exact_solution_0, exact_time};
-
-  /* This is not used ever */
-  inline static scalar_func<P> const exact_scalar_func_ = source_0_t;
 
   static P get_dt_(dimension<P> const &dim)
   {

--- a/src/pde/pde_diffusion2.hpp
+++ b/src/pde/pde_diffusion2.hpp
@@ -115,7 +115,9 @@ private:
   static fk::vector<P> exact_time(fk::vector<P>, P const time)
   {
     constexpr P neg_two_pi_squared = static_cast<P>(-2.0 * PI * PI);
-    return {std::exp(neg_two_pi_squared * time),};
+    return {
+        std::exp(neg_two_pi_squared * time),
+    };
   }
 
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {

--- a/src/pde/pde_diffusion2.hpp
+++ b/src/pde/pde_diffusion2.hpp
@@ -14,7 +14,7 @@ class PDE_diffusion_2d : public PDE<P>
 public:
   PDE_diffusion_2d(parser const &cli_input)
       : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
-               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               terms_, sources_, exact_vector_funcs_,
                get_dt_, do_poisson_solve_, has_analytic_soln_)
   {}
 
@@ -112,22 +112,14 @@ private:
     return fx;
   }
 
-  static P exact_time(P const time)
+  static fk::vector<P> exact_time(fk::vector<P>, P const time)
   {
     constexpr P neg_two_pi_squared = static_cast<P>(-2.0 * PI * PI);
-
-    return std::exp(neg_two_pi_squared * time);
-  }
-
-  static fk::vector<P> exact_time_v(fk::vector<P> x, P const time)
-  {
-    x.resize(1);
-    x[0] = exact_time(time);
-    return x;
+    return {std::exp(neg_two_pi_squared * time),};
   }
 
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {
-      exact_solution, exact_solution, exact_time_v};
+      exact_solution, exact_solution, exact_time};
 
   /* This is not used ever */
   static P exact_scalar_func(P const t)
@@ -136,8 +128,6 @@ private:
 
     return std::exp(neg_two_pi_squared * t);
   }
-
-  inline static scalar_func<P> const exact_scalar_func_ = exact_scalar_func;
 
   static P get_dt_(dimension<P> const &dim)
   {

--- a/src/pde/pde_fokkerplanck1_4p3.hpp
+++ b/src/pde/pde_fokkerplanck1_4p3.hpp
@@ -27,7 +27,7 @@ class PDE_fokkerplanck_1d_4p3 : public PDE<P>
 public:
   PDE_fokkerplanck_1d_4p3(parser const &cli_input)
       : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
-               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               terms_, sources_, exact_vector_funcs_,
                get_dt_, do_poisson_solve_, has_analytic_soln_)
   {}
 
@@ -82,12 +82,6 @@ private:
       f(i)          = t1 / t2 * t3;
     }
     return f;
-  }
-
-  static P analytic_solution_time(P const time)
-  {
-    ignore(time);
-    return 1.0;
   }
 
   // specify source functions...
@@ -155,8 +149,5 @@ private:
   // define exact soln functions
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {
       analytic_solution_dim0};
-
-  inline static scalar_func<P> const exact_scalar_func_ =
-      analytic_solution_time;
 };
 } // namespace asgard

--- a/src/pde/pde_fokkerplanck1_4p4.hpp
+++ b/src/pde/pde_fokkerplanck1_4p4.hpp
@@ -29,7 +29,7 @@ class PDE_fokkerplanck_1d_4p4 : public PDE<P>
 public:
   PDE_fokkerplanck_1d_4p4(parser const &cli_input)
       : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
-               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               terms_, sources_, exact_vector_funcs_,
                get_dt_, do_poisson_solve_, has_analytic_soln_)
   {}
 
@@ -95,12 +95,6 @@ private:
       f(i)         = A / (2 * std::sinh(A) * std::exp(A * z(i)));
     }
     return f;
-  }
-
-  static P analytic_solution_time(P const time)
-  {
-    ignore(time);
-    return 1.0;
   }
 
   // specify source functions...
@@ -203,8 +197,5 @@ private:
   // define exact soln functions
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {
       analytic_solution_dim0};
-
-  inline static scalar_func<P> const exact_scalar_func_ =
-      analytic_solution_time;
 };
 } // namespace asgard

--- a/src/pde/pde_fokkerplanck1_4p5.hpp
+++ b/src/pde/pde_fokkerplanck1_4p5.hpp
@@ -30,7 +30,7 @@ class PDE_fokkerplanck_1d_4p5 : public PDE<P>
 public:
   PDE_fokkerplanck_1d_4p5(parser const &cli_input)
       : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
-               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               terms_, sources_, exact_vector_funcs_,
                get_dt_, do_poisson_solve_, has_analytic_soln_)
   {}
 
@@ -98,12 +98,6 @@ private:
       f(i)             = Q * std::exp(A * z(i) + (B / 2) * std::pow(z(i), 2));
     }
     return f;
-  }
-
-  static P analytic_solution_time(P const time)
-  {
-    ignore(time);
-    return 1.0;
   }
 
   // specify source functions...
@@ -229,8 +223,5 @@ private:
   // define exact soln functions
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {
       analytic_solution_dim0};
-
-  inline static scalar_func<P> const exact_scalar_func_ =
-      analytic_solution_time;
 };
 } // namespace asgard

--- a/src/pde/pde_fokkerplanck1_pitch_C.hpp
+++ b/src/pde/pde_fokkerplanck1_pitch_C.hpp
@@ -38,7 +38,7 @@ class PDE_fokkerplanck_1d_pitch_C : public PDE<P>
 public:
   PDE_fokkerplanck_1d_pitch_C(parser const &cli_input)
       : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
-               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               terms_, sources_, exact_vector_funcs_,
                get_dt_, do_poisson_solve_, has_analytic_soln_)
   {}
 
@@ -86,12 +86,6 @@ private:
     }
 
     return f;
-  }
-
-  static P analytic_solution_time(P const time)
-  {
-    ignore(time);
-    return 1.0;
   }
 
   // specify source functions...
@@ -186,8 +180,5 @@ private:
   // define exact soln functions
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {
       analytic_solution_dim0};
-
-  inline static scalar_func<P> const exact_scalar_func_ =
-      analytic_solution_time;
 };
 } // namespace asgard

--- a/src/pde/pde_fokkerplanck1_pitch_E.hpp
+++ b/src/pde/pde_fokkerplanck1_pitch_E.hpp
@@ -38,7 +38,7 @@ class PDE_fokkerplanck_1d_pitch_E : public PDE<P>
 public:
   PDE_fokkerplanck_1d_pitch_E(parser const &cli_input)
       : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
-               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               terms_, sources_, exact_vector_funcs_,
                get_dt_, do_poisson_solve_, has_analytic_soln_)
   {}
 
@@ -93,12 +93,6 @@ private:
       f(i) = t1 / t2 * t3;
     }
     return f;
-  }
-
-  static P analytic_solution_time(P const time)
-  {
-    ignore(time);
-    return 1.0;
   }
 
   // specify source functions...
@@ -179,8 +173,5 @@ private:
   // define exact soln functions
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {
       analytic_solution_dim0};
-
-  inline static scalar_func<P> const exact_scalar_func_ =
-      analytic_solution_time;
 };
 } // namespace asgard

--- a/src/pde/pde_fokkerplanck2_complete.hpp
+++ b/src/pde/pde_fokkerplanck2_complete.hpp
@@ -50,7 +50,7 @@ class PDE_fokkerplanck_2d_complete : public PDE<P>
 public:
   PDE_fokkerplanck_2d_complete(parser const &cli_input)
       : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
-               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               terms_, sources_, exact_vector_funcs_,
                get_dt_, do_poisson_solve_, has_analytic_soln_)
   {}
 
@@ -794,6 +794,5 @@ private:
   // -------------------------------------------------
 
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {};
-  inline static scalar_func<P> const exact_scalar_func_               = {};
 };
 } // namespace asgard

--- a/src/pde/pde_relaxation_1x1v.hpp
+++ b/src/pde/pde_relaxation_1x1v.hpp
@@ -18,7 +18,7 @@ class PDE_relaxation_1x1v : public PDE<P>
 public:
   PDE_relaxation_1x1v(parser const &cli_input)
       : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
-               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               terms_, sources_, exact_vector_funcs_,
                get_dt_, do_poisson_solve_, has_analytic_soln_, moments_,
                do_collision_operator_)
   {
@@ -321,8 +321,6 @@ private:
 
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {
       exact_dim_x_0, exact_dim_v_0};
-
-  inline static scalar_func<P> const exact_scalar_func_ = {};
 
   static P get_dt_(dimension<P> const &dim)
   {

--- a/src/pde/pde_relaxation_1x2v.hpp
+++ b/src/pde/pde_relaxation_1x2v.hpp
@@ -18,7 +18,7 @@ class PDE_relaxation_1x2v : public PDE<P>
 public:
   PDE_relaxation_1x2v(parser const &cli_input)
       : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
-               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               terms_, sources_, exact_vector_funcs_,
                get_dt_, do_poisson_solve_, has_analytic_soln_, moments_,
                do_collision_operator_)
   {
@@ -443,8 +443,6 @@ private:
 
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {
       exact_dim_x_0, exact_dim_v_0, exact_dim_v_1};
-
-  inline static scalar_func<P> const exact_scalar_func_ = {};
 
   static P get_dt_(dimension<P> const &dim)
   {

--- a/src/pde/pde_relaxation_1x3v.hpp
+++ b/src/pde/pde_relaxation_1x3v.hpp
@@ -18,7 +18,7 @@ class PDE_relaxation_1x3v : public PDE<P>
 public:
   PDE_relaxation_1x3v(parser const &cli_input)
       : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
-               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               terms_, sources_, exact_vector_funcs_,
                get_dt_, do_poisson_solve_, has_analytic_soln_, moments_,
                do_collision_operator_)
   {
@@ -614,8 +614,6 @@ private:
 
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {
       exact_dim_x_0, exact_dim_v_0, exact_dim_v_1, exact_dim_v_2};
-
-  inline static scalar_func<P> const exact_scalar_func_ = {};
 
   static P get_dt_(dimension<P> const &dim)
   {

--- a/src/pde/pde_riemann_1x2v.hpp
+++ b/src/pde/pde_riemann_1x2v.hpp
@@ -18,7 +18,7 @@ class PDE_riemann_1x2v : public PDE<P>
 public:
   PDE_riemann_1x2v(parser const &cli_input)
       : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
-               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               terms_, sources_, exact_vector_funcs_,
                get_dt_, do_poisson_solve_, has_analytic_soln_, moments_,
                do_collision_operator_)
   {
@@ -474,8 +474,6 @@ private:
   }
 
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {};
-
-  inline static scalar_func<P> const exact_scalar_func_ = {};
 
   static P get_dt_(dimension<P> const &dim)
   {

--- a/src/pde/pde_riemann_1x3v.hpp
+++ b/src/pde/pde_riemann_1x3v.hpp
@@ -18,7 +18,7 @@ class PDE_riemann_1x3v : public PDE<P>
 public:
   PDE_riemann_1x3v(parser const &cli_input)
       : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
-               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               terms_, sources_, exact_vector_funcs_,
                get_dt_, do_poisson_solve_, has_analytic_soln_, moments_,
                do_collision_operator_)
   {
@@ -519,8 +519,6 @@ private:
   }
 
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {};
-
-  inline static scalar_func<P> const exact_scalar_func_ = {};
 
   static P get_dt_(dimension<P> const &dim)
   {

--- a/src/pde/pde_two_stream.hpp
+++ b/src/pde/pde_two_stream.hpp
@@ -45,7 +45,6 @@ public:
                                  std::vector<term<P>>{E_mass_x_neg, div_v_up}},
                      std::vector<source<P>>{},       // no sources
                      std::vector<md_func_type<P>>{}, // no exact solution
-                     scalar_func<P>{},               // no exact time
                      get_dt_, do_poisson_solve, has_analytic_soln,
                      std::vector<moment<P>>{moment0, moment1, moment2}, // moments
                      do_collision_operator);

--- a/src/pde/pde_vlasov_lb_full_f.hpp
+++ b/src/pde/pde_vlasov_lb_full_f.hpp
@@ -16,7 +16,7 @@ class PDE_vlasov_lb : public PDE<P>
 public:
   PDE_vlasov_lb(parser const &cli_input)
       : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
-               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               terms_, sources_, exact_vector_funcs_,
                get_dt_, do_poisson_solve_, has_analytic_soln_, moments_)
   {
     param_manager.add_parameter(parameter<P>{"n", n});
@@ -356,7 +356,6 @@ private:
                                             terms_5};
 
   inline static std::vector<vector_func<P>> const exact_vector_funcs_ = {};
-  inline static scalar_func<P> const exact_scalar_func_               = {};
 
   static P get_dt_(dimension<P> const &dim)
   {

--- a/src/pde_tests.cpp
+++ b/src/pde_tests.cpp
@@ -49,7 +49,7 @@ void test_exact_solution(PDE<P> const &pde, std::filesystem::path base_dir,
 
   P const gold = read_scalar_from_txt_file(
       base_dir.replace_filename(filename + "exact_time.dat"));
-  P const fx = pde.exact_time()(time);
+  P const fx = pde.exact_time(time);
   relaxed_fp_comparison(fx, gold, pde_eps_multiplier);
 }
 


### PR DESCRIPTION
Closes #673

The exact time function was still in use when setting the initial conditions (and only when setting the initial conditions).

The worst part is that in the absence of an analytic solution the initial condition default to time `1.0` as opposed to `0.0`. There is something in the fokkerplank pdes that seems out of line.