### PR TITLE
allows for single level to be defined in the cli

### DIFF
--- a/src/pde/pde_base.hpp
+++ b/src/pde/pde_base.hpp
@@ -652,7 +652,7 @@ public:
     // modify for appropriate level/degree
     // if default lev/degree not used
     auto const user_levels = cli_input.get_starting_levels().size();
-    if (user_levels != 0 && user_levels != num_dims_)
+    if (user_levels >= 2 && user_levels != num_dims_)
     {
       std::cerr << "failed to parse dimension-many starting levels - parsed "
                 << user_levels << " levels\n";
@@ -667,6 +667,12 @@ public:
         expect(num_levels >= 0);
         d.set_level(num_levels);
       }
+    }
+    else if (user_levels == 1)
+    {
+      auto const num_levels = cli_input.get_starting_levels()[0];
+      for (dimension<P> &d : dimensions_)
+        d.set_level(num_levels);
     }
 
     auto const num_active_terms = cli_input.get_active_terms().size();

--- a/src/program_options.cpp
+++ b/src/program_options.cpp
@@ -470,8 +470,8 @@ bool parser::do_poisson_solve() const { return do_poisson; }
 bool parser::do_adapt_levels() const { return do_adapt; }
 bool parser::do_restart() const { return restart_file != NO_USER_VALUE_STR; }
 
-fk::vector<int> parser::get_starting_levels() const { return starting_levels; }
-fk::vector<int> parser::get_active_terms() const { return active_terms; }
+fk::vector<int> const &parser::get_starting_levels() const { return starting_levels; }
+fk::vector<int> const &parser::get_active_terms() const { return active_terms; }
 int parser::get_degree() const { return degree; }
 int parser::get_max_level() const { return max_level; }
 int parser::get_mixed_grid_group() const { return mixed_grid_group; }

--- a/src/program_options.hpp
+++ b/src/program_options.hpp
@@ -312,8 +312,8 @@ public:
   bool do_adapt_levels() const;
   bool do_restart() const;
 
-  fk::vector<int> get_starting_levels() const;
-  fk::vector<int> get_active_terms() const;
+  fk::vector<int>  const &get_starting_levels() const;
+  fk::vector<int>  const &get_active_terms() const;
 
   int get_degree() const;
   int get_max_level() const;


### PR DESCRIPTION
closes  #367

I've been meaning to do this in a while, now can pass single number to the `-l` option, e.g.,
```
./asgard -p continuity_6 -l 6
```