### PR TITLE
max level sets automatically

### DIFF
--- a/src/adapt_tests.cpp
+++ b/src/adapt_tests.cpp
@@ -127,6 +127,7 @@ TEMPLATE_TEST_CASE("adapt - 1d, scattered coarsen/refine", "[adapt]",
                degree);
   parser_mod::set(parse, parser_mod::adapt_threshold, adapt_threshold);
   parser_mod::set(parse, parser_mod::use_linf_nrm, use_linf_nrm);
+  parser_mod::set(parse, parser_mod::max_level, 8);
   test_adapt<TestType>(parse, adapt_base_dir / "continuity1_l4_d3_");
 }
 
@@ -144,6 +145,7 @@ TEMPLATE_TEST_CASE("adapt - 2d, all zero", "[adapt]", test_precs)
                degree);
   parser_mod::set(parse, parser_mod::adapt_threshold, adapt_threshold);
   parser_mod::set(parse, parser_mod::use_linf_nrm, use_linf_nrm);
+  parser_mod::set(parse, parser_mod::max_level, 8);
 
   // temporarily disable test for MPI due to table elements < num ranks
   if (get_num_ranks() == 1)
@@ -167,6 +169,7 @@ TEMPLATE_TEST_CASE("adapt - 3d, scattered, contiguous refine/adapt", "[adapt]",
                degree);
   parser_mod::set(parse, parser_mod::adapt_threshold, adapt_threshold);
   parser_mod::set(parse, parser_mod::use_linf_nrm, use_linf_nrm);
+  parser_mod::set(parse, parser_mod::max_level, 8);
   test_adapt<TestType>(parse, adapt_base_dir / "continuity3_l4_d4_");
 }
 
@@ -215,6 +218,7 @@ TEMPLATE_TEST_CASE("initial - diffusion 1d", "[adapt]", test_precs)
   parser_mod::set(parse, parser_mod::do_adapt, true);
   parser_mod::set(parse, parser_mod::adapt_threshold, adapt_threshold);
   parser_mod::set(parse, parser_mod::use_linf_nrm, use_linf_nrm);
+  parser_mod::set(parse, parser_mod::max_level, 8);
 
   // don't test this in the MPI case -- too small to split table
   if (get_num_ranks() == 1)
@@ -239,6 +243,7 @@ TEMPLATE_TEST_CASE("initial - diffusion 2d", "[adapt]", test_precs)
   parser_mod::set(parse, parser_mod::do_adapt, true);
   parser_mod::set(parse, parser_mod::adapt_threshold, adapt_threshold);
   parser_mod::set(parse, parser_mod::use_linf_nrm, use_linf_nrm);
+  parser_mod::set(parse, parser_mod::max_level, 8);
 
   test_initial<TestType>(parse,
                          adapt_base_dir / "diffusion2_l2_d3_initial.dat");

--- a/src/program_options.cpp
+++ b/src/program_options.cpp
@@ -100,6 +100,11 @@ parser::parser(int argc, char const *const *argv)
     valid = false;
   }
 
