### PR TITLE
Interpolation in pde

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,7 +302,6 @@ set (components
      tensors
      sparse
      time_advance
-     tools
      transformations
      asgard_field
      asgard_dimension
@@ -313,6 +312,7 @@ set (components
      asgard_indexset
      asgard_interpolation1d
      asgard_interpolation
+     asgard_tools
      asgard
 )
 

--- a/src/asgard.hpp
+++ b/src/asgard.hpp
@@ -2,11 +2,10 @@
 
 #include "batch.hpp"
 
-#include "build_info.hpp"
+#include "asgard_tools.hpp"
 #include "coefficients.hpp"
 #include "distribution.hpp"
 #include "elements.hpp"
-#include "tools.hpp"
 
 #ifdef ASGARD_IO_HIGHFIVE
 #include "io.hpp"

--- a/src/asgard_dimension.hpp
+++ b/src/asgard_dimension.hpp
@@ -1,22 +1,10 @@
 #pragma once
 
-#include <algorithm>
-#include <cmath>
-#include <functional>
-#include <iostream>
-#include <limits.h>
-#include <map>
-#include <memory>
-#include <string>
-#include <typeinfo>
-#include <vector>
-
 #include "asgard_matrix.hpp"
 #include "asgard_vector.hpp"
 #include "fast_math.hpp"
 #include "matlab_utilities.hpp"
 #include "program_options.hpp"
-#include "tools.hpp"
 
 namespace asgard
 {

--- a/src/asgard_grid_1d.hpp
+++ b/src/asgard_grid_1d.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "elements.hpp"
+#include "fast_math.hpp"
 
 namespace asgard
 {

--- a/src/asgard_indexset.hpp
+++ b/src/asgard_indexset.hpp
@@ -1,12 +1,6 @@
 #pragma once
 
-#include <algorithm>
-#include <memory>
-#include <numeric>
-#include <vector>
-
 #include "asgard_grid_1d.hpp"
-#include "tools.hpp"
 
 namespace asgard
 {
@@ -141,14 +135,6 @@ inline vector2d<int> asg2tsg_convert(int num_dimensions, int64_t num_indexes,
   for (int64_t i = 0; i < num_indexes; i++)
     asg2tsg_convert(num_dimensions, asg + 2 * num_dimensions * i, tsg[i]);
   return tsg;
-}
-//! \brief Helper to compute integer power function, exact but not cheap.
-inline int64_t int_pow(int64_t base, int pow)
-{
-  int64_t result = 1;
-  for (int p = 0; p < pow; p++)
-    result *= base;
-  return result;
 }
 
 /*!

--- a/src/asgard_interpolation1d.cpp
+++ b/src/asgard_interpolation1d.cpp
@@ -9,8 +9,8 @@ struct linear
 {
   static P constexpr s3 = 1.73205080756887729; // sqrt(3.0)
   // projection basis
-  static P plag0(P) { return 1; }
-  static P plag1(P x) { return 2 * s3 * x - s3; }
+  static P pleg0(P) { return 1; }
+  static P pleg1(P x) { return 2 * s3 * x - s3; }
   static P pwav0L(P x) { return s3 * (1 - 4 * x); }
   static P pwav0R(P x) { return s3 * (-3 + 4 * x); }
   static P pwav1L(P x) { return -1 + 6 * x; }
@@ -82,8 +82,8 @@ struct linear
 template<typename P>
 struct linear_integrator
 {
-  static constexpr auto plag0  = linear<P>::plag0;
-  static constexpr auto plag1  = linear<P>::plag1;
+  static constexpr auto pleg0  = linear<P>::pleg0;
+  static constexpr auto pleg1  = linear<P>::pleg1;
   static constexpr auto pwav0L = linear<P>::pwav0L;
   static constexpr auto pwav0R = linear<P>::pwav0R;
   static constexpr auto pwav1L = linear<P>::pwav1L;
@@ -109,26 +109,26 @@ struct linear_integrator
   // level 0 vs. level 0
   static constexpr void lb00(P mat[])
   {
-    mat[0] = w * (plag0(x0) * ibas0(x0) + plag0(x1) * ibas0(x1));
-    mat[1] = w * (plag1(x0) * ibas0(x0) + plag1(x1) * ibas0(x1));
-    mat[2] = w * (plag0(x0) * ibas1(x0) + plag0(x1) * ibas1(x1));
-    mat[3] = w * (plag1(x0) * ibas1(x0) + plag1(x1) * ibas1(x1));
+    mat[0] = w * (pleg0(x0) * ibas0(x0) + pleg0(x1) * ibas0(x1));
+    mat[1] = w * (pleg1(x0) * ibas0(x0) + pleg1(x1) * ibas0(x1));
+    mat[2] = w * (pleg0(x0) * ibas1(x0) + pleg0(x1) * ibas1(x1));
+    mat[3] = w * (pleg1(x0) * ibas1(x0) + pleg1(x1) * ibas1(x1));
   }
   // projection legendre basis (level 0) vs. interpolation level 1
   static constexpr void li01(P mat[])
   {
-    mat[0] = wL * (plag0(x0L) * iwav0L(x0L) + plag0(x1L) * iwav0L(x1L));
-    mat[1] = wL * (plag1(x0L) * iwav0L(x0L) + plag1(x1L) * iwav0L(x1L));
-    mat[2] = wR * (plag0(x0R) * iwav1R(x0R) + plag0(x1R) * iwav1R(x1R));
-    mat[3] = wR * (plag1(x0R) * iwav1R(x0R) + plag1(x1R) * iwav1R(x1R));
+    mat[0] = wL * (pleg0(x0L) * iwav0L(x0L) + pleg0(x1L) * iwav0L(x1L));
+    mat[1] = wL * (pleg1(x0L) * iwav0L(x0L) + pleg1(x1L) * iwav0L(x1L));
+    mat[2] = wR * (pleg0(x0R) * iwav1R(x0R) + pleg0(x1R) * iwav1R(x1R));
+    mat[3] = wR * (pleg1(x0R) * iwav1R(x0R) + pleg1(x1R) * iwav1R(x1R));
   }
   // projection legendre basis (level 0) vs. interpolation level x
   static constexpr void li0x(P xl, P scale, std::array<P, 4> &mat)
   {
-    mat[0] = wL * (plag0(xl + scale * x0L) * iwav0L(x0L) + plag0(xl + scale * x1L) * iwav0L(x1L));
-    mat[1] = wL * (plag1(xl + scale * x0L) * iwav0L(x0L) + plag1(xl + scale * x1L) * iwav0L(x1L));
-    mat[2] = wR * (plag0(xl + scale * x0R) * iwav1R(x0R) + plag0(xl + scale * x1R) * iwav1R(x1R));
-    mat[3] = wR * (plag1(xl + scale * x0R) * iwav1R(x0R) + plag1(xl + scale * x1R) * iwav1R(x1R));
+    mat[0] = wL * (pleg0(xl + scale * x0L) * iwav0L(x0L) + pleg0(xl + scale * x1L) * iwav0L(x1L));
+    mat[1] = wL * (pleg1(xl + scale * x0L) * iwav0L(x0L) + pleg1(xl + scale * x1L) * iwav0L(x1L));
+    mat[2] = wR * (pleg0(xl + scale * x0R) * iwav1R(x0R) + pleg0(xl + scale * x1R) * iwav1R(x1R));
+    mat[3] = wR * (pleg1(xl + scale * x0R) * iwav1R(x0R) + pleg1(xl + scale * x1R) * iwav1R(x1R));
   }
   // projection basis (level 1) vs. interpolation level 0
   static constexpr void wb10(P mat[])
@@ -200,22 +200,20 @@ struct linear_integrator
 
 template<int order, typename precision>
 void wavelet_interp1d<order, precision>::make_wavelet_wmat0(
-    std::array<precision, pterms> const &x,
-    std::array<precision, matsize> &mat)
+    std::array<precision, pterms> const &x, precision mat[])
 {
   if constexpr (order == 1)
   {
-    mat[0] = linear<precision>::plag0(x[0]);
-    mat[1] = linear<precision>::plag0(x[1]);
-    mat[2] = linear<precision>::plag1(x[0]);
-    mat[3] = linear<precision>::plag1(x[1]);
+    mat[0] = linear<precision>::pleg0(x[0]);
+    mat[1] = linear<precision>::pleg0(x[1]);
+    mat[2] = linear<precision>::pleg1(x[0]);
+    mat[3] = linear<precision>::pleg1(x[1]);
   }
 }
 
 template<int order, typename precision>
 void wavelet_interp1d<order, precision>::make_wavelet_imat0(
-    std::array<precision, pterms> const &x,
-    std::array<precision, matsize> &mat)
+    std::array<precision, pterms> const &x, precision mat[])
 {
   if constexpr (order == 1)
   {
@@ -228,8 +226,7 @@ void wavelet_interp1d<order, precision>::make_wavelet_imat0(
 
 template<int order, typename precision>
 void wavelet_interp1d<order, precision>::make_wavelet_wmat(
-    std::array<precision, pterms> const &x,
-    std::array<precision, matsize> &mat)
+    std::array<precision, pterms> const &x, precision mat[])
 {
   if constexpr (order == 1)
   {
@@ -249,8 +246,7 @@ void wavelet_interp1d<order, precision>::make_wavelet_wmat(
 
 template<int order, typename precision>
 void wavelet_interp1d<order, precision>::make_wavelet_imat(
-    std::array<precision, pterms> const &x,
-    std::array<precision, matsize> &mat)
+    std::array<precision, pterms> const &x, precision mat[])
 {
   if constexpr (order == 1)
   {
@@ -268,11 +264,14 @@ void wavelet_interp1d<order, precision>::make_wavelet_imat(
   }
 }
 
+// the algorithms behind the 3 prepare methods are similar
+// the ideal is to allocate the matrix and write over the blocks
+// the goal is to do so sequentially with minimal indexing work
 template<int order, typename precision>
-void wavelet_interp1d<order, precision>::prepare_wmatrix()
+void wavelet_interp1d<order, precision>::prepare_proj2node()
 {
-  eval_matrix.resize(conn->num_connections() * matsize);
-  auto em = eval_matrix.begin();
+  proj2node_.resize(conn->num_connections() * matsize);
+  auto em = proj2node_.data();
 
   // functions 0/1 at nodes 0/1
   std::array<precision, matsize> local_mat;
@@ -281,23 +280,18 @@ void wavelet_interp1d<order, precision>::prepare_wmatrix()
 
   for (int row = 0; row < conn->num_rows(); row++)
   {
-    for (int i = 0; i < pterms; i++)
-      x[i] = nodes[pterms * row + i];
+    std::copy_n(nodes_.begin() + pterms * row, pterms, x.begin());
 
-    // cell 0 is always connected
-    make_wavelet_wmat0(x, local_mat);
-    em = std::copy(local_mat.begin(), local_mat.end(), em);
-    //eval_matrix.insert(eval_matrix.end(), local_mat.begin(), local_mat.end());
+    // cells 0 and 1 are always connected
+    make_wavelet_wmat0(x, em);
+    em += matsize;
+    make_wavelet_wmat(x, em);
+    em += matsize;
 
-    // cell 1 is always connected
-    make_wavelet_wmat(x, local_mat);
-    em = std::copy(local_mat.begin(), local_mat.end(), em);
-    //eval_matrix.insert(eval_matrix.end(), local_mat.begin(), local_mat.end());
-
-    int level  = 1; // keep track of which level the cell belong
     int lbegin = 2; // first cell on each level
 
-    precision scale = s2;
+    precision scale     = s2;
+    precision cell_size = 0.5;
 
     // using the wavelet functions
     int const row_start = conn->row_begin(row) + 2;
@@ -306,16 +300,13 @@ void wavelet_interp1d<order, precision>::prepare_wmatrix()
     {
       int const col = (*conn)[c]; // connected cell
 
-      // get the level for the current cell
-      // void intlog2 since cells in conn are ordered
-      while (4 * level <= col)
+      // move to the next level
+      while (col >= 2 * lbegin)
       {
-        ++level;
         lbegin *= 2;
         scale *= s2;
+        cell_size *= 0.5;
       }
-
-      precision cell_size = std::pow(precision{0.5}, level);
 
       precision xl = cell_size * (col - lbegin);
 
@@ -323,7 +314,7 @@ void wavelet_interp1d<order, precision>::prepare_wmatrix()
       for (int i = 0; i < pterms; i++)
         nx[i] = (x[i] - xl) / cell_size;
 
-      make_wavelet_wmat(nx, local_mat);
+      make_wavelet_wmat(nx, local_mat.data());
       for (int i = 0; i < pterms; i++)
         if (nx[i] < precision{0} or nx[i] > precision{1})
           for (int j = 0; j < pterms; j++)
@@ -338,9 +329,13 @@ void wavelet_interp1d<order, precision>::prepare_wmatrix()
 }
 
 template<int order, typename precision>
-void wavelet_interp1d<order, precision>::prepare_imatrix()
+void wavelet_interp1d<order, precision>::prepare_node2hier()
 {
-  interp_matrix.resize(conn->num_connections() * matsize);
+  node2hier_.resize(conn->num_connections() * matsize);
+
+  // computing the hierarchical coefficients uses only the lower triangular
+  // part of the connectivity pattern with implicit identity blocks
+  // along the diagona
 
   // functions 0/1 at nodes 0/1
   std::array<precision, matsize> local_mat;
@@ -348,30 +343,29 @@ void wavelet_interp1d<order, precision>::prepare_imatrix()
   std::array<precision, pterms> nx;
 
   // row zero is irrelevant (won't be used)
-  auto em = interp_matrix.begin() + matsize * conn->row_begin(1);
+  auto em = node2hier_.data() + matsize * conn->row_begin(1);
+
   // row one is trivial as it contains only one block
-  for (int i = 0; i < pterms; i++)
-    x[i] = nodes[pterms + i];
-  make_wavelet_imat0(x, local_mat);
-  std::copy(local_mat.begin(), local_mat.end(), em);
+  std::copy_n(nodes_.begin() + pterms, pterms, x.begin());
+  make_wavelet_imat0(x, em);
   // jump to row 2
-  em = interp_matrix.begin() + matsize * (conn->row_begin(2));
+  em = node2hier_.data() + matsize * conn->row_begin(2);
 
   for (int row = 2; row < conn->num_rows(); row++)
   {
-    for (int i = 0; i < pterms; i++)
-      x[i] = nodes[pterms * row + i];
+    std::copy_n(nodes_.begin() + row * pterms, pterms, x.begin());
 
     // cell 0 is always connected
-    make_wavelet_imat0(x, local_mat);
-    em = std::copy(local_mat.begin(), local_mat.end(), em);
+    make_wavelet_imat0(x, em);
+    em += matsize;
 
     // cell 1 is always connected
-    make_wavelet_imat(x, local_mat);
-    em = std::copy(local_mat.begin(), local_mat.end(), em);
+    make_wavelet_imat(x, em);
+    em += matsize;
 
-    int level  = 1; // keep track of which level the cell belong
-    int lbegin = 2; // first cell on each level
+    int lbegin = 2; // level begin, first cell on each level
+
+    precision cell_size = 0.5;
 
     int const row_start = conn->row_begin(row) + 2;
     int const row_diag  = conn->row_diag(row);
@@ -379,15 +373,12 @@ void wavelet_interp1d<order, precision>::prepare_imatrix()
     {
       int const col = (*conn)[c]; // connected cell
 
-      // get the level for the current cell
-      // void intlog2 since cells in conn are ordered
-      if (4 * level <= col)
+      // if reached the next leve, adjust constants
+      if (col >= 2 * lbegin)
       {
-        ++level;
-        lbegin *= 2;
+        lbegin *= 2;      // adjust starting index
+        cell_size *= 0.5; // cells shrink in size
       }
-
-      precision cell_size = std::pow(precision{0.5}, level);
 
       precision xl = cell_size * (col - lbegin);
 
@@ -395,7 +386,7 @@ void wavelet_interp1d<order, precision>::prepare_imatrix()
       for (int i = 0; i < pterms; i++)
         nx[i] = (x[i] - xl) / cell_size;
 
-      make_wavelet_imat(nx, local_mat);
+      make_wavelet_imat(nx, local_mat.data());
       for (int i = 0; i < pterms; i++)
         if (nx[i] < precision{0} or nx[i] > precision{1})
           for (int j = 0; j < pterms; j++)
@@ -404,37 +395,37 @@ void wavelet_interp1d<order, precision>::prepare_imatrix()
       em = std::copy(local_mat.begin(), local_mat.end(), em);
     }
 
+    // ignore the rest of the pattern, won't be used
     em += matsize * (conn->row_end(row) - row_diag);
   }
-  expect(em == interp_matrix.end());
+  expect(em == (node2hier_.data() + node2hier_.size()));
 }
 
 template<int order, typename precision>
-void wavelet_interp1d<order, precision>::prepare_iematrix()
+void wavelet_interp1d<order, precision>::prepare_hier2proj()
 {
-  ie_matrix.resize(conn->num_connections() * matsize);
+  hier2proj_.resize(conn->num_connections() * matsize);
 
   // unscaled values for the integrals
   std::array<precision, matsize> local_mat;
 
   // row zero, first two cells have global support
-  linear_integrator<precision>::lb00(ie_matrix.data());
-  linear_integrator<precision>::li01(ie_matrix.data() + matsize);
+  linear_integrator<precision>::lb00(hier2proj_.data());
+  linear_integrator<precision>::li01(hier2proj_.data() + matsize);
 
-  auto em = ie_matrix.begin() + 2 * matsize;
+  auto em = hier2proj_.data() + 2 * matsize;
 
   // if a block is already computed in local_mat, scale by s and add to
-  // the ie_matrix using the iterator em
+  // the hier2proj using the iterator em
   auto add_block = [&](precision s)
       -> void {
 #pragma omp simd
     for (int i = 0; i < matsize; i++)
-      *(em + i) = local_mat[i] * s;
+      em[i] = local_mat[i] * s;
     em += matsize;
   };
 
-  int level  = 2;
-  int lbegin = 2;
+  int lbegin = 2; // level begin index
 
   precision w = 0.5; // quadrature scale
 
@@ -444,9 +435,8 @@ void wavelet_interp1d<order, precision>::prepare_iematrix()
   {
     int const col = (*conn)[c]; // connected cell
 
-    if (2 * level <= col)
+    if (col >= 2 * lbegin)
     {
-      ++level;     // moving to a new level
       lbegin *= 2; // reset the index of first cell in the level
       w *= 0.5;    // effective size of integration domain drops by 2
     }
@@ -458,22 +448,21 @@ void wavelet_interp1d<order, precision>::prepare_iematrix()
   }
 
   // row one, first 2 cells use full support (no-scale)
-  linear_integrator<precision>::wb10(&*em);
+  linear_integrator<precision>::wb10(em);
   em += matsize;
 
   linear_integrator<precision>::wixx(local_mat);
   em = std::copy(local_mat.begin(), local_mat.end(), em);
 
-  level  = 2;
   lbegin = 2;
   w      = 0.5; // quadrature scale
 
   for (int c = conn->row_begin(1) + 2; c < conn->row_end(1); c++)
   {
     int const col = (*conn)[c]; // connected cell
-    if (2 * level <= col)
+
+    if (col >= 2 * lbegin)
     {
-      ++level;     // moving to a new level
       lbegin *= 2; // reset the index of first cell in the level
       w *= 0.5;    // effective size of integration domain drops by 2
     }
@@ -485,22 +474,20 @@ void wavelet_interp1d<order, precision>::prepare_iematrix()
   }
 
   // rows 2 and onwards
-  int plevel   = 2;   // level of the projection functions
   int pbegin   = 2;   // index of the level of proj. functions
   precision ps = s2;  // projection basis function scale
   precision pw = 0.5; // proj. domain scale
 
   for (int row = 2; row < conn->num_rows(); row++)
   {
-    if (2 * plevel <= row)
+    if (row >= 2 * pbegin)
     {
-      ++plevel;
       pbegin *= 2;
       ps *= s2;
       pw *= 0.5;
     }
 
-    // handle functions larger than this one
+    // 1. handle functions larger than this one
     precision rl = pw * (row - pbegin);
 
     // starting the row with cells with larger support, the intergation
@@ -515,16 +502,14 @@ void wavelet_interp1d<order, precision>::prepare_iematrix()
     linear_integrator<precision>::wii(rl, pw, local_mat);
     add_block(iscale);
 
-    level  = 2;
     lbegin = 2;
     w      = 0.5; // quadrature scale for the columns
 
     for (int c = conn->row_begin(row) + 2; c < conn->row_diag(row); c++)
     {
       int const col = (*conn)[c]; // connected cell
-      if (2 * level <= col)
+      if (col >= 2 * lbegin)
       {
-        ++level;     // moving to a new level
         lbegin *= 2; // reset the index of first cell in the level
         w *= 0.5;    // effective size of integration domain drops by 2
       }
@@ -535,22 +520,21 @@ void wavelet_interp1d<order, precision>::prepare_iematrix()
       add_block(iscale);
     }
 
-    // the self-connection is handled here
+    // 2. the self-connection is handled here
     linear_integrator<precision>::wixx(local_mat);
     add_block(iscale);
 
+    // 3. handle functions with smaller support
     // now switching the logic, the row cell will be the larger cell
     // there's only one connection at this level, so updating the variables
-    ++level;
     lbegin *= 2;
     w *= 0.5;
 
     for (int c = conn->row_diag(row) + 1; c < conn->row_end(row); c++)
     {
       int const col = (*conn)[c]; // connected cell
-      if (2 * level <= col)
+      if (col >= 2 * lbegin)
       {
-        ++level;     // moving to a new level
         lbegin *= 2; // reset the index of first cell in the level
         w *= 0.5;    // effective size of integration domain drops by 2
       }
@@ -569,34 +553,36 @@ void wavelet_interp1d<order, precision>::cache_nodes()
   if constexpr (order == 1)
   {
     int const mlevel = conn->max_loaded_level();
-    nodes.reserve(pterms * conn->num_rows());
+    nodes_.resize(pterms * conn->num_rows());
 
-    nodes.push_back(precision{1.0} / precision{3.0});
-    nodes.push_back(precision{2.0} / precision{3.0});
+    nodes_[0] = precision{1.0} / precision{3.0};
+    nodes_[1] = precision{2.0} / precision{3.0};
     if (mlevel == 0)
       return;
 
-    nodes.push_back(precision{1.0} / precision{6.0});
-    nodes.push_back(precision{5.0} / precision{6.0});
+    nodes_[2] = precision{1.0} / precision{6.0};
+    nodes_[3] = precision{5.0} / precision{6.0};
 
-    precision num = 0.0; // numerator
-    precision den = 6.0; // denominator
+    int num_points = 2; // number of points on level 1
+
+    auto em = nodes_.begin() + 4;
+
+    precision num  = 0.0;       // numerator
+    precision step = 1.0 / 6.0; // denominator
     for (int l = 2; l <= mlevel; l++)
     {
-      int const np = fm::two_raised_to(l) - 2;
-      den *= 2;
+      num_points *= 2; // double the level above
+      step *= 0.5;     // denominator drops by factor 2
       num = 1;
-      nodes.push_back(num / den);
-      for (int p = 0; p < np; p += 2)
+      for (int p = 0; p < num_points; p += 2)
       {
+        *em++ = num * step;
         num += 4;
-        nodes.push_back(num / den);
+        *em++ = num * step;
         num += 2;
-        nodes.push_back(num / den);
       }
-      num += 4;
-      nodes.push_back(num / den);
     }
+    expect(em == nodes_.end());
   }
 }
 

--- a/src/asgard_interptest_common.hpp
+++ b/src/asgard_interptest_common.hpp
@@ -5,7 +5,6 @@
 
 namespace asgard
 {
-
 /*!
  * Hand crafted function designed to test
  * different aspects of the interpolatoin framework.
@@ -18,7 +17,7 @@ struct test_functions
   // first basis function, constant one
   static precision one(precision) { return 1.0; }
   // second basis funciton, linear Lagendre polynomial order 1
-  static precision lag1(precision x) { return 2  * s3 * x - s3; }
+  static precision lag1(precision x) { return 2 * s3 * x - s3; }
   // general linear function (i.e., combination of one and lag1)
   static precision lin(precision x) { return x + 3.0; }
   // Linear functions with discontinuity in value or derivative,
@@ -27,7 +26,7 @@ struct test_functions
   // The number correspnds to the min-level required for exactness.
   static precision lin1(precision x) { return std::abs(x - 0.5); }
   static precision lin2(precision x) { return std::abs(lin1(x) - 0.25); }
-  static precision lin3(precision x) { return (x < 0.5) ? lin2(2*x) : -lin2(2*x - 1); }
+  static precision lin3(precision x) { return (x < 0.5) ? lin2(2 * x) : -lin2(2 * x - 1); }
 
   // interpolation basis functions
   static precision ibasis0(precision x) { return -3 * x + 2; }
@@ -36,4 +35,4 @@ struct test_functions
   static precision ibasis3(precision x) { return (x < 0.5) ? 0 : (6 * x - 4); }
 };
 
-}
+} // namespace asgard

--- a/src/asgard_kronmult_matrix_tests.cpp
+++ b/src/asgard_kronmult_matrix_tests.cpp
@@ -457,15 +457,17 @@ int int_log2(int x)
 template<typename precision>
 void test_global_kron(int num_dimensions, int level)
 {
+  int constexpr max_num_dimensions = asgard::max_num_dimensions;
+
   std::minstd_rand park_miller(42);
   std::uniform_real_distribution<precision> unif(-1.0, 1.0);
 
   auto indexes = asgard::permutations::generate_lower_index_set(
       num_dimensions,
-      [&](std::vector<int> const &index) -> bool {
+      [&](std::array<int, max_num_dimensions> const &index) -> bool {
         int L = 0;
-        for (auto const &i : index)
-          L += int_log2(i);
+        for (int i = 0; i < num_dimensions; i++)
+          L += int_log2(index[i]);
         return (L <= level);
       });
 

--- a/src/asgard_matrix.hpp
+++ b/src/asgard_matrix.hpp
@@ -2,14 +2,8 @@
 #include "build_info.hpp"
 
 #include "asgard_resources.hpp"
+#include "asgard_tools.hpp"
 #include "lib_dispatch.hpp"
-#include "tools.hpp"
-
-#include <filesystem>
-#include <memory>
-#include <new>
-#include <string>
-#include <vector>
 
 namespace asgard
 {

--- a/src/asgard_resources.hpp
+++ b/src/asgard_resources.hpp
@@ -5,11 +5,8 @@
 //-----------------------------------------------------------------------------
 #pragma once
 
-#include "build_info.hpp"
+#include "asgard_tools.hpp"
 #include "lib_dispatch.hpp"
-
-#include <cstdint>
-#include <type_traits>
 
 namespace asgard
 {

--- a/src/asgard_resources_cuda.tpp
+++ b/src/asgard_resources_cuda.tpp
@@ -1,4 +1,4 @@
-#include "tools.hpp"
+#include "asgard_tools.hpp"
 
 #include <cuda_runtime.h>
 

--- a/src/asgard_testpdes_interpolation.hpp
+++ b/src/asgard_testpdes_interpolation.hpp
@@ -1,0 +1,483 @@
+#pragma once
+
+#include "tests_general.hpp"
+
+#include "asgard_interptest_common.hpp"
+
+#include "coefficients.hpp"
+#include "time_advance.hpp"
+
+#ifdef KRON_MODE_GLOBAL_BLOCK
+
+using namespace asgard;
+
+// this is part of testing, rename it in case of a conflict
+enum class testode_modes
+{
+  expdecay,
+  expexp
+};
+
+// 1d problem expressing a system of odes since the solution u(t, x)
+// depends only on u(0, x) and no other value within the domain
+// the solution is exp(-t) * u(0, x) for PDE (i.e., ode) u_t = - u
+//   mockode_modes::expdecay -> u(t, x) = 1
+//   mockode_modes::expexp -> u(t, x) = std::exp(x)
+// the interp_mode can be on or off so that the simulation can be done
+// in two different ways allowing for cross reference of the solutions
+template<typename P, bool interp_mode, testode_modes imode>
+class testode final : public PDE<P>
+{
+public:
+  testode(parser const &cli_input)
+  {
+    int constexpr num_dims          = 1;
+    int constexpr num_sources       = 0;
+    int constexpr num_terms         = (interp_mode) ? 0 : 1;
+    bool constexpr do_poisson_solve = false;
+    // disable implicit steps in IMEX
+    bool constexpr do_collision_operator = false;
+    bool constexpr has_analytic_soln     = true;
+    int constexpr default_degree         = 2;
+
+    partial_term<P> pterm = partial_term<P>(
+        coefficient_type::mass, negid, nullptr, flux_type::central,
+        boundary_condition::periodic, boundary_condition::periodic);
+
+    term<P> fterm = term<P>(false, "-u", {pterm,}, imex_flag::unspecified);
+
+    term_set<P> terms;
+
+    if constexpr (interp_mode)
+      this->interp_nox_ =
+          [](P, std::vector<P> const &u, std::vector<P> &fu)
+          -> void {
+        for (size_t i = 0; i < u.size(); i++)
+          fu[i] = -u[i];
+      };
+    else
+      terms = std::vector<std::vector<term<P>>>{std::vector<term<P>>{fterm,}};
+
+    this->initialize(cli_input, num_dims, num_sources, num_terms,
+                     std::vector<dimension<P>>{
+                         dimension<P>(0.0, 1.0, 4, default_degree,
+                                      component_x, nullptr, "x")},
+                     terms, std::vector<source<P>>{},
+                     std::vector<md_func_type<P>>{{component_x, component_t}},
+                     get_dt_, do_poisson_solve, has_analytic_soln,
+                     std::vector<moment<P>>{}, do_collision_operator);
+  }
+
+private:
+  static fk::vector<P>
+  component_x(fk::vector<P> const &x, P const = 0)
+  {
+    fk::vector<P> fx(x.size());
+    for (int i = 0; i < x.size(); i++)
+      if constexpr (imode == testode_modes::expdecay)
+        fx[i] = P{1};
+      else if constexpr (imode == testode_modes::expexp)
+        fx[i] = std::exp(x[i]);
+    return fx;
+  }
+
+  static P negid(P const, P const = 0) { return -1.0; }
+
+  static fk::vector<P> component_t(fk::vector<P> const &, P const t)
+  {
+    return {std::exp(-t), };
+  }
+
+  static P get_dt_(dimension<P> const &) { return 1.0; }
+};
+
+// another enum used only for testing
+// can be renamed in case of a conflict
+enum class testforcing_modes
+{
+  interp_exact,
+  separable_exact
+};
+
+// 2d problem with an exact solution that is the same as continuity_2
+// i.e., u_t = - div(u) + f, the initial condition is u(0, x, y) = 0
+// the divergence operator is implemented in the regular separable way
+// the forcing term is implemented with interpolation
+//   testforcing_modes::interp_exact -> interpolated exact solution
+//   testforcing_modes::separable_exact -> separable exact solution
+template<typename precision, testforcing_modes imode>
+class testforcing : public PDE<precision>
+{
+public:
+  using vector = fk::vector<precision>;
+  using dimen  = dimension<precision>;
+
+  using partial_term_1d = partial_term<precision>;
+  using term_1d         = term<precision>;
+
+  testforcing(asgard::parser const &cli_input)
+  {
+    int constexpr num_dimensions = 2;
+    int constexpr num_sources    = 0;
+    int constexpr num_terms      = 2;
+
+    bool constexpr do_poisson_solve = false;
+
+    bool constexpr time_independent = false;
+
+    dimen dim0(-1.0, 1.0, 2, 2, zero, nullptr, "x");
+    dimen dim1(-2.0, 2.0, 2, 2, zero, nullptr, "y");
+    std::vector<dimen> domain = {dim0, dim1};
+
+    partial_term_1d par_der(
+        coefficient_type::div, op_coeff, nullptr, flux_type::downwind,
+        boundary_condition::periodic, boundary_condition::periodic);
+
+    partial_term_1d par_mass(
+        coefficient_type::mass, nullptr, nullptr, flux_type::central,
+        boundary_condition::periodic, boundary_condition::periodic);
+
+    term_1d d_x(time_independent, "d_x", {par_der});
+    term_1d mass_y(time_independent, "mass_y", {par_mass});
+
+    term_1d mass_x(time_independent, "mass_x", {par_mass});
+    term_1d d_y(time_independent, "d_y", {par_der});
+
+    term_set<precision> terms = {
+        std::vector<term<precision>>{d_x, mass_y},
+        std::vector<term<precision>>{mass_x, d_y}};
+
+    static bool constexpr has_analytic_solution =
+        (imode == testforcing_modes::separable_exact);
+    std::vector<vector_func<precision>> exact_solution = {};
+    if constexpr (has_analytic_solution)
+      exact_solution = {exx, exy, ext};
+
+    std::vector<source<precision>> sources = {};
+
+    using P = precision;
+
+    this->interp_x_ = [](P t, vector2d<P> const &nodes, std::vector<P> const &u,
+                         std::vector<P> &F)
+        -> void {
+      for (size_t i = 0; i < u.size(); i++)
+      {
+        P x  = nodes[i][0];
+        P y  = nodes[i][1];
+        F[i] = 2 * std::cos(2.0 * t) * std::cos(M_PI * x) * std::sin(2.0 * M_PI * y)
+              - M_PI * std::sin(2.0 * t) * std::sin(M_PI * x) * std::sin(2 * M_PI * y)
+                + 2 * M_PI * std::sin(2.0 * t) * std::cos(M_PI * x) * std::cos(2 * M_PI * y);
+      }
+    };
+
+    if constexpr (imode == testforcing_modes::interp_exact)
+      this->interp_exact_ = [](P t, vector2d<P> const &x, std::vector<P> &u)
+          -> void {
+        for (int64_t i = 0; i < x.num_strips(); i++)
+          u[i] = std::sin(P{2.0} * t) * std::cos(M_PI * x[i][0])
+                * std::sin(P{2.0} * M_PI * x[i][1]);
+      };
+
+    this->initialize(
+        cli_input, num_dimensions, num_sources, num_terms,
+        domain, terms, sources, {exact_solution},
+        get_dt, do_poisson_solve, has_analytic_solution);
+  }
+
+private:
+  static vector exx(vector const &x, precision const = 0)
+  {
+    vector fx(x.size());
+    for (int i = 0; i < x.size(); i++)
+      fx[i] = std::cos(M_PI * x[i]);
+    return fx;
+  }
+
+  static vector exy(vector const &x, precision const = 0)
+  {
+    vector fx(x.size());
+    for (int i = 0; i < x.size(); i++)
+      fx[i] = std::sin(precision{2.0} * M_PI * x[i]);
+    return fx;
+  }
+
+  static vector ext(vector const &, precision const t)
+  {
+    return {std::sin(precision{2} * t), };
+  }
+
+  static vector zero(vector const &x, precision const = 0)
+  {
+    return vector(x.size());
+  }
+
+  static precision get_dt(asgard::dimension<precision> const &dim)
+  {
+    precision const x_range = dim.domain_max - dim.domain_min;
+    precision const dx      = x_range / asgard::fm::two_raised_to(dim.get_level());
+    return dx;
+  }
+
+  static precision op_coeff(precision const, precision const)
+  {
+    return -1.0;
+  }
+};
+
+// 2d problem with interpolated initial conditions
+// u(t, x, y) = sin((x^2 - pi * x)(t+1)) * cos((y^2 - y)(t+1))
+// the exact solution is non-separable in time and
+// the intial condition is not trivial
+// The pde is: u_t = - u_x + f
+// allowing for the use of one derivative term (separable) and interp. forcing
+// the check for exactness is done against projected exct solution
+// note: the main point is that the initial conditions is non-trivial
+template<typename precision, bool interp_ic>
+class testic : public PDE<precision>
+{
+public:
+  using vector = fk::vector<precision>;
+  using dimen  = dimension<precision>;
+
+  using partial_term_1d = partial_term<precision>;
+  using term_1d         = term<precision>;
+
+  testic(asgard::parser const &cli_input)
+  {
+    int constexpr num_dimensions = 2;
+    int constexpr num_sources    = 0;
+    int constexpr num_terms      = 1;
+
+    bool constexpr do_poisson_solve = false;
+    bool constexpr time_independent = false;
+
+    std::vector<dimen> domain = {};
+    if constexpr (interp_ic)
+    {
+      // interpolating the initial conditions
+      // separable init-cond are set to zero
+      dimen dim0(0.0, M_PI, 2, 2, zero, nullptr, "x");
+      dimen dim1(0.0, 1.0, 2, 2, zero, nullptr, "y");
+      domain = {dim0, dim1};
+    }
+    else
+    {
+      // interpolating the initial conditions
+      // separable init-cond are set to zero
+      dimen dim0(0.0, M_PI, 2, 2, icx, nullptr, "x");
+      dimen dim1(0.0, 1.0, 2, 2, icy, nullptr, "y");
+      domain = {dim0, dim1};
+    }
+
+    partial_term_1d par_der(
+        coefficient_type::div, neg_one, nullptr, flux_type::downwind,
+        boundary_condition::dirichlet, boundary_condition::dirichlet,
+        homogeneity::homogeneous, homogeneity::homogeneous);
+
+    partial_term_1d par_mass(coefficient_type::mass);
+
+    term_1d d_x(time_independent, "d_x", {par_der});
+    term_1d mass_y(time_independent, "mass_y", {par_mass});
+
+    term_set<precision> terms = {
+        std::vector<term<precision>>{d_x, mass_y},
+    };
+
+    bool constexpr has_analytic_solution = true;
+
+    std::vector<vector_func<precision>> exact_solution = {exx, exy};
+
+    std::vector<source<precision>> sources = {};
+
+    using P = precision;
+
+    this->interp_x_ = [](P t, vector2d<P> const &nodes, std::vector<P> const &u,
+                         std::vector<P> &F) -> void {
+      for (size_t i = 0; i < u.size(); i++)
+      {
+        P x  = nodes[i][0];
+        P y  = nodes[i][1];
+        F[i] = xs_dt(x, t) * std::cos(xs(x, t)) * std::cos(yc(y, t))
+              - yc_dt(y, t) * std::sin(xs(x, t)) * std::sin(yc(y, t))
+                + xs_dx(x, t) * std::cos(xs(x, t)) * std::cos(yc(y, t));
+      }
+    };
+
+    if constexpr (interp_ic)
+      this->interp_initial_ = [](vector2d<P> const &nodes, std::vector<P> &u)
+          -> void {
+        for (int64_t i = 0; i < nodes.num_strips(); i++)
+        {
+          P x  = nodes[i][0];
+          P y  = nodes[i][1];
+          u[i] = std::sin(xs(x, 0)) * std::cos(yc(y, 0));
+        }
+      };
+
+    this->initialize(
+        cli_input, num_dimensions, num_sources, num_terms,
+        domain, terms, sources, {exact_solution},
+        get_dt, do_poisson_solve, has_analytic_solution);
+  }
+
+private:
+  // expression that goes inside the sin, i.e., sin(xs(x))
+  static precision xs(precision x, precision t)
+  {
+    return (x * x - M_PI * x) * (t + 1);
+  }
+  static precision xs_dx(precision x, precision t) // drivative in x
+  {
+    return (2 * x - M_PI) * (t + 1);
+  }
+  static precision xs_dt(precision x, precision) // drivative in t
+  {
+    return (x * x - M_PI * x);
+  }
+
+  // expression that goes inside the cos, i.e., cos(yc(y))
+  static precision yc(precision y, precision t)
+  {
+    return -M_PI / 2 + (y * y - y) * (t + 1);
+  }
+  static precision yc_dt(precision y, precision)
+  {
+    return (y * y - y);
+  }
+
+  static vector icx(vector const &x, precision const = 0)
+  {
+    vector fx(x.size());
+    for (int i = 0; i < x.size(); i++)
+      fx[i] = std::sin(xs(x[i], 0));
+    return fx;
+  }
+  static vector icy(vector const &y, precision const = 0)
+  {
+    vector fy(y.size());
+    for (int i = 0; i < y.size(); i++)
+      fy[i] = std::cos(yc(y[i], 0));
+    return fy;
+  }
+  static vector exx(vector const &x, precision const t)
+  {
+    vector fx(x.size());
+    for (int i = 0; i < x.size(); i++)
+      fx[i] = std::sin(xs(x[i], t));
+    return fx;
+  }
+  static vector exy(vector const &y, precision const t)
+  {
+    vector fy(y.size());
+    for (int i = 0; i < y.size(); i++)
+      fy[i] = std::cos(yc(y[i], t));
+    return fy;
+  }
+
+  static vector zero(vector const &x, precision const = 0)
+  {
+    return vector(x.size());
+  }
+
+  static precision get_dt(asgard::dimension<precision> const &dim)
+  {
+    precision const x_range = dim.domain_max - dim.domain_min;
+
+    precision const dx = x_range / asgard::fm::two_raised_to(dim.get_level());
+    return dx;
+  }
+
+  static precision neg_one(precision const, precision const)
+  {
+    return -1.0;
+  }
+};
+
+// for a pde with existing exact solution (separable or not)
+// simulates the pde and returns the list of rmse at each time step
+template<typename P>
+std::vector<P>
+time_advance_errors(std::unique_ptr<PDE<P>> &pde, parser const &parse)
+{
+  expect(pde->has_analytic_soln() or pde->interp_exact());
+
+  auto const num_ranks = get_num_ranks();
+  if (num_ranks > 1) // not interpolation for MPI yet
+    return {};
+
+  int const degree = pde->get_dimensions()[0].get_degree();
+
+  options const opts(parse);
+  elements::table const check(opts, *pde);
+  adapt::distributed_grid adaptive_grid(*pde, opts);
+  basis::wavelet_transform<P, resource::host> const transformer(opts, *pde);
+
+  // -- compute dimension mass matrices
+  generate_dimension_mass_mat(*pde, transformer);
+
+  // -- generate initial condition vector.
+  auto const initial_condition =
+      adaptive_grid.get_initial_condition(*pde, transformer, opts);
+
+  // TODO: look into issue requiring mass mats to be regenerated after init
+  // cond. see problem in main.cpp
+  generate_dimension_mass_mat(*pde, transformer);
+
+  generate_all_coefficients_max_level(*pde, transformer);
+
+  kron_operators<P> kops;
+
+  fk::vector<P> f_val = [&]() -> fk::vector<P> {
+    if (pde->interp_initial())
+    {
+      kops.make(imex_flag::unspecified, *pde, adaptive_grid, opts);
+      vector2d<P> const &nodes = kops.get_inodes();
+      std::vector<P> icn(initial_condition.size());
+      pde->interp_initial()(nodes, icn);
+      fk::vector<P> ic;
+      kops.get_project(icn.data(), ic);
+      return ic;
+    }
+    else
+    {
+      return initial_condition;
+    }
+  }();
+
+  std::vector<P> errors;
+
+  // -- time loop
+  for (auto i = 0; i < opts.num_time_steps; ++i)
+  {
+    std::cout.setstate(std::ios_base::failbit);
+    auto const time          = i * pde->get_dt();
+    auto const update_system = i == 0;
+
+    f_val = time_advance::adaptive_advance(
+        time_advance::method::exp, *pde, kops, adaptive_grid,
+        transformer, opts, f_val, time, update_system);
+
+    if (pde->has_analytic_soln())
+    {
+      auto const analytic_solution = sum_separable_funcs(
+          pde->exact_vector_funcs(), pde->get_dimensions(), adaptive_grid,
+          transformer, degree, time + pde->get_dt());
+
+      errors.push_back(fm::rmserr(analytic_solution, f_val));
+    }
+    else // if (pde->interp_exact())
+    {
+      vector2d<P> const &inodes = kops.get_inodes();
+      std::vector<P> u_exact(inodes.num_strips());
+      pde->interp_exact()(time + pde->get_dt(), inodes, u_exact);
+
+      std::vector<P> u_comp = kops.get_nodals(f_val.data());
+
+      errors.push_back(fm::rmserr(u_comp, u_exact));
+    }
+  }
+
+  return errors;
+}
+
+#endif

--- a/src/asgard_tools.cpp
+++ b/src/asgard_tools.cpp
@@ -1,11 +1,4 @@
-#include "tools.hpp"
-#include <algorithm>
-// FIXME use string format after C++20
-// #include <format>
-#include <cstdio>
-#include <math.h>
-#include <numeric>
-#include <sstream>
+#include "asgard_tools.hpp"
 
 namespace asgard::tools
 {

--- a/src/asgard_tools.hpp
+++ b/src/asgard_tools.hpp
@@ -1,10 +1,37 @@
 #pragma once
+// one place for all std headers
+#include <algorithm>
+#include <array>
 #include <cassert>
 #include <chrono>
+#include <climits>
+#include <cmath>
+#include <csignal>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iomanip>
 #include <iostream>
+#include <limits>
+#include <list>
 #include <map>
+#include <math.h>
+#include <memory>
+#include <mutex>
+#include <new>
+#include <numeric>
+#include <optional>
+#include <random>
+#include <sstream>
+#include <stdexcept>
 #include <string>
+#include <string_view>
 #include <type_traits>
+#include <typeinfo>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "build_info.hpp"

--- a/src/asgard_tools_tests.cpp
+++ b/src/asgard_tools_tests.cpp
@@ -1,8 +1,6 @@
+#include "asgard_tools.hpp"
+
 #include "tests_general.hpp"
-#include "tools.hpp"
-#include <algorithm>
-#include <random>
-#include <sstream>
 
 using namespace asgard;
 

--- a/src/asgard_vector.hpp
+++ b/src/asgard_vector.hpp
@@ -1,15 +1,6 @@
 #pragma once
-#include "build_info.hpp"
 
 #include "asgard_resources.hpp"
-#include "lib_dispatch.hpp"
-#include "tools.hpp"
-
-#include <filesystem>
-#include <memory>
-#include <new>
-#include <string>
-#include <vector>
 
 namespace asgard
 {
@@ -57,6 +48,8 @@ class vector
   friend class vector;
 
 public:
+  //! \brief Value type of the container
+  using value_type = P;
   /*! constructor
    * \brief creates an empty vector.
    */

--- a/src/basis.cpp
+++ b/src/basis.cpp
@@ -5,10 +5,6 @@
 #include "fast_math.hpp"
 #include "matlab_utilities.hpp"
 #include "quadrature.hpp"
-#include "tools.hpp"
-#include <algorithm>
-#include <cmath>
-#include <numeric>
 
 namespace asgard
 {

--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -5,7 +5,6 @@
 #include "distribution.hpp"
 #include "elements.hpp"
 #include "lib_dispatch.hpp"
-#include "tools.hpp"
 
 #ifdef ASGARD_USE_OPENMP
 #include <omp.h>

--- a/src/batch.hpp
+++ b/src/batch.hpp
@@ -3,9 +3,6 @@
 #include "asgard_vector.hpp"
 #include "elements.hpp"
 #include "pde/pde_base.hpp"
-#include "tools.hpp"
-#include <array>
-#include <numeric>
 
 namespace asgard
 {

--- a/src/batch_tests.cpp
+++ b/src/batch_tests.cpp
@@ -4,9 +4,6 @@
 #include "coefficients.hpp"
 #include "fast_math.hpp"
 #include "tests_general.hpp"
-#include "tools.hpp"
-#include <numeric>
-#include <random>
 
 #ifdef ASGARD_ENABLE_DOUBLE
 #ifdef ASGARD_ENABLE_FLOAT

--- a/src/boundary_conditions.cpp
+++ b/src/boundary_conditions.cpp
@@ -1,5 +1,4 @@
 #include "boundary_conditions.hpp"
-#include "tools.hpp"
 
 /*
 

--- a/src/cblacs_grid.cpp
+++ b/src/cblacs_grid.cpp
@@ -1,6 +1,7 @@
+#include "asgard_tools.hpp"
+
 #include "cblacs_grid.hpp"
 #include "distribution.hpp"
-#include "tools.hpp"
 
 #include <cmath>
 

--- a/src/coefficients.cpp
+++ b/src/coefficients.cpp
@@ -7,9 +7,7 @@
 #include "matlab_utilities.hpp"
 #include "pde.hpp"
 #include "quadrature.hpp"
-#include "tools.hpp"
 #include "transformations.hpp"
-#include <numeric>
 
 namespace asgard
 {

--- a/src/device/asgard_kronmult.hpp
+++ b/src/device/asgard_kronmult.hpp
@@ -450,6 +450,13 @@ template<typename precision>
 void global_cpu(int num_dimensions, int n, int64_t block_size,
                 vector2d<int> const &ilist, dimension_sort const &dsort,
                 permutes const &perm, connect_1d const &vconn,
+                precision const gvals[], precision alpha, precision const x[],
+                precision y[], block_global_workspace<precision> &workspace);
+
+template<typename precision>
+void global_cpu(int num_dimensions, int n, int64_t block_size,
+                vector2d<int> const &ilist, dimension_sort const &dsort,
+                permutes const &perm, connect_1d const &vconn,
                 precision const gvals[], precision const x[], precision y[],
                 block_global_workspace<precision> &workspace);
 

--- a/src/distribution.cpp
+++ b/src/distribution.cpp
@@ -1,6 +1,5 @@
 #include "distribution.hpp"
 #include "lib_dispatch.hpp"
-#include "tools.hpp"
 
 #include <cmath>
 #include <csignal>

--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -5,15 +5,6 @@
 #include "fast_math.hpp"
 #include "matlab_utilities.hpp"
 #include "program_options.hpp"
-#include "tools.hpp"
-
-#include <cmath>
-#include <functional>
-#include <limits>
-#include <map>
-#include <numeric>
-#include <unordered_set>
-#include <vector>
 
 namespace asgard::elements
 {

--- a/src/elements.hpp
+++ b/src/elements.hpp
@@ -5,12 +5,6 @@
 #include "pde.hpp"
 #include "permutations.hpp"
 #include "program_options.hpp"
-#include "tools.hpp"
-#include <algorithm>
-#include <list>
-#include <map>
-#include <unordered_map>
-#include <vector>
 
 namespace asgard::elements
 {

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -3,11 +3,11 @@
 #include "build_info.hpp"
 
 #include "asgard_matrix.hpp"
+#include "asgard_tools.hpp"
 #include "asgard_vector.hpp"
 #include "pde.hpp"
 #include "program_options.hpp"
 #include "solver.hpp"
-#include "tools.hpp"
 #include "transformations.hpp"
 
 // workaround for missing include issue with highfive

--- a/src/lib_dispatch.cpp
+++ b/src/lib_dispatch.cpp
@@ -2,7 +2,6 @@
 #include "build_info.hpp"
 #include "distribution.hpp"
 #include "sparse.hpp"
-#include "tools.hpp"
 
 // ==========================================================================
 // external declarations for calling blas routines linked with -lblas

--- a/src/matlab_plot.hpp
+++ b/src/matlab_plot.hpp
@@ -2,10 +2,10 @@
 
 #include "asgard_dimension.hpp"
 #include "asgard_matrix.hpp"
+#include "asgard_tools.hpp"
 #include "asgard_vector.hpp"
 #include "elements.hpp"
 #include "pde.hpp"
-#include "tools.hpp"
 #include <MatlabDataArray.hpp>
 #include <MatlabEngine.hpp>
 #include <type_traits>

--- a/src/matlab_utilities.cpp
+++ b/src/matlab_utilities.cpp
@@ -1,13 +1,6 @@
 #include "matlab_utilities.hpp"
 #include "asgard_matrix.hpp"
 #include "asgard_vector.hpp"
-#include "tools.hpp"
-#include <array>
-#include <cmath>
-#include <fstream>
-#include <numeric>
-#include <string>
-#include <vector>
 
 namespace asgard
 {

--- a/src/moment.cpp
+++ b/src/moment.cpp
@@ -2,7 +2,6 @@
 #include "basis.hpp"
 #include "elements.hpp"
 #include "sparse.hpp"
-#include "tools.hpp"
 #include "transformations.hpp"
 
 namespace asgard

--- a/src/pde/pde_fokkerplanck2_complete.hpp
+++ b/src/pde/pde_fokkerplanck2_complete.hpp
@@ -1,17 +1,6 @@
 #pragma once
-#include <algorithm>
-#include <cmath>
-#include <functional>
-#include <iostream>
-#include <map>
-#include <math.h>
-#include <memory>
-#include <string>
-#include <typeinfo>
-#include <vector>
 
 #include "../quadrature.hpp"
-#include "../tools.hpp"
 #include "pde_base.hpp"
 
 namespace asgard

--- a/src/permutations.cpp
+++ b/src/permutations.cpp
@@ -3,11 +3,6 @@
 #include "asgard_matrix.hpp"
 #include "asgard_vector.hpp"
 #include "matlab_utilities.hpp"
-#include "tools.hpp"
-#include <algorithm>
-#include <cmath>
-#include <numeric>
-#include <vector>
 
 namespace asgard::permutations
 {
@@ -21,9 +16,9 @@ get_lequal(int const num_dims, int const limit, bool const order_by_n)
   expect(limit >= 0);
 
   return select_indexex(num_dims, order_by_n, false,
-                        [&](std::vector<int> const &index) -> bool {
+                        [&](std::array<int, max_num_dimensions> const &index) -> bool {
                           int level = index[0];
-                          for (size_t i = 1; i < index.size(); i++)
+                          for (int i = 1; i < num_dims; i++)
                             level += index[i];
                           return (level <= limit);
                         });
@@ -42,9 +37,9 @@ fk::matrix<int> get_lequal_multi(fk::vector<int> const &levels,
   expect(limit >= 0);
 
   return select_indexex(num_dims, true, not increasing_sum_order,
-                        [&](std::vector<int> const &index) -> bool {
+                        [&](std::array<int, max_num_dimensions> const &index) -> bool {
                           int level = 0;
-                          for (size_t i = 0; i < index.size(); i++)
+                          for (int i = 0; i < num_dims; i++)
                           {
                             if (index[i] > levels(i))
                               return false;
@@ -66,7 +61,7 @@ get_mix_leqmax_multi(fk::vector<int> const &levels, int const num_dims,
   expect(mixed_max[1] >= 0);
 
   return select_indexex(num_dims, true, not increasing_sum_order,
-                        [&](std::vector<int> const &index) -> bool {
+                        [&](std::array<int, max_num_dimensions> const &index) -> bool {
                           // check first group
                           int level_g1 = 0;
                           for (int i = 0; i < num_first_group; i++)

--- a/src/permutations.hpp
+++ b/src/permutations.hpp
@@ -31,17 +31,18 @@ namespace asgard::permutations
  * dimension.
  */
 inline std::vector<int> generate_lower_index_set(
-    size_t num_dims, std::function<bool(std::vector<int> const &index)> inside)
+    size_t num_dims, std::function<bool(std::array<int, max_num_dimensions> const &index)> inside)
 {
   size_t c   = 0;
   bool is_in = true;
-  std::vector<int> root(num_dims, 0);
+  std::array<int, max_num_dimensions> root;
+  std::fill_n(root.begin(), num_dims, 0);
   std::vector<int> indexes;
   while (is_in || (c < num_dims))
   {
     if (is_in)
     {
-      indexes.insert(indexes.end(), root.begin(), root.end());
+      indexes.insert(indexes.end(), root.begin(), root.begin() + num_dims);
       c = 0;
       root[c]++;
     }
@@ -69,11 +70,12 @@ inline std::vector<int> generate_lower_index_set(
  * with sum of the entries equal to L.
  */
 inline std::vector<std::vector<int>> generate_lower_index_level_sets(
-    size_t num_dims, std::function<bool(std::vector<int> const &index)> inside)
+    size_t num_dims, std::function<bool(std::array<int, max_num_dimensions> const &index)> inside)
 {
   size_t c = 0, level = 0;
   bool is_in = true;
-  std::vector<int> root(num_dims, 0);
+  std::array<int, max_num_dimensions> root;
+  std::fill_n(root.begin(), num_dims, 0);
   std::vector<std::vector<int>> indexes(1);
   while (is_in || (c < num_dims))
   {
@@ -81,11 +83,11 @@ inline std::vector<std::vector<int>> generate_lower_index_level_sets(
     {
       if (level == indexes.size())
       {
-        indexes.push_back(std::vector<int>(root));
+        indexes.emplace_back(root.begin(), root.begin() + num_dims);
       }
       else
       {
-        indexes[level].insert(indexes[level].end(), root.begin(), root.end());
+        indexes[level].insert(indexes[level].end(), root.begin(), root.begin() + num_dims);
       }
       c = 0;
       root[c]++;
@@ -99,7 +101,7 @@ inline std::vector<std::vector<int>> generate_lower_index_level_sets(
         break;
       root[c]++;
       level = root[0];
-      for (size_t i = 1; i < root.size(); i++)
+      for (size_t i = 1; i < num_dims; i++)
         level += root[i];
     }
     is_in = inside(root);
@@ -204,8 +206,9 @@ inline fk::matrix<int> transp_data(int const num_dims, bool levels_in_reverse,
  * \returns fk::matrix<int> containing the selected multi-indexes
  */
 inline fk::matrix<int>
-select_indexex(int const num_dims, bool order_by_n, bool levels_in_reverse,
-               std::function<bool(std::vector<int> const &index)> inside)
+select_indexex(
+    int const num_dims, bool order_by_n, bool levels_in_reverse,
+    std::function<bool(std::array<int, max_num_dimensions> const &index)> inside)
 {
   if (order_by_n)
   {

--- a/src/program_options.cpp
+++ b/src/program_options.cpp
@@ -5,13 +5,9 @@
 #include "clara.hpp"
 #pragma GCC diagnostic pop
 #include "distribution.hpp"
-#include "tools.hpp"
 #ifdef ASGARD_IO_HIGHFIVE
 #include "io.hpp"
 #endif
-
-#include <iostream>
-#include <string>
 
 namespace asgard
 {

--- a/src/program_options.hpp
+++ b/src/program_options.hpp
@@ -1,14 +1,6 @@
 #pragma once
 
 #include "asgard_vector.hpp"
-#include "tools.hpp"
-
-#include <limits>
-#include <map>
-#include <sstream>
-#include <string>
-#include <string_view>
-#include <vector>
 
 namespace asgard
 {

--- a/src/quadrature.cpp
+++ b/src/quadrature.cpp
@@ -1,11 +1,5 @@
 #include "quadrature.hpp"
 #include "matlab_utilities.hpp"
-#include "tools.hpp"
-
-#include <algorithm>
-#include <array>
-#include <cmath>
-#include <functional>
 
 namespace asgard
 {

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -2,9 +2,6 @@
 #include "distribution.hpp"
 #include "fast_math.hpp"
 #include "quadrature.hpp"
-#include "tools.hpp"
-#include <algorithm>
-#include <stdexcept>
 
 namespace asgard::solver
 {

--- a/src/sparse.hpp
+++ b/src/sparse.hpp
@@ -9,13 +9,6 @@
 #include "asgard_matrix.hpp"
 #include "asgard_vector.hpp"
 #include "lib_dispatch.hpp"
-#include "tools.hpp"
-
-#include <filesystem>
-#include <memory>
-#include <new>
-#include <string>
-#include <vector>
 
 namespace asgard
 {

--- a/src/transformations.cpp
+++ b/src/transformations.cpp
@@ -4,11 +4,6 @@
 #include "batch.hpp"
 #include "matlab_utilities.hpp"
 #include "quadrature.hpp"
-#include "tools.hpp"
-#include <algorithm>
-#include <climits>
-#include <cmath>
-#include <numeric>
 
 namespace asgard
 {

--- a/src/transformations.hpp
+++ b/src/transformations.hpp
@@ -10,12 +10,6 @@
 #include "fast_math.hpp"
 #include "pde.hpp"
 #include "quadrature.hpp"
-#include "tools.hpp"
-
-#include <algorithm>
-#include <cmath>
-#include <type_traits>
-#include <vector>
 
 namespace asgard
 {

--- a/src/transformations_tests.cpp
+++ b/src/transformations_tests.cpp
@@ -3,10 +3,7 @@
 #include "matlab_utilities.hpp"
 #include "pde.hpp"
 #include "tests_general.hpp"
-#include "tools.hpp"
 #include "transformations.hpp"
-#include <climits>
-#include <numeric>
 
 static auto const transformations_base_dir = gold_base_dir / "transformations";
 

--- a/testing/automated/clang-format-check.sh
+++ b/testing/automated/clang-format-check.sh
@@ -62,9 +62,11 @@ asgard_indexset.hpp
 asgard_indexset_tests.cpp
 asgard_interpolation1d.hpp
 asgard_interpolation1d.cpp
+asgard_interptest_common.hpp
 #asgard_interpolation1d_tests.cpp
 asgard_interpolation.hpp
 #asgard_interpolation_tests.cpp
+asgard_kron_operators.hpp
 asgard_kronmult_benchmark.cpp
 asgard_kronmult_matrix.cpp
 asgard_kronmult_matrix.hpp
@@ -78,6 +80,10 @@ asgard_resources_cuda.tpp
 asgard_resources_host.tpp
 asgard_resources.hpp
 asgard_resources_tests.cpp
+#asgard_testpdes_interpolation.hpp
+asgard_tools.cpp
+asgard_tools.hpp
+asgard_tools_tests.cpp
 asgard_vector.hpp
 #basis.cpp
 basis.hpp
@@ -143,9 +149,6 @@ tensors.hpp
 time_advance.cpp
 time_advance.hpp
 time_advance_tests.cpp
-tools.cpp
-tools.hpp
-tools_tests.cpp
 #transformations.cpp
 #transformations.hpp
 #transformations_tests.cpp

--- a/testing/sandbox.cpp
+++ b/testing/sandbox.cpp
@@ -4,7 +4,6 @@
 #include "coefficients.hpp"
 #include "distribution.hpp"
 #include "elements.hpp"
-#include "tools.hpp"
 
 #ifdef ASGARD_IO_HIGHFIVE
 #include "io.hpp"
@@ -20,17 +19,12 @@
 #include "asgard_vector.hpp"
 #include "time_advance.hpp"
 #include "transformations.hpp"
-#include <numeric>
 
 #include "asgard_kronmult_tests.hpp"
 
 using namespace asgard;
 
-#ifdef ASGARD_USE_DOUBLE_PREC
-using prec = double;
-#else
-using prec = float;
-#endif
+using prec = asgard::default_precision;
 
 int main(int, char **)
 {


### PR DESCRIPTION
We can now use interpolation to handle some non-separable cases:
* non-separable initial conditions
* non-separable exact solution (for verification purposes)
* non-separable forcing terms
* non-separable mass terms

Still missing (will come soon):
* second and higher order basis, works only with linear basis
* cannot take derivatives of the operators, works only with the mass term
* cannot do Hermite interpolation
* support for local kronmult and MPI