+  // default to max-level 8 but if max level is not explicitly given
+  // and the active levels exceed 8, then bump up the max-level
+  bool const missing_max_level = (max_level == DEFAULT_MAX_LEVEL);
+  max_level = std::max(max_level, 8);
+
   for (int i = 1; i < argc; i++)
   {
     this->cli_opts.push_back(std::string(argv[i]));
@@ -175,6 +180,10 @@ parser::parser(int argc, char const *const *argv)
     starting_levels.resize(starting_lev.size()) = starting_lev;
     // check that at least one level is greater than 0
     int lev_sum = 0;
+    if (missing_max_level)
+      for (auto const lev : starting_levels)
+        max_level = std::max(max_level, lev);
+
     for (auto const lev : starting_levels)
     {
       if (lev < 0)
@@ -438,6 +447,10 @@ parser::parser(int argc, char const *const *argv)
           << '\n';
       valid = false;
     }
+    if (missing_max_level)
+      for (int i = 0; i < max_adapt_levels.size(); ++i)
+        max_level = std::max(max_level, max_adapt_levels[i]);
+
     for (int i = 0; i < max_adapt_levels.size(); ++i)
     {
       if (max_adapt_levels[i] < 0)

--- a/src/program_options.cpp
+++ b/src/program_options.cpp
@@ -103,6 +103,7 @@ parser::parser(int argc, char const *const *argv)
   // default to max-level 8 but if max level is not explicitly given
   // and the active levels exceed 8, then bump up the max-level
   bool const missing_max_level = (max_level == DEFAULT_MAX_LEVEL);
+
   max_level = std::max(max_level, 8);
 
   for (int i = 1; i < argc; i++)

--- a/src/program_options.hpp
+++ b/src/program_options.hpp
@@ -270,7 +270,11 @@ public:
         kmode(kmode_in), gmres_tolerance(gmres_tolerance_in),
         gmres_inner_iterations(gmres_inner_iterations_in),
         gmres_outer_iterations(gmres_outer_iterations_in),
-        max_adapt_levels(max_adapt_levels_in), restart_file(restart_file_in){};
+        max_adapt_levels(max_adapt_levels_in), restart_file(restart_file_in)
+  {
+    for (auto l : starting_levels_in)
+      max_level = std::max(max_level, l);
+  }
 
   explicit parser(
       std::string const &pde_choice_in, fk::vector<int> starting_levels_in,

--- a/src/program_options.hpp
+++ b/src/program_options.hpp
@@ -212,7 +212,7 @@ public:
 
   static auto constexpr DEFAULT_CFL               = 0.01;
   static auto constexpr DEFAULT_ADAPT_THRESH      = 1e-3;
-  static auto constexpr DEFAULT_MAX_LEVEL         = 8;
+  static auto constexpr DEFAULT_MAX_LEVEL         = -1;
   static auto constexpr DEFAULT_MIXED_GRID_GROUP  = -1;
   static auto constexpr DEFAULT_TIME_STEPS        = 10;
   static auto constexpr DEFAULT_WRITE_FREQ        = 0;

--- a/src/program_options_tests.cpp
+++ b/src/program_options_tests.cpp
@@ -111,7 +111,8 @@ TEST_CASE("parser constructor/getters", "[program_options]")
 
     REQUIRE(p.get_degree() == def_degree);
     REQUIRE(p.get_starting_levels() == def_levels);
-    REQUIRE(p.get_max_level() == def_max_level);
+    REQUIRE(def_max_level == -1);
+    REQUIRE(p.get_max_level() == 8);
     REQUIRE(p.get_time_steps() == def_num_steps);
     REQUIRE(p.get_wavelet_output_freq() == def_write_freq);
     REQUIRE(p.get_realspace_output_freq() == def_realspace_freq);
@@ -177,7 +178,7 @@ TEST_CASE("parser constructor/getters", "[program_options]")
     std::cerr.setstate(std::ios_base::failbit);
     parser const p = make_parser({"-l=3", "-m=2"});
     std::cerr.clear();
-    REQUIRE(!p.is_valid());
+    REQUIRE(p.is_valid());
   }
   SECTION("negative cfl")
   {

--- a/src/time_advance_tests.cpp
+++ b/src/time_advance_tests.cpp
@@ -140,6 +140,8 @@ parser make_basic_parser(std::string const &pde_choice,
   parser_mod::set(parse, parser_mod::use_full_grid, full_grid);
   parser_mod::set(parse, parser_mod::num_time_steps, num_time_steps);
   parser_mod::set(parse, parser_mod::cfl, cfl);
+  // lots of tests assume max-level 8, which is an old behavior
+  parser_mod::set(parse, parser_mod::max_level, 8);
   return parse;
 }
 parser make_basic_parser(std::string const &pde_choice,


### PR DESCRIPTION
The old behavior is that `max_level` or `-m` defaults to `8` and has to be manually set when the starting level `-l` exceeds 8.

The new behavior is to set `max_level` to 8 but if no value is explicitly given, then `max-level` will automatically assume the largest level provided by the starting or refine levels.

In the new way, if `-m` is not set and the starting level is more than 8, then the refinement is done as a subset of a full tensor grid.

Refinement runs probably want to explicitly specify `-m` but this is very useful for non-adaptive tests.