### PR TITLE
Input files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,7 +229,7 @@ if (ASGARD_USE_PYTHON)
                            COMMENT "Copying ${CMAKE_CURRENT_SOURCE_DIR}/python/${_asg_pybuildfile}")
         list(APPEND _pyasgard_buildstage "${CMAKE_CURRENT_BINARY_DIR}/${_asg_pybuildfile}")
     endforeach()
-    foreach(_asg_pybuildfile continuity_2d.py)
+    foreach(_asg_pybuildfile continuity_2d.py inputs_1d.py)
         add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/example_${_asg_pybuildfile}"
                            COMMAND "${CMAKE_COMMAND}"
                            ARGS -E copy ${CMAKE_CURRENT_SOURCE_DIR}/examples/${_asg_pybuildfile} ${CMAKE_CURRENT_BINARY_DIR}/example_${_asg_pybuildfile}
@@ -246,7 +246,7 @@ if (ASGARD_USE_PYTHON)
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/python/asgard_config.py"  "${CMAKE_CURRENT_BINARY_DIR}/pyinstall/asgard_config.py")
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/pyinstall/asgard_config.py" DESTINATION "${_asgard_python_path}")
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/asgard.py" DESTINATION "${_asgard_python_path}")
-    foreach(_asg_pybuildfile example_continuity_2d.py)
+    foreach(_asg_pybuildfile example_continuity_2d.py example_inputs_1d.py)
         install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${_asg_pybuildfile}" DESTINATION share/asgard/examples/)
     endforeach()
 
@@ -276,6 +276,26 @@ if (ASGARD_USE_PYTHON)
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/python/asgard_matlab.py" "${CMAKE_CURRENT_BINARY_DIR}/pyinstall/asgard_matlab.py" @ONLY)
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/pyinstall/asgard_matlab.py" DESTINATION share/asgard/matlab)
 endif()
+
+foreach(_asg_testinput test_input1.txt test_input2.txt)
+    add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${_asg_testinput}"
+                       COMMAND "${CMAKE_COMMAND}"
+                       ARGS -E copy ${CMAKE_CURRENT_SOURCE_DIR}/testing/${_asg_testinput} ${CMAKE_CURRENT_BINARY_DIR}/${_asg_testinput}
+                       DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/testing/${_asg_testinput}"
+                       COMMENT "Copying ${CMAKE_CURRENT_SOURCE_DIR}/testing/${_asg_testinput}")
+    list(APPEND _asg_testinputfiles "${CMAKE_CURRENT_BINARY_DIR}/${_asg_testinput}")
+endforeach()
+foreach(_asg_testinput inputs_1d_1.txt inputs_1d_2.txt)
+    add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${_asg_testinput}"
+                       COMMAND "${CMAKE_COMMAND}"
+                       ARGS -E copy ${CMAKE_CURRENT_SOURCE_DIR}/examples/${_asg_testinput} ${CMAKE_CURRENT_BINARY_DIR}/${_asg_testinput}
+                       DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/examples/${_asg_testinput}"
+                       COMMENT "Copying ${CMAKE_CURRENT_SOURCE_DIR}/examples/${_asg_testinput}")
+    list(APPEND _asg_testinputfiles "${CMAKE_CURRENT_BINARY_DIR}/${_asg_testinput}")
+
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${_asg_testinput} DESTINATION share/asgard/examples)
+endforeach()
+add_custom_target(asgard_test_inputs ALL DEPENDS "${_asg_testinputfiles}")
 
 if (ASGARD_USE_MPI)
     find_package(MPI REQUIRED)
@@ -649,8 +669,10 @@ endif ()
 #-------------------------------------------------------------------------------
 # Building the examples to make sure they build but will not run here
 #-------------------------------------------------------------------------------
-add_executable(example_continuity_2d "${CMAKE_CURRENT_SOURCE_DIR}/examples/continuity_2d.cpp")
-target_link_libraries(example_continuity_2d libasgard)
+foreach(_exfile continuity_2d inputs_1d)
+  add_executable(example_${_exfile} "${CMAKE_CURRENT_SOURCE_DIR}/examples/${_exfile}.cpp")
+  target_link_libraries(example_${_exfile} libasgard)
+endforeach()
 
 #-------------------------------------------------------------------------------
 # Installing the library as stand-alone

--- a/doxygen/CMakeLists.txt
+++ b/doxygen/CMakeLists.txt
@@ -29,7 +29,7 @@ doxygen_add_docs(asgard_doxygen
                  README.md
                  #doxygen/installation.md
                  #doxygen/basic_usage.md
-                 src/
+                 src/program_options.hpp
                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../
                  COMMENT "Building the ${PROJECT_NAME} documentation")
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,10 +6,17 @@ find_package(asgard @asgard_VERSION_MAJOR@.@asgard_VERSION_MINOR@.@asgard_VERSIO
              PATHS "@CMAKE_INSTALL_PREFIX@")
 
 add_executable(example_continuity_2d  continuity_2d.cpp)
+add_executable(example_inputs_1d      inputs_1d.cpp)
 
-target_link_libraries(example_continuity_2d asgard::asgard)
+target_link_libraries(example_continuity_2d  asgard::asgard)
+target_link_libraries(example_inputs_1d      asgard::asgard)
+
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/inputs_1d_1.txt"   "${CMAKE_CURRENT_BINARY_DIR}/inputs_1d_1.txt" COPYONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/inputs_1d_2.txt"   "${CMAKE_CURRENT_BINARY_DIR}/inputs_1d_2.txt" COPYONLY)
 
 if (asgard_PYTHON_FOUND)
-    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/example_continuity_2d.py"  "${CMAKE_CURRENT_BINARY_DIR}/example_continuity_2d.py")
-    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/example_continuity_2d.m"   "${CMAKE_CURRENT_BINARY_DIR}/example_continuity_2d.m")
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/example_continuity_2d.py"  "${CMAKE_CURRENT_BINARY_DIR}/example_continuity_2d.py" COPYONLY)
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/example_continuity_2d.m"   "${CMAKE_CURRENT_BINARY_DIR}/example_continuity_2d.m" COPYONLY)
+
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/example_inputs_1d.py"   "${CMAKE_CURRENT_BINARY_DIR}/example_inputs_1d.py" COPYONLY)
 endif()

--- a/examples/inputs_1d.cpp
+++ b/examples/inputs_1d.cpp
@@ -1,0 +1,277 @@
+#include "asgard.hpp"
+
+// if ASGarD is compiled with double precision, this defaults to double
+// if only single precision is avaiable, this will be float
+using precision = asgard::default_precision;
+
+// very simple PDE that demonstrates using external file with parameters
+//   df / dt + df / dx = s(t, x)
+// the domain is set to be (-n * M_PI, n * M_PI)
+// here n is set to be the number of waves, i.e., num_waves static variable
+// the forcing term is chosen so the exact solution is just sin(x) cos(t)
+class example_sinwaves : public asgard::PDE<precision>
+{
+public:
+  // short-hand notation of the asgard vector
+  using vector = asgard::fk::vector<precision>;
+  // short-hand notation for the asgard 1d dimension
+  using dimension = asgard::dimension<precision>;
+
+  // short-hand notations
+  // a collection of PDE operators (term_set) is broken up into separable
+  //   multidimensional terms (term_md)
+  // each multidimensional terms has num-dimensions 1d components (term1d)
+  // each one dimensional term consists of one or more partial terms
+  using partial_term_1d = asgard::partial_term<precision>;
+  using term_1d = asgard::term<precision>;
+  using term_md = std::vector<asgard::term<precision>>;
+  // term_set is actually std::vector<term_md>
+  using term_set = asgard::term_set<precision>;
+
+  // short-hand notation
+  using source_md  = asgard::source<precision>;
+  using source_set = std::vector<source_md>;
+
+  example_sinwaves(asgard::prog_opts const &cli_input)
+  {
+    // these fields check correctness of the specification
+    int constexpr num_dimensions = 1;
+    int constexpr num_sources    = 2;
+    int constexpr num_terms      = 1;
+
+    // the Poisson solver is not used here
+    bool constexpr do_poisson_solve  = false;
+
+    // flagging terms as time_independent (using the false value)
+    // improves speed by keeping some constant matrices across time-steps
+    bool constexpr time_independent = false;
+
+    // define the domain but use the static variable num_waves
+    if (num_waves <= 0)
+      throw std::runtime_error("num_waves must be set to a positive integer");
+
+    dimension dim0(-M_PI * num_waves,   // domain min
+                   M_PI * num_waves,    // domain max
+                   2,                   // levels
+                   2,                   // degree
+                   initial_condition_x, // initial condition
+                   nullptr,             // Cartesian coordinates
+                   "x");                // reference name
+
+    // building up the df / dx term
+    partial_term_1d par_derivative(
+        asgard::coefficient_type::div, // uses derivative
+        op_coeff,                      // -1.0 (appears on the r.h.s)
+        nullptr,                       // no l.h.s. coefficient
+        asgard::flux_type::upwind,
+        asgard::boundary_condition::periodic,
+        asgard::boundary_condition::periodic);
+
+    term_1d d_x(time_independent, "d_x", {par_derivative});
+
+    term_set terms = { term_md{d_x, }, };
+
+    // the PDE has analytic solution
+    // the computed solution will be verified against the analytic one
+    // the solution is the product of the the 3 functions
+    static bool constexpr has_analytic_solution = true;
+    std::vector<asgard::vector_func<precision>> exact_solution = {
+        initial_condition_x, exact_time_vector};
+
+    // in order to manufacture a specific analytic solution
+    // we use artificial source terms that balance the derivatives
+    // see the comments before the definition of diff_time
+    // each separable source consists of num-dimensions spacial funcitons
+    // and a time function
+    source_md s0({initial_condition_dx, },  exact_solution_time);
+    source_md s1({initial_condition_x,  },  exact_solution_dt);
+
+    source_set sources = {s0, s1};
+
+    // once all the components are prepared, the PDE must be initialized
+    // this is done at the end of the constructor
+    this->initialize(
+        cli_input, // allows modifications, e.g., override mesh level
+        num_dimensions, num_sources, num_terms,  // for sanity-check purposes
+        std::vector<dimension>{dim0, }, // domain
+        terms, sources, exact_solution,
+        get_dt, do_poisson_solve, has_analytic_solution);
+  }
+
+  // using a static variable allows us to include the variable into function
+  // calls without the need to use closures capturing the "this" pointer
+  // in this example, we are only using num_waves in the domain min/max
+  // but in general, this class is what is known as a "singleton"
+  inline static int num_waves = 0;
+
+private:
+  //
+  // function definitions needed to build up the dimension, terms and sources
+  //
+
+  // for all funtions, the "vector x" indicates a batch of quadrature points
+  // in the corresponding dimension (e.g., dim0 or dim1)
+  // the output should be a vector with the same size holding f(x)
+  // funcitons also accept a "time" scalar but it is often ignored
+
+  // specify initial condition vector functions...
+  static vector initial_condition_x(vector const &x, precision const = 0)
+  {
+    // ignored parameter corresponds to time
+    vector fx(x.size());
+    for (int i = 0; i < x.size(); i++)
+      fx[i] = std::sin(x[i]);
+    return fx;
+  }
+
+  // The exact_solution_time() has two signatures:
+  // - scalar-to-scalar signature used in the source definitions
+  // - vector signature that matches the signature of the initial conditions
+  static precision exact_solution_time(precision const t)
+  {
+    return std::cos(t);
+  }
+
+  static vector exact_time_vector(vector const &, precision const t)
+  {
+    // unlike the initial condition functions, the time variable is used
+    // while the x-variable is ignored
+    return {
+        exact_solution_time(t),
+    };
+  }
+
+  // specify source functions...
+  // we are using the method of manufactured solutions where we create
+  // a source that will balance the PDE terms and result in problem
+  // with known analytic solution
+
+  // to this end, we need the derivatives
+  // of the three components of the exact solution
+
+  static vector initial_condition_dx(vector const &x, precision const = 0)
+  {
+    vector fx(x.size());
+    for (int i = 0; i < x.size(); i++)
+      fx[i] = std::cos(x[i]);
+    return fx;
+  }
+
+  // derivative of exact_solution_time
+  static precision exact_solution_dt(precision const t)
+  {
+    return -std::sin(t);
+  }
+
+  // a bit of a misnomer, this is a scaling factor applied to dt
+  // in conjuction with the CFL conidition provided from the command line
+  // (note: this is probably not fully supported at the moment)
+  static precision get_dt(asgard::dimension<precision> const &dim)
+  {
+    precision const x_range = dim.domain_max - dim.domain_min;
+    precision const dx      = x_range / asgard::fm::two_raised_to(dim.get_level());
+    // return dx; this will be scaled by CFL
+    // from command line
+    return dx;
+  }
+
+  // operator coefficient
+  static precision op_coeff(precision const, precision const)
+  {
+    // the signature is op_coeff(x, t) where x is in space and t is time
+    // here we are using a simple operator with just -1.0
+    return -1.0;
+  }
+
+};
+
+int main(int argc, char **argv)
+{
+  // if using MPI, this will call MPI_Init()
+  // with or without MPI, this sets the ASGarD environment
+  auto const [my_rank, num_ranks] = asgard::initialize_distribution();
+
+  // kill off unused processes (MPI only)
+  if (my_rank >= num_ranks)
+  {
+    asgard::finalize_distribution();
+    return 0;
+  }
+
+  // parse the command line inputs
+  asgard::prog_opts options(argc, argv);
+
+  std::optional<int> num_waves = options.file_value<int>("number of waves");
+  if (not num_waves)
+    throw std::runtime_error("inputs_1d needs an input file with "
+                             "the 'number of waves' defined in it");
+
+  // the static variable must be set before we create an instance
+  // of the example_sinwaves PDE
+  example_sinwaves::num_waves = num_waves.value();
+
+  int cells_per_wavel = 16; // assume we want an accurate wave picture
+  std::optional<int> read_cpw = options.file_value<int>("cells per wave");
+
+  if (read_cpw) // if the file contains custom "cells per wave" entry
+    cells_per_wavel = read_cpw.value();
+  // else, we will use the default 16 set from above
+
+  // setup the discretization parameters, we at least 8 grid cells per wave
+  int level     =  4;
+  int num_cells = 16; // level 4 yields 16 cells
+  while (num_cells < cells_per_wavel * example_sinwaves::num_waves)
+  {
+    // not enough cells, increase the level
+    ++level;
+    // number of cells per level is 2^level
+    num_cells *= 2;
+  }
+
+  // set the fixed grid
+  // the code can be adjusted here so we take the max of level
+  // and any existing level provided by the input file or cli
+  options.start_levels = {level, };
+
+  // we also need to adjust the time-step and number of steps
+
+  // stability region for RK3 time-stepping method <= 0.01, using 0.005
+  // CFL condition is equal to the cell size
+  // cell size is the domain size 2 * num_waves * M_PI / num_cells
+
+  double cell_size
+      = 2.0 * example_sinwaves::num_waves * M_PI
+        / static_cast<double>(num_cells);
+
+  options.dt = 0.005 / cell_size;
+
+  // desired final time
+  // the code can be adjusted so that time is also read from the file
+  // (also the input files have to be adjusted)
+  double const time = 1.0;
+
+  // round up to the time-steps that it will take to reach time = 1.0
+  options.num_time_steps = 1 + static_cast<int>(time / options.dt.value());
+
+  // note here that dt * num_time_steps is not necessarily 1.0 due to rounding
+  // readjust the dt to so the rounding is less
+  options.dt = time / static_cast<double>(options.num_time_steps.value());
+
+  // we want to generate a single output file at the end
+  options.wavelet_output_freq = options.num_time_steps;
+
+  // create an instance of the PDE that we want to solve
+  // pde has type std::unique_ptr<asgard::PDE<precision>>
+  auto pde = asgard::make_custom_pde<example_sinwaves>(options);
+
+  // main call to asgard, does all the work
+  asgard::simulate(pde);
+
+  if (asgard::get_local_rank() == 0)
+    std::cout << " -- done simulating " << example_sinwaves::num_waves << '\n';
+
+  // call MPI_Finalize() and/or cleanup after the simulation
+  asgard::finalize_distribution();
+
+  return 0;
+}

--- a/examples/inputs_1d.py
+++ b/examples/inputs_1d.py
@@ -1,0 +1,88 @@
+
+import numpy as np
+import os
+
+import matplotlib.pyplot as plt
+
+import asgard
+
+# This exmaple is related to continuity_2d.cpp
+# 1. This will run the C++ executable and generate an hdf5 file
+#    - The file contains a snapshot of the PDE solution
+# 2. The snapshot is loaded using the asgard python bindings
+# 3. The solution and the exact solution are plotted together
+
+if __name__ == '__main__':
+    if not os.path.isfile('example_inputs_1d'):
+        print("You must first build this project using CMake, e.g.,")
+        print("  mkdir build")
+        print("  cd build")
+        print("  cmake ..")
+        print("  make -j")
+        print("")
+        print("Then run this script from the build folder")
+        exit(1)
+
+    print("running the inputs examples")
+
+    outfile1 = 'waves1.h5'
+    outfile2 = 'waves2.h5'
+
+    # providing the input file and also forcing the degree to 1
+    os.system("./example_inputs_1d -if inputs_1d_1.txt -d 1 -of %s" % outfile1)
+    os.system("./example_inputs_1d -if inputs_1d_2.txt -d 1 -of %s" % outfile2)
+
+    if not os.path.isfile(outfile1) or not os.path.isfile(outfile2):
+        print("ERROR: example_inputs_1d did not generate an output file")
+        exit(1)
+
+    # using the ASGarD python module to read from the file
+    snapshot1 = asgard.pde_snapshot(outfile1)
+    snapshot2 = asgard.pde_snapshot(outfile2)
+
+    print(" -- using inputs_1d_1.txt --")
+    print("problem title: %s" % snapshot1.title)
+    print("problem   sub: %s" % snapshot1.subtitle)
+    print("num cells:     %s" % snapshot1.num_cells)
+    print("final time:    %s" % snapshot1.time)
+    print(" -- using inputs_1d_2.txt --")
+    print("problem title: %s" % snapshot2.title)
+    print("problem   sub: %s" % snapshot2.subtitle)
+    print("num cells:     %s" % snapshot2.num_cells)
+    print("final time:    %s" % snapshot2.time)
+    print("")
+
+    print("creating plots")
+
+    # see the continuity_2d example for details on the plotting calls
+
+    z1, x1 = snapshot1.plot_data1d(((), ), num_points = 1024)
+    z2, x2 = snapshot2.plot_data1d(((), ), num_points = 1024)
+
+    # expected exact solution
+    h1 = np.sin(x1) * np.cos(snapshot1.time)
+    h2 = np.sin(x2) * np.cos(snapshot1.time)
+
+    # create a new figure with aspect ratio (14, 8)
+    # plot side-by-side as above but using line plots
+    fig = plt.figure(1, figsize=(14, 7))
+
+    ax = plt.subplot2grid((1, 2), (0, 0))
+    ax.set_title("computed", fontsize = 18)
+    comp = ax.plot(x1, z1)
+    ax = plt.subplot2grid((1, 2), (0, 1))
+    ax.set_title("exact", fontsize = 18)
+    comp = ax.plot(x1, h1)
+
+    fig = plt.figure(2, figsize=(14, 7))
+
+    ax = plt.subplot2grid((1, 2), (0, 0))
+    ax.set_title("computed", fontsize = 18)
+    comp = ax.plot(x2, z2)
+    ax = plt.subplot2grid((1, 2), (0, 1))
+    ax.set_title("exact", fontsize = 18)
+    comp = ax.plot(x2, h2)
+
+    print("")  # prettier output
+
+    plt.show()

--- a/examples/inputs_1d_1.txt
+++ b/examples/inputs_1d_1.txt
@@ -1,0 +1,10 @@
+# number of waves
+# this number will be used to set the rest
+# of the discretization parameters
+
+# ASGarD specific inputs, such as "-title"
+# must include the command line "-"
+-title     : Wave inputs test
+-subtitle  : using a single wave
+
+number of waves : 1

--- a/examples/inputs_1d_2.txt
+++ b/examples/inputs_1d_2.txt
@@ -1,0 +1,13 @@
+# number of waves
+# this number will be used to set the rest        
+# of the discretization parameters
+
+# ASGarD specific inputs, such as "-title"
+# must include the command line "-"
+-title     : Wave inputs test
+-subtitle  : using 3 waves
+
+number of waves : 3
+cells per wave  : 8
+# this will require 3 * 8 = 24 cell minimum
+# will round up to the next power of 2, i.e., 32 cells

--- a/src/asgard.cpp
+++ b/src/asgard.cpp
@@ -21,7 +21,8 @@ void simulate(std::unique_ptr<PDE<precision>> &pde)
     node_out() << "  filename: " << options.restart_file << '\n';
   }
   else if (get_local_rank() == 0)
-      options.print();
+    std::cout << options;
+    //options.print_options();
 #else
   if (get_local_rank() == 0)
     options.print();
@@ -193,7 +194,7 @@ void simulate(std::unique_ptr<PDE<precision>> &pde)
 
   kron_operators<precision> operator_matrices;
 
-  for (auto i = start_step; i < options.num_time_steps; ++i)
+  for (auto i = start_step; i < options.num_time_steps.value(); ++i)
   {
     // take a time advance step
     auto const time          = i * pde->get_dt();
@@ -272,6 +273,11 @@ void simulate(std::unique_ptr<PDE<precision>> &pde)
     {
       write_output(*pde, f_val, time + pde->get_dt(), i + 1,
                    f_val.size(), adaptive_grid.get_table(), "asgard_wavelet");
+    }
+    if (i == options.num_time_steps.value() - 1 and not options.outfile.empty())
+    {
+      write_output(*pde, f_val, time + pde->get_dt(), i + 1,
+                   f_val.size(), adaptive_grid.get_table(), "", options.outfile);
     }
 #endif
 

--- a/src/asgard.cpp
+++ b/src/asgard.cpp
@@ -22,7 +22,6 @@ void simulate(std::unique_ptr<PDE<precision>> &pde)
   }
   else if (get_local_rank() == 0)
     std::cout << options;
-    //options.print_options();
 #else
   if (get_local_rank() == 0)
     options.print();

--- a/src/asgard.cpp
+++ b/src/asgard.cpp
@@ -24,7 +24,7 @@ void simulate(std::unique_ptr<PDE<precision>> &pde)
     std::cout << options;
 #else
   if (get_local_rank() == 0)
-    options.print();
+    std::cout << options;
 #endif
 
   node_out() << "--- begin setup ---" << '\n';

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -139,15 +139,33 @@ void generate_initial_moments(
   }
 }
 
+// the method expects either root or fixed name, one must be empty and one not
+// the root is appended with step-number and .h5 extension
+// the fixed filename is used "as-is" without any changes
 template<typename P>
 void write_output(PDE<P> const &pde,
                   fk::vector<P> const &vec, P const time, int const file_index,
                   int const dof, elements::table const &hash_table,
-                  std::string const output_dataset_name = "asgard")
+                  std::string const output_dataset_root  = "asgard",
+                  std::string const output_dataset_fixed = "")
 {
   tools::timer.start("write_output");
-  std::string const output_file_name =
-      output_dataset_name + "_" + std::to_string(file_index) + ".h5";
+
+  expect(not output_dataset_root.empty() or not output_dataset_fixed.empty());
+
+  std::string const output_file_name = [&]()
+      -> std::string {
+    if (output_dataset_root.empty())
+    {
+      expect(not output_dataset_fixed.empty());
+      return output_dataset_fixed;
+    }
+    else
+    {
+      expect(output_dataset_fixed.empty());
+      return output_dataset_root + "_" + std::to_string(file_index) + ".h5";
+    }
+  }();
 
   // TODO: Rewrite this entirely!
   HighFive::File file(output_file_name, HighFive::File::ReadWrite |
@@ -159,7 +177,13 @@ void write_output(PDE<P> const &pde,
 
   // TODO: needs to be checked further based on problem sizes
   HighFive::DataSetCreateProps plist;
-  plist.add(HighFive::Chunking(hsize_t{64}));
+  // just a temporary hack
+  if (hash_table.get_active_table().size() < 32)
+    plist.add(HighFive::Chunking(hsize_t{4}));
+  else if (hash_table.get_active_table().size() < 64)
+    plist.add(HighFive::Chunking(hsize_t{32}));
+  else
+    plist.add(HighFive::Chunking(hsize_t{64}));
   plist.add(HighFive::Deflate(9));
 
   auto const &options = pde.options();
@@ -383,7 +407,7 @@ void read_restart_metadata(prog_opts &options, std::string const &restart_file)
   }
 
   if (get_local_rank() == 0)
-    options.print();
+    options.print_options();
 }
 
 template<typename P>

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -407,7 +407,7 @@ void read_restart_metadata(prog_opts &options, std::string const &restart_file)
   }
 
   if (get_local_rank() == 0)
-    options.print_options();
+    std::cout << options;
 }
 
 template<typename P>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,8 +14,18 @@ int main(int argc, char **argv)
     return 0;
   }
 
+  // custom projects may implement their own inputs
+  //   in addition to ASGarD standard ones
+  // however, this the main executable and all
+  //   unknonw cli commands are to be treated as errors
+  // first we generate warnigns for the user
+  bool constexpr ignore_unknown = false;
   // -- parse cli
-  asgard::prog_opts const cli_input(argc, argv);
+  asgard::prog_opts const cli_input(argc, argv, ignore_unknown);
+
+  // if there were unknown options, throw an error
+  if (not cli_input.externals.empty())
+    throw std::runtime_error("encountered unrecognized command line option");
 
   // main call to asgard, does all the work
   asgard::simulate<precision>(cli_input);

--- a/src/program_options.cpp
+++ b/src/program_options.cpp
@@ -22,7 +22,8 @@ prog_opts::prog_opts(int const argc, char const *const *argv,
   for (auto i : indexof(argc))
     view_argv.emplace_back(argv[i]);
 
-  process_inputs(view_argv, ignore_unknown);
+  process_inputs(
+      view_argv, (ignore_unknown) ? handle_mode::ignore_unknown : handle_mode::warn_on_unknown);
 }
 
 void prog_opts::print_help(std::ostream &os)
@@ -43,6 +44,7 @@ Options          Short   Value      Description
                                     will be saved, reloaded and printed to the screen.
                                     If omitted, the string will assume the name of the PDE.
 -subtitle          -     string     An addition to the title, optional use.
+-infile          -if     filename   Read options and values from a provided file.
 
 <<< discretization of the domain options >>>
 -grid            -g      string     accepts: sparse/dense/full/mixed/mix
@@ -80,6 +82,7 @@ Options          Short   Value      Description
 -wave-freq       -w      int        Interval (in time steps) for outputting the hierarchical
                                     wavelet data, compatible with Python plotting.
 -restart                 filename   Wavelet output file to restart the simulation.
+-outfile         -of     filename   File to write the last step of the simulation.
 
 <<< solvers and linear algebra options >>>
 -kron-mode       -       string     accepts: dense/sparse
@@ -179,7 +182,7 @@ landau_1x3v    Collisional Landau 1x3v.
 }
 
 void prog_opts::process_inputs(std::vector<std::string_view> const &argv,
-                               bool ignore_unknown)
+                               handle_mode mode)
 {
   std::map<std::string_view, optentry> commands = {
       {"help", optentry::show_help}, {"-help", optentry::show_help}, {"--help", optentry::show_help},
@@ -188,6 +191,7 @@ void prog_opts::process_inputs(std::vector<std::string_view> const &argv,
       {"version", optentry::version_help}, {"-v", optentry::version_help},
       {"-pde?", optentry::pde_help}, {"-p?", optentry::pde_help},
       {"-pde", optentry::pde_choice}, {"-p", optentry::pde_choice},
+      {"-infile", optentry::input_file}, {"-if", optentry::input_file},
       {"-title", optentry::title},
       {"-subtitle", optentry::subtitle},
       {"-grid", optentry::grid_mode}, {"-g", optentry::grid_mode},
@@ -201,6 +205,7 @@ void prog_opts::process_inputs(std::vector<std::string_view> const &argv,
       {"-num-steps", optentry::num_time_steps}, {"-n", optentry::num_time_steps},
       {"-wave-freq", optentry::wavelet_output_freq}, {"-w", optentry::wavelet_output_freq},
       {"-real-freq", optentry::realspace_output_freq}, {"-r", optentry::realspace_output_freq},
+      {"-outfile", optentry::output_file}, {"-of", optentry::output_file},
       {"-dt", optentry::dt},
       {"-available-pdes", optentry::pde_help},
       {"-solver", optentry::solver}, {"-sv", optentry::solver},
@@ -246,9 +251,12 @@ void prog_opts::process_inputs(std::vector<std::string_view> const &argv,
     auto imap = commands.find(*iarg);
     if (imap == commands.end())
     { // entry not found
-      if (not ignore_unknown)
+      if (mode == handle_mode::warn_on_unknown)
         std::cerr << "  unrecognized option: " << *iarg << "\n";
-      externals.emplace_back(*iarg);
+      if (mode == handle_mode::save_unknown)
+        filedata.emplace_back(*iarg);
+      else
+        externals.emplace_back(*iarg);
       continue;
     }
 
@@ -263,6 +271,16 @@ void prog_opts::process_inputs(std::vector<std::string_view> const &argv,
     case optentry::pde_help:
       show_pde_help = true;
       break;
+    case optentry::input_file: {
+      auto selected = move_process_next();
+      if (not selected)
+        throw std::runtime_error(report_no_value());
+      if (not infile.empty())
+        throw std::runtime_error("cannot read from two input files");
+      infile = *selected;
+      process_file(argv.front());
+    }
+    break;
     case optentry::grid_mode: {
       auto selected = move_process_next();
       if (not selected)
@@ -375,6 +393,13 @@ void prog_opts::process_inputs(std::vector<std::string_view> const &argv,
       } catch(std::out_of_range &) {
         throw std::runtime_error(report_wrong_value());
       }
+    }
+    break;
+    case optentry::output_file: {
+      auto selected = move_process_next();
+      if (not selected)
+        throw std::runtime_error(report_no_value());
+      outfile = *selected;
     }
     break;
     case optentry::realspace_output_freq: {
@@ -576,7 +601,69 @@ std::optional<PDE_opts> prog_opts::get_pde_opt(std::string_view const &pde_str)
   return (imap != pdes.end()) ? imap->second : std::optional<PDE_opts>();
 }
 
-void prog_opts::print(std::ostream &os) const
+void prog_opts::process_file(std::string_view const &exec_name)
+{
+  // 1. read the lines from the file
+  // 2. split each line into 2 strings
+  // 3. feed the result into process_inputs()
+  //    (this will extract all standard known inputs)
+  // 4. the remaining inputs will be stored in filedata
+  rassert(std::filesystem::exists(infile),
+          "cannot find the input file " + std::string(infile));
+
+  std::ifstream ifs(infile, std::ifstream::in);
+  rassert(ifs, "cannot open the input file " + std::string(infile));
+
+  auto strip_line = [](std::string const &s)
+      -> std::string
+  {
+    if (s.empty())
+      return s;
+    std::string::size_type be = 0;
+    while (std::isspace(static_cast<unsigned char>(s[be])))
+      be++;
+    std::string::size_type en = s.size() - 1;
+    while (en > be and std::isspace(static_cast<unsigned char>(s[en])))
+      en--;
+    return s.substr(be, en - be + 1);
+  };
+
+  std::vector<std::string> line_pairs;
+  std::string line;
+  int line_num = 0;
+  while (getline(ifs, line))
+  {
+    line_num++;
+    //std::cout << "reading line: " << line_num << " as: " << line << '\n';
+    line = strip_line(line);
+    if (line[0] == '#') // ignore lines starting with '#' (comments)
+      continue;
+    //std::cout << "stripped to: " << line << '\n';
+    if (line.empty())
+      continue;
+    auto pos = line.find(':');
+    //std::cout << "found : at position " << pos << '\n';
+    rassert(pos < line.size(),
+            "invalid file format, lines must be '<option> : <value>\nline: "
+              + std::to_string(line_num) + " is missing ':'");
+
+    std::string op = strip_line(line.substr(0, pos));
+    std::string va = strip_line(line.substr(pos + 1, line.size() - pos));
+
+    line_pairs.emplace_back(op);
+    line_pairs.emplace_back(va);
+  }
+
+  std::vector<std::string_view> views;
+  views.reserve(line_pairs.size() + 1);
+  views.emplace_back(exec_name);
+  for (auto &s : line_pairs)
+    views.emplace_back(s);
+
+  process_inputs(views, handle_mode::save_unknown);
+}
+
+void prog_opts::print_options(std::ostream &os) const
 {
   os << "ASGarD problem configuration:\n";
   os << "  title: " << title << '\n';

--- a/src/program_options.cpp
+++ b/src/program_options.cpp
@@ -634,15 +634,12 @@ void prog_opts::process_file(std::string_view const &exec_name)
   while (getline(ifs, line))
   {
     line_num++;
-    //std::cout << "reading line: " << line_num << " as: " << line << '\n';
     line = strip_line(line);
     if (line[0] == '#') // ignore lines starting with '#' (comments)
       continue;
-    //std::cout << "stripped to: " << line << '\n';
     if (line.empty())
       continue;
     auto pos = line.find(':');
-    //std::cout << "found : at position " << pos << '\n';
     rassert(pos < line.size(),
             "invalid file format, lines must be '<option> : <value>\nline: "
               + std::to_string(line_num) + " is missing ':'");

--- a/src/program_options.hpp
+++ b/src/program_options.hpp
@@ -112,6 +112,25 @@ double constexpr notolerance = -1.0;
 
 /*!
  * \internal
+ * \brief Internal use (mostly)
+ *
+ * Allows constructing prog_opts directly from a vector of string_view.
+ * Works around the ambiguity in the constructor between using a filename
+ * and a list of views.
+ * \endinternal
+ */
+struct vecstrview
+{
+  explicit vecstrview(std::vector<std::string_view> const &s) : s_(s)
+  {}
+
+  operator std::vector<std::string_view> const &() const { return s_; }
+
+  std::vector<std::string_view> const &s_;
+};
+
+/*!
+ * \internal
  * \brief Internal use only
  *
  * Takes ownership of a vector of strings and creates an associated vector
@@ -123,7 +142,7 @@ double constexpr notolerance = -1.0;
 struct split_views
 {
   split_views(std::vector<std::string> &&own)
-      : own_(std::move(own))
+      : own_(std::move(own)), strview(views_)
   {
     views_.reserve(own_.size() + 1);
     views_.push_back("test");
@@ -134,8 +153,13 @@ struct split_views
   {
     return views_;
   }
+  operator vecstrview const &()
+  {
+    return strview;
+  }
   std::vector<std::string> own_;
   std::vector<std::string_view> views_;
+  vecstrview strview;
 };
 
 /*!
@@ -154,59 +178,166 @@ struct split_views
  */
 split_views split_argv(std::string_view const &opts);
 
+/*!
+ * \brief Reads options from the command line and input files
+ *
+ * The file and command line capabilities are provided for
+ * convenience and are entirely optional.
+ * The asgsrd::prog_opts objects can be default-constructed as empty,
+ * i.e., no options provided, then each of the values can be set manually
+ * before passing into other ASGarD objects.
+ *
+ * Reading from the command line example:
+ * \code
+ *   int main(int argc, char **argv) {
+ *
+ *     prog_opts options(argc, argv);
+ *
+ *     // for the use of imex, all options can be adjusted
+ *     options.step_method = time_advance::method::imex;
+ *
+ *     // make new PDE with these options
+ *     auto pde = asgard::make_custom_pde<mypde>(options);
+ *
+ * \endcode
+ * This will process the inputs from argv and will also include any inputs
+ * from a file. If an option is present multiple times, the last option
+ * will take precedence, this options hard-coded in the file can be adjusted
+ * from the command line, but only if they appear after the -if option.
+ *
+ * List of the standard ASGarD options can be seen with:
+ * \code
+ *   ./asgard --help # from the command line
+ *   or
+ *   asgard::prog_opts::print_help(); // from C++
+ * \endcode
+ *
+ * Reading extra options from the file:
+ * \code
+ *   std::optional<int> foo = options.file_value<int>("foo");
+ *
+ *   std::optional<double> bar = options.file_value<double>("bar");
+ *
+ *   std::optional<std::string> myname = options.file_value<std::string>("myname");
+ * \endcode
+ * Supported types are bool, int, float, double, and std::string.
+ *
+ * Reading from a hard-coded filename reduces flexibility but can improve
+ * reproducibility:
+ * \code
+ *   prog_opts options("intput_filename.txt")
+ * \endcode
+ *
+ * The file format consists of simple pairs of keys-values separated by colon ":"
+ * Keys that match command line input options will be used as if provided by
+ * the command line, other values can be read and retrieved
+ * \code
+ *  # ASGarD standard options
+ *  -tile         : read from test file
+ *  -start_levels : 4 5
+ *  -max_levels   : 7 8
+ *
+ *  # user specific options
+ *  my keyname 1  : 1.E-4
+ *  my keyname 2  : 5
+ *  my keyname 3  : enable
+ * \endcode
+ * The 3 keys can be retrieved as double, int and bool respectively, or they can
+ * all be read as strings. A good practice is to provide meaningful names for
+ * the keys, e.g., "temperature".
+ *
+ * Notes about the API:
+ * - If the keyword is missing or it is missing a value, the optional will be empty.
+ * - The file_value() method may throw conversion error, e.g., trying to read
+ *   an int from a sting describing a double.
+ * - Boolean values interpreted as true are "true", "on", "enable", "1", "yes"
+ * - Boolean values interpreted as false are "false", "off", "disable", "0", "no"
+ * - ASGarD will not access or use any of the extra options provided in the file
+ *   or the command line, those are responsibility of the user code.
+ */
 struct prog_opts
 {
+  //! if provided, the title helps organize projects with multiple files
   std::string title;
+  //! if provided, the subtitile is an addition to the main title
   std::string subtitle;
 
-  std::optional<adapt_norm> anorm;       // norm to use in adapt
-  std::optional<bool> set_electric;      // do poisson solve for electric field
-  std::optional<double> adapt_threshold; // adapt number of basis levels
+  //! if set, one of the builtin PDEs will be used, keep unset for custom PDE projects
+  std::optional<PDE_opts> pde_choice;
 
-  // the starting and max levels can be set per dimenision or with a single
-  // value that will be applied to all dimenisons
-  // empty vectors mean no user value
+  //! read from -start_levels
   std::vector<int> start_levels;
+  //! read from -max_levels
   std::vector<int> max_levels;
 
-  std::optional<int> degree; // polynomial degree
-  // number of dimensions to use for the tensor groups in mixed grid
+  //! sparse, dense or mixed grid
   std::optional<grid_type> grid;
+  //! if using mixed group, the size of the first mixed group
   std::optional<int> mgrid_group;
+  //! degree of the polynomial basis
+  std::optional<int> degree;
+
+  //! if set, enables grid adaptivity and provides the tolerance threshold
+  std::optional<double> adapt_threshold;
+  //! adaptivity norm, either l2 or linf
+  std::optional<adapt_norm> anorm;
+
+  //! time stepping method, explicit, implicit or imex
+  std::optional<time_advance::method> step_method;
+  //! fixed time step, if missing the default cfl condition will be used
+  std::optional<double> dt;
+  //! number of fixed time steps to take
   std::optional<int> num_time_steps;
 
-  // output frequency of wavelet or real space data
+  //! enable/disable the Poisson solver
+  std::optional<bool> set_electric;
+
+  //! output frequency of wavelet data used for restarts or python plotting
   std::optional<int> wavelet_output_freq;
+  //! older method for plotting using MATLAB integration
   std::optional<int> realspace_output_freq;
 
-  std::optional<time_advance::method> step_method;
-  std::optional<double> dt; // time-step
-
-  std::optional<PDE_opts> pde_choice;
+  //! solver for implicit or imex methods: direct, gmres, bicgstab
   std::optional<solve_opts> solver;
-
-  std::optional<int> memory_limit;        // local-kron only
-  std::optional<kronmult_mode> kron_mode; // local-kron only
-
-  // iterative solver section, the solvers can take tolerance and iterations
-  // and gmres takes an extra parameter of outer iterations
+  //! tolerance for the iterative solvers (gmres, bicgstab)
   std::optional<double> isolver_tolerance;
+  //! max number of iterations (inner iterations for gmres)
   std::optional<int> isolver_iterations;
+  //! max number of output gmres iterations
   std::optional<int> isolver_outer_iterations;
 
-  std::string restart_file; // empty means no user value
+  //! local kron method only, mode dense or sparse (faster but memory hungry)
+  std::optional<kronmult_mode> kron_mode;
+  //! local kron method only, sparse mode, keeps less data on the device
+  std::optional<int> memory_limit;
 
-  bool show_help     = false;
-  bool show_version  = false;
+  //! restart the simulation from a file
+  std::string restart_file;
+  //! filename for the last time step
+  std::filesystem::path outfile;
+
+  //! indicates if the --help option was selected
+  bool show_help = false;
+  //! indicates if the --version option was selected
+  bool show_version = false;
+  //! indicates if the -pde? options was selected
   bool show_pde_help = false;
 
+  //! print list of ASGarD specific options
   static void print_help(std::ostream &os = std::cout);
+  //! print version and build (cmake) options
   static void print_version_help(std::ostream &os = std::cout);
+  //! print information about the builtin PDEs
   static void print_pde_help(std::ostream &os = std::cout);
+  //! print the current set of options
+  void print_options(std::ostream &os = std::cout) const;
 
-  std::vector<std::string_view> externals;
+  //! argv input values unrecognized by ASGarD
+  std::vector<std::string> externals;
 
+  //! converts the start_levels to a human readable string
   std::string start_levels_str() const { return vect_to_str(start_levels); }
+  //! converts the max_levels to a human readable string
   std::string max_levels_str() const { return vect_to_str(max_levels); }
 
   //! create empty options, allows to manually fill the options later
@@ -214,16 +345,33 @@ struct prog_opts
 
   //! process the command line arguments
   prog_opts(int const argc, char const *const *argv,
-            bool ignore_unknown = false);
+            bool ignore_unknown = true);
 
-  //! mostly for testing
-  prog_opts(std::vector<std::string_view> const &argv,
-            bool ignore_unknown = false)
+  //! process from a file
+  explicit prog_opts(std::filesystem::path const &filename)
+      : infile(filename)
   {
-    process_inputs(argv, ignore_unknown);
+    process_file("<executable>");
   }
 
-  void print(std::ostream &os = std::cout) const;
+  //! mostly for testing
+  explicit prog_opts(vecstrview const &argv)
+  {
+    process_inputs(argv, handle_mode::ignore_unknown);
+  }
+
+  //! read an extra option from a file
+  template<typename out_type>
+  std::optional<out_type> file_value(std::string_view const &s) const
+  {
+    return get_val<out_type>(filedata, s);
+  }
+  //! read an extra option from the cli extras
+  template<typename out_type>
+  std::optional<out_type> extra_cli_value(std::string_view const &s) const
+  {
+    return get_val<out_type>(externals, s);
+  }
 
 private:
   //! mapping from cli options to variables and actions
@@ -232,6 +380,7 @@ private:
     show_help,
     version_help,
     pde_help,
+    input_file,
     title,
     subtitle,
     grid_mode,
@@ -245,6 +394,7 @@ private:
     num_time_steps,
     wavelet_output_freq,
     realspace_output_freq,
+    output_file,
     dt,
     pde_choice,
     solver,
@@ -255,10 +405,24 @@ private:
     isol_outer_iterations,
     restart_file,
   };
+  enum class handle_mode
+  {
+    warn_on_unknown, // print warning
+    ignore_unknown,  // do nothing (user inputs)
+    save_unknown     // reading from file
+  };
+
+  //! input filename
+  std::filesystem::path infile;
+
+  //! file inputs, ordered as pairs by line
+  std::vector<std::string> filedata;
+  //! process input file, exec_name is the name of the executable
+  void process_file(std::string_view const &exec_name);
 
   //! not in the constructor so it can be reused when reading from file
   void process_inputs(std::vector<std::string_view> const &argv,
-                      bool ignore_unknown);
+                      handle_mode mode);
   //! map pde options string to enum value
   static std::optional<PDE_opts> get_pde_opt(std::string_view const &pde_str);
 
@@ -294,6 +458,45 @@ private:
     return result;
   }
 
+  template<typename out_type>
+  std::optional<out_type> get_val(std::vector<std::string> const &strs,
+                                  std::string_view const &s) const
+  {
+    static_assert(std::is_same_v<out_type, int> or std::is_same_v<out_type, bool>
+                  or std::is_same_v<out_type, float> or std::is_same_v<out_type, double>
+                  or std::is_same_v<out_type, std::string>,
+                  "prog_opts can only process: int, float, double, bool or string");
+    for (size_t i = 0; i < strs.size(); i += 2)
+    {
+      if (strs[i] == s)
+      {
+        if (i + 1 == strs.size())
+          return {};
+        const std::string &val = strs[i + 1];
+        if constexpr (std::is_same_v<out_type, std::string>)
+          return val;
+        else if constexpr (std::is_same_v<out_type, int>)
+          return std::stoi(val);
+        else if constexpr (std::is_same_v<out_type, double>)
+          return std::stod(val);
+        else if constexpr (std::is_same_v<out_type, float>)
+          return std::stof(val);
+        else if constexpr (std::is_same_v<out_type, bool>)
+        {
+          if (val == "on" or val == "yes" or val == "enable" or val == "true"
+              or val == "1")
+            return true;
+          else if (val == "off" or val == "no" or val == "disable"
+                   or val == "false" or val == "0")
+            return false;
+          else
+            return {};
+        }
+      }
+    }
+    return {};
+  }
+
   //! converts vector of ints into a string
   static std::string vect_to_str(std::vector<int> const &ints)
   {
@@ -313,6 +516,13 @@ private:
 inline prog_opts make_opts(std::string const &cli)
 {
   return prog_opts(split_argv(cli));
+}
+
+//! overload for writing options to a stream
+inline std::ostream &operator<<(std::ostream &os, prog_opts const &options)
+{
+  options.print_options(os);
+  return os;
 }
 
 } // namespace asgard

--- a/src/program_options_tests.cpp
+++ b/src/program_options_tests.cpp
@@ -16,242 +16,353 @@ TEST_CASE("new program options", "[single options]")
 {
   SECTION("no opts")
   {
-    prog_opts prog({""});
+    prog_opts prog(vecstrview({""}));
     REQUIRE_FALSE((prog.show_help and prog.show_pde_help));
   }
   SECTION("no help")
   {
-    prog_opts prog({"", "--help"});
+    prog_opts prog(vecstrview({"", "--help"}));
     REQUIRE(prog.show_help);
-    REQUIRE(prog_opts({"", "-?"}).show_help);
-    REQUIRE(prog_opts({"", "-h"}).show_help);
-    REQUIRE(prog_opts({"", "-help"}).show_help);
-    REQUIRE(prog_opts({"", "help"}).show_help);
-    prog_opts prog2({"", "-p?"});
+    REQUIRE(prog_opts(vecstrview({"", "-?"})).show_help);
+    REQUIRE(prog_opts(vecstrview({"", "-h"})).show_help);
+    REQUIRE(prog_opts(vecstrview({"", "-help"})).show_help);
+    REQUIRE(prog_opts(vecstrview({"", "help"})).show_help);
+    prog_opts prog2(vecstrview({"", "-p?"}));
     REQUIRE(prog2.show_pde_help);
-    REQUIRE(prog_opts({"", "-pde?"}).show_pde_help);
+    REQUIRE(prog_opts(vecstrview({"", "-pde?"})).show_pde_help);
   }
   SECTION("-step-method")
   {
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-step-method"}), "-step-method must be followed by a value, see exe -help");
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-s", "dummy"}), "invalid value for -s, see exe -help");
-    prog_opts prog({"", "-s", "expl"});
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-step-method"})),
+                        "-step-method must be followed by a value, see exe -help");
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-s", "dummy"})),
+                        "invalid value for -s, see exe -help");
+    prog_opts prog(vecstrview({"", "-s", "expl"}));
     REQUIRE(prog.step_method);
     REQUIRE(*prog.step_method == time_advance::method::exp);
-    prog = prog_opts({"", "-s", "impl"});
+    prog = prog_opts(vecstrview({"", "-s", "impl"}));
     REQUIRE(prog.step_method);
     REQUIRE(*prog.step_method == time_advance::method::imp);
-    REQUIRE(prog_opts({"", "-s", "imex"}).step_method.value() == time_advance::method::imex);
+    REQUIRE(prog_opts(vecstrview({"", "-s", "imex"})).step_method.value()
+            == time_advance::method::imex);
   }
   SECTION("-adapt-norm")
   {
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-adapt-norm"}),
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-adapt-norm"})),
                         "-adapt-norm must be followed by a value, see exe -help");
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-an", "dummy"}), "invalid value for -an, see exe -help");
-    prog_opts prog({"", "-an", "l2"});
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-an", "dummy"})),
+                        "invalid value for -an, see exe -help");
+    prog_opts prog(vecstrview({"", "-an", "l2"}));
     REQUIRE(!!prog.anorm);
     REQUIRE(*prog.anorm == adapt_norm::l2);
-    prog_opts prog2({"", "-an", "linf"});
+    prog_opts prog2(vecstrview({"", "-an", "linf"}));
     REQUIRE(!!prog2.anorm);
     REQUIRE(*prog2.anorm == adapt_norm::linf);
   }
   SECTION("-grid")
   {
-    REQUIRE(prog_opts({"exe", "-grid", "sparse"}).grid);
-    REQUIRE(prog_opts({"exe", "-grid", "sparse"}).grid.value() == grid_type::sparse);
-    REQUIRE(prog_opts({"exe", "-g", "dense"}).grid.value() == grid_type::dense);
-    REQUIRE(prog_opts({"exe", "-g", "mix", "1"}).grid.value() == grid_type::mixed);
-    REQUIRE(prog_opts({"exe", "-g", "mixed", "2"}).grid.value() == grid_type::mixed);
-    prog_opts opts({"exe", "-g", "mixed", "2"});
+    REQUIRE(prog_opts(vecstrview({"exe", "-grid", "sparse"})).grid);
+    REQUIRE(prog_opts(vecstrview({"exe", "-grid", "sparse"})).grid.value() == grid_type::sparse);
+    REQUIRE(prog_opts(vecstrview({"exe", "-g", "dense"})).grid.value() == grid_type::dense);
+    REQUIRE(prog_opts(vecstrview({"exe", "-g", "mix", "1"})).grid.value() == grid_type::mixed);
+    REQUIRE(prog_opts(vecstrview({"exe", "-g", "mixed", "2"})).grid.value() == grid_type::mixed);
+    prog_opts opts(vecstrview({"exe", "-g", "mixed", "2"}));
     REQUIRE(opts.mgrid_group);
     REQUIRE(opts.mgrid_group.value() == 2);
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-g"}), "-g must be followed by a value, see exe -help");
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-g", "dummy"}), "invalid value for -g, see exe -help");
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-g", "mix"}), "mix must be followed by a value, see exe -help");
-    prog_opts opts3({"exe", "-g", "sparse"});
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-g"})),
+                        "-g must be followed by a value, see exe -help");
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-g", "dummy"})),
+                        "invalid value for -g, see exe -help");
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-g", "mix"})),
+                        "mix must be followed by a value, see exe -help");
+    prog_opts opts3(vecstrview({"exe", "-g", "sparse"}));
     REQUIRE_FALSE(opts3.mgrid_group);
   }
   SECTION("-electric-solve")
   {
-    REQUIRE_FALSE(!!prog_opts({""}).set_electric);
-    prog_opts prog({"", "-electric-solve"});
+    REQUIRE_FALSE(!!prog_opts(vecstrview({""})).set_electric);
+    prog_opts prog(vecstrview({"", "-electric-solve"}));
     REQUIRE(prog.set_electric);
     REQUIRE(prog.set_electric.value());
-    prog_opts prog2({"", "-es"});
+    prog_opts prog2(vecstrview({"", "-es"}));
     REQUIRE(prog2.set_electric);
     REQUIRE(prog2.set_electric.value());
   }
   SECTION("-start-levels")
   {
-    prog_opts prog({"", "-start-levels", "3 4"});
+    prog_opts prog(vecstrview({"", "-start-levels", "3 4"}));
     REQUIRE_FALSE(prog.start_levels.empty());
     REQUIRE(prog.start_levels.size() == 2);
     auto const &arr = prog.start_levels;
     REQUIRE(arr[0] == 3);
     REQUIRE(arr[1] == 4);
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-l"}), "-l must be followed by a value, see exe -help");
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-l", "\"\""}), "invalid value for -l, see exe -help");
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-l"})),
+                        "-l must be followed by a value, see exe -help");
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-l", "\"\""})),
+                        "invalid value for -l, see exe -help");
     // the test checks if guard agains overflor over max_num_dimensions
     // must be updated if we ever go above 6 dimensions
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-l", "1 1 1 1 1 1 1"}), "invalid value for -l, see exe -help");
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-l", "1 1 1 1 1 1 1"})),
+                        "invalid value for -l, see exe -help");
   }
   SECTION("-max-levels")
   {
-    prog_opts prog({"", "-max-levels", "9 8 3"});
+    prog_opts prog(vecstrview({"", "-max-levels", "9 8 3"}));
     REQUIRE_FALSE(prog.max_levels.empty());
     REQUIRE(prog.max_levels.size() == 3);
     auto const &arr = prog.max_levels;
     REQUIRE(arr[0] == 9);
     REQUIRE(arr[1] == 8);
     REQUIRE(arr[2] == 3);
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-m"}), "-m must be followed by a value, see exe -help");
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-m", "\"\""}), "invalid value for -m, see exe -help");
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-m"})),
+                        "-m must be followed by a value, see exe -help");
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-m", "\"\""})),
+                        "invalid value for -m, see exe -help");
   }
   SECTION("-degree")
   {
-    prog_opts prog({"", "-degree", "2"});
+    prog_opts prog(vecstrview({"", "-degree", "2"}));
     REQUIRE(prog.degree);
     REQUIRE(prog.degree.value() == 2);
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-d"}), "-d must be followed by a value, see exe -help");
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-d", "dummy"}), "invalid value for -d, see exe -help");
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-d"})),
+                        "-d must be followed by a value, see exe -help");
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-d", "dummy"})),
+                        "invalid value for -d, see exe -help");
     // checks for out-of-range overflow
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-d", "8100100100"}), "invalid value for -d, see exe -help");
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-d", "8100100100"})),
+                        "invalid value for -d, see exe -help");
   }
   SECTION("-num_steps")
   {
-    prog_opts prog({"", "-num-steps", "2"});
+    prog_opts prog(vecstrview({"", "-num-steps", "2"}));
     REQUIRE(prog.num_time_steps);
     REQUIRE(prog.num_time_steps.value() == 2);
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-m"}), "-m must be followed by a value, see exe -help");
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-num-steps", "dummy"}), "invalid value for -num-steps, see exe -help");
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-m"})),
+                        "-m must be followed by a value, see exe -help");
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-num-steps", "dummy"})),
+                        "invalid value for -num-steps, see exe -help");
   }
   SECTION("-wave_freq")
   {
-    prog_opts prog({"", "-wave-freq", "10"});
+    prog_opts prog(vecstrview({"", "-wave-freq", "10"}));
     REQUIRE(prog.wavelet_output_freq);
     REQUIRE(prog.wavelet_output_freq.value() == 10);
-    REQUIRE(prog_opts({"exe", "-w", "4"}).wavelet_output_freq);
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-w"}), "-w must be followed by a value, see exe -help");
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-wave-freq", "dummy"}), "invalid value for -wave-freq, see exe -help");
+    REQUIRE(prog_opts(vecstrview({"exe", "-w", "4"})).wavelet_output_freq);
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-w"})),
+                        "-w must be followed by a value, see exe -help");
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-wave-freq", "dummy"})),
+                        "invalid value for -wave-freq, see exe -help");
   }
   SECTION("-real_freq")
   {
-    prog_opts prog({"", "-real-freq", "12"});
+    prog_opts prog(vecstrview({"", "-real-freq", "12"}));
     REQUIRE(prog.realspace_output_freq);
     REQUIRE(prog.realspace_output_freq.value() == 12);
-    REQUIRE(prog_opts({"exe", "-r", "9"}).realspace_output_freq);
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-r"}), "-r must be followed by a value, see exe -help");
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-real-freq", "dummy"}), "invalid value for -real-freq, see exe -help");
+    REQUIRE(prog_opts(vecstrview({"exe", "-r", "9"})).realspace_output_freq);
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-r"})),
+                        "-r must be followed by a value, see exe -help");
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-real-freq", "dummy"})),
+                        "invalid value for -real-freq, see exe -help");
   }
   SECTION("-dt")
   {
-    prog_opts prog({"", "-dt", "0.5"});
+    prog_opts prog(vecstrview({"", "-dt", "0.5"}));
     REQUIRE(prog.dt);
     REQUIRE(prog.dt.value() == 0.5);
-    REQUIRE(prog_opts({"exe", "-dt", "0.1"}).dt);
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-dt"}), "-dt must be followed by a value, see exe -help");
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-dt", "dummy"}), "invalid value for -dt, see exe -help");
+    REQUIRE(prog_opts(vecstrview({"exe", "-dt", "0.1"})).dt);
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-dt"})),
+                        "-dt must be followed by a value, see exe -help");
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-dt", "dummy"})),
+                        "invalid value for -dt, see exe -help");
   }
   SECTION("-adapt")
   {
-    prog_opts prog({"", "-adapt", "0.5"});
+    prog_opts prog(vecstrview({"", "-adapt", "0.5"}));
     REQUIRE(prog.adapt_threshold);
     REQUIRE(prog.adapt_threshold.value() == 0.5);
-    REQUIRE(prog_opts({"exe", "-adapt", "0.1"}).adapt_threshold);
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-a"}), "-a must be followed by a value, see exe -help");
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-adapt", "dummy"}), "invalid value for -adapt, see exe -help");
+    REQUIRE(prog_opts(vecstrview({"exe", "-adapt", "0.1"})).adapt_threshold);
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-a"})),
+                        "-a must be followed by a value, see exe -help");
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-adapt", "dummy"})),
+                        "invalid value for -adapt, see exe -help");
   }
   SECTION("-solver")
   {
-    prog_opts prog({"", "-solver", "direct"});
+    prog_opts prog(vecstrview({"", "-solver", "direct"}));
     REQUIRE(prog.solver);
     REQUIRE(prog.solver.value() == solve_opts::direct);
-    REQUIRE(prog_opts({"exe", "-sv", "gmres"}).solver.value() == solve_opts::gmres);
-    REQUIRE(prog_opts({"exe", "-solver", "bicgstab"}).solver.value() == solve_opts::bicgstab);
-    REQUIRE(prog_opts({"exe", "-sv", "scalapack"}).solver.value() == solve_opts::scalapack);
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-solver", "dummy"}), "invalid value for -solver, see exe -help");
+    REQUIRE(prog_opts(vecstrview({"exe", "-sv", "gmres"})).solver.value() == solve_opts::gmres);
+    REQUIRE(prog_opts(vecstrview({"exe", "-solver", "bicgstab"})).solver.value() == solve_opts::bicgstab);
+    REQUIRE(prog_opts(vecstrview({"exe", "-sv", "scalapack"})).solver.value() == solve_opts::scalapack);
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-solver", "dummy"})),
+                        "invalid value for -solver, see exe -help");
   }
   SECTION("-memory")
   {
-    prog_opts prog({"", "-memory", "1024"});
+    prog_opts prog(vecstrview({"", "-memory", "1024"}));
     REQUIRE(prog.memory_limit);
     REQUIRE(prog.memory_limit.value() == 1024);
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-memory"}), "-memory must be followed by a value, see exe -help");
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-memory", "dummy"}), "invalid value for -memory, see exe -help");
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-memory"})),
+                        "-memory must be followed by a value, see exe -help");
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-memory", "dummy"})),
+                        "invalid value for -memory, see exe -help");
   }
   SECTION("-kron-mode")
   {
-    prog_opts prog({"", "-kron-mode", "dense"});
+    prog_opts prog(vecstrview({"", "-kron-mode", "dense"}));
     REQUIRE(prog.kron_mode);
     REQUIRE(prog.kron_mode.value() == kronmult_mode::dense);
-    REQUIRE(prog_opts({"", "-kron-mode", "sparse"}).kron_mode.value() == kronmult_mode::sparse);
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-kron-mode"}),
+    REQUIRE(prog_opts(vecstrview({"", "-kron-mode", "sparse"})).kron_mode.value()
+            == kronmult_mode::sparse);
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-kron-mode"})),
                         "-kron-mode must be followed by a value, see exe -help");
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-kron-mode", "dummy"}),
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-kron-mode", "dummy"})),
                         "invalid value for -kron-mode, see exe -help");
   }
   SECTION("-isolve_tol")
   {
-    prog_opts prog({"", "-isolve-tol", "0.25"});
+    prog_opts prog(vecstrview({"", "-isolve-tol", "0.25"}));
     REQUIRE(prog.isolver_tolerance);
     REQUIRE(prog.isolver_tolerance.value() == 0.25);
-    REQUIRE(prog_opts({"exe", "-ist", "0.1"}).isolver_tolerance);
-    REQUIRE(prog_opts({"exe", "-isolve-tol", "0.01"}).isolver_tolerance.value() < 0.02);
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-isolve-tol"}),
+    REQUIRE(prog_opts(vecstrview({"exe", "-ist", "0.1"})).isolver_tolerance);
+    REQUIRE(prog_opts(vecstrview({"exe", "-isolve-tol", "0.01"})).isolver_tolerance.value() < 0.02);
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-isolve-tol"})),
                         "-isolve-tol must be followed by a value, see exe -help");
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-ist", "dummy"}),
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-ist", "dummy"})),
                         "invalid value for -ist, see exe -help");
   }
   SECTION("-isolve_iter")
   {
-    prog_opts prog({"", "-isolve-iter", "100"});
+    prog_opts prog(vecstrview({"", "-isolve-iter", "100"}));
     REQUIRE(prog.isolver_iterations);
     REQUIRE(prog.isolver_iterations.value() == 100);
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-isolve-iter"}),
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-isolve-iter"})),
                         "-isolve-iter must be followed by a value, see exe -help");
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-isi", "dummy"}),
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-isi", "dummy"})),
                         "invalid value for -isi, see exe -help");
   }
   SECTION("-isolve_outer")
   {
-    prog_opts prog({"", "-isolve-outer", "200"});
+    prog_opts prog(vecstrview({"", "-isolve-outer", "200"}));
     REQUIRE(prog.isolver_outer_iterations);
     REQUIRE(prog.isolver_outer_iterations.value() == 200);
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-isolve-outer"}),
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-isolve-outer"})),
                         "-isolve-outer must be followed by a value, see exe -help");
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-iso", "dummy"}),
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-iso", "dummy"})),
                         "invalid value for -iso, see exe -help");
   }
   SECTION("-pde")
   {
-    prog_opts prog({"", "-pde", "continuity_6"});
+    prog_opts prog(vecstrview({"", "-pde", "continuity_6"}));
     REQUIRE(prog.pde_choice);
     REQUIRE(prog.pde_choice.value() == PDE_opts::continuity_6);
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-pde"}),
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-pde"})),
                         "-pde must be followed by a value, see exe -help");
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-p", "dummy"}),
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-p", "dummy"})),
                         "invalid pde 'dummy', see 'exe -pde?' for full list");
   }
   SECTION("-title")
   {
-    prog_opts prog({"", "-title", "mypde"});
+    prog_opts prog(vecstrview({"", "-title", "mypde"}));
     REQUIRE_FALSE(prog.title.empty());
     REQUIRE(prog.title == "mypde");
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-title"}),
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-title"})),
                         "-title must be followed by a value, see exe -help");
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-title", ""}),
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-title", ""})),
                         "invalid value for -title, see exe -help");
-    prog_opts prog2({"", "-title", "continuity_6"});
+    prog_opts prog2(vecstrview({"", "-title", "continuity_6"}));
     REQUIRE_FALSE(prog2.title.empty());
     REQUIRE(prog2.title == "continuity_6");
   }
   SECTION("-subtitle")
   {
-    prog_opts prog({"", "-subtitle", "mypde-variant"});
+    prog_opts prog(vecstrview({"", "-subtitle", "mypde-variant"}));
     REQUIRE_FALSE(prog.subtitle.empty());
     REQUIRE(prog.subtitle == "mypde-variant");
-    REQUIRE_THROWS_WITH(prog_opts({"exe", "-subtitle"}),
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-subtitle"})),
                         "-subtitle must be followed by a value, see exe -help");
-    REQUIRE(prog_opts({"exe", "-subtitle", "dummy", "-subtitle", ""}).subtitle.empty());
+    REQUIRE(prog_opts(vecstrview({"exe", "-subtitle", "dummy", "-subtitle", ""})).subtitle.empty());
+  }
+  SECTION("-outfile")
+  {
+    prog_opts prog(vecstrview({"", "-outfile", "some-file"}));
+    REQUIRE_FALSE(prog.outfile.empty());
+    REQUIRE(prog.outfile == "some-file");
+    REQUIRE_THROWS_WITH(prog_opts(vecstrview({"exe", "-of"})),
+                        "-of must be followed by a value, see exe -help");
+    REQUIRE(prog_opts(vecstrview({"exe", "-outfile", "dummy", "-of", ""})).subtitle.empty());
+  }
+}
+
+TEST_CASE("input file processing", "[file i/o]")
+{
+  SECTION("test_input1.txt")
+  {
+    prog_opts prog(vecstrview({"", "-l", "3", "-if", "test_input1.txt"}));
+    REQUIRE_FALSE(prog.start_levels.empty());
+    REQUIRE(prog.start_levels[0] == 5);
+    REQUIRE(prog.adapt_threshold);
+    REQUIRE(prog.adapt_threshold.value() == 0.125);
+    REQUIRE(prog.grid);
+    REQUIRE(prog.grid.value() == grid_type::dense);
+    REQUIRE(prog.step_method);
+    REQUIRE(prog.step_method.value() == time_advance::method::exp);
+
+    REQUIRE_FALSE(prog.file_value<int>("missing"));
+    auto bbool = prog.file_value<bool>("bb1");
+    static_assert(std::is_same_v<decltype(bbool), std::optional<bool>>);
+    REQUIRE(bbool);
+    REQUIRE(bbool.value());
+    auto iint = prog.file_value<int>("some_int");
+    static_assert(std::is_same_v<decltype(iint), std::optional<int>>);
+    REQUIRE(iint);
+    REQUIRE(iint.value() == 8);
+
+    prog_opts prog2(vecstrview({"", "-infile", "test_input1.txt", "-l", "3"}));
+    REQUIRE_FALSE(prog2.start_levels.empty());
+    REQUIRE(prog2.start_levels[0] == 3);
+  }
+
+  SECTION("test_input2.txt")
+  {
+    prog_opts prog(vecstrview({"", "-if", "test_input2.txt"}));
+    REQUIRE(prog.start_levels.size() == 4);
+    REQUIRE(prog.start_levels[0] ==  9);
+    REQUIRE(prog.start_levels[1] == 11);
+    REQUIRE(prog.start_levels[2] ==  1);
+    REQUIRE(prog.start_levels[3] == 88);
+    REQUIRE(prog.title == "some long title");
+    REQUIRE(prog.subtitle == "short title");
+
+    auto dbl = prog.file_value<double>("v_thermal");
+    static_assert(std::is_same_v<decltype(dbl), std::optional<double>>);
+    REQUIRE(dbl);
+    REQUIRE(dbl.value() == 0.5);
+
+    auto flt = prog.file_value<float>("half percent");
+    static_assert(std::is_same_v<decltype(flt), std::optional<float>>);
+    REQUIRE(flt);
+    REQUIRE(std::abs(flt.value() - 5.E-3) < 1.E-6);
+
+    REQUIRE_FALSE(prog.file_value<float>("misspelled"));
+
+    auto name = prog.file_value<std::string>("extra name");
+    static_assert(std::is_same_v<decltype(name), std::optional<std::string>>);
+    REQUIRE(!!name);
+    REQUIRE(name.value() == "some-name test");
+  }
+
+  SECTION("test_input1.txt -- direct ")
+  {
+    prog_opts prog("test_input1.txt");
+    REQUIRE(prog.start_levels.size() == 1);
+    REQUIRE(prog.start_levels[0] == 5);
+    REQUIRE(prog.adapt_threshold);
+    REQUIRE(prog.adapt_threshold.value() == 0.125);
+
+    auto iint = prog.file_value<int>("some_int");
+    static_assert(std::is_same_v<decltype(iint), std::optional<int>>);
+    REQUIRE(iint);
+    REQUIRE(iint.value() == 8);
   }
 }

--- a/testing/TestingCMakeLists.txt
+++ b/testing/TestingCMakeLists.txt
@@ -10,4 +10,4 @@ find_package(asgard @asgard_VERSION_MAJOR@.@asgard_VERSION_MINOR@.@asgard_VERSIO
 add_subdirectory("@CMAKE_INSTALL_PREFIX@/share/asgard/examples" examples_cxx)
 
 add_test(continuity_2d  "${CMAKE_CURRENT_BINARY_DIR}/examples_cxx/example_continuity_2d")
-add_test(input_1d       "${CMAKE_CURRENT_BINARY_DIR}/examples_cxx/example_input_1d")
+add_test(input_1d       "${CMAKE_CURRENT_BINARY_DIR}/examples_cxx/example_inputs_1d")

--- a/testing/TestingCMakeLists.txt
+++ b/testing/TestingCMakeLists.txt
@@ -10,3 +10,4 @@ find_package(asgard @asgard_VERSION_MAJOR@.@asgard_VERSION_MINOR@.@asgard_VERSIO
 add_subdirectory("@CMAKE_INSTALL_PREFIX@/share/asgard/examples" examples_cxx)
 
 add_test(continuity_2d  "${CMAKE_CURRENT_BINARY_DIR}/examples_cxx/example_continuity_2d")
+add_test(input_1d       "${CMAKE_CURRENT_BINARY_DIR}/examples_cxx/example_input_1d")

--- a/testing/TestingCMakeLists.txt
+++ b/testing/TestingCMakeLists.txt
@@ -10,4 +10,4 @@ find_package(asgard @asgard_VERSION_MAJOR@.@asgard_VERSION_MINOR@.@asgard_VERSIO
 add_subdirectory("@CMAKE_INSTALL_PREFIX@/share/asgard/examples" examples_cxx)
 
 add_test(continuity_2d  "${CMAKE_CURRENT_BINARY_DIR}/examples_cxx/example_continuity_2d")
-add_test(input_1d       "${CMAKE_CURRENT_BINARY_DIR}/examples_cxx/example_inputs_1d")
+add_test(input_1d       "${CMAKE_CURRENT_BINARY_DIR}/examples_cxx/example_inputs_1d" "-if" "examples_cxx/inputs_1d_1.txt")

--- a/testing/automated/clang-format-check.sh
+++ b/testing/automated/clang-format-check.sh
@@ -121,8 +121,8 @@ permutations.cpp
 permutations.hpp
 permutations_tests.cpp
 #program_options.cpp
-program_options.hpp
-program_options_tests.cpp
+#program_options.hpp
+#program_options_tests.cpp
 quadrature.cpp
 quadrature.hpp
 quadrature_tests.cpp

--- a/testing/sandbox.cpp
+++ b/testing/sandbox.cpp
@@ -6,6 +6,8 @@ using prec = asgard::default_precision;
 
 int main(int argc, char **argv)
 {
+  ignore(argc);
+  ignore(argv);
   // keep this file clean for each PR
   // allows someone to easily come here, dump code and start playing
   // this is good for prototyping and quick-testing features/behavior

--- a/testing/sandbox.cpp
+++ b/testing/sandbox.cpp
@@ -9,13 +9,5 @@ int main(int argc, char **argv)
   // keep this file clean for each PR
   // allows someone to easily come here, dump code and start playing
   // this is good for prototyping and quick-testing features/behavior
-
-  prog_opts opts(argc, argv);
-
-  std::cout << " read start levels: \n";
-  for (auto l : opts.start_levels)
-    std::cout << l << "  ";
-  std::cout << '\n';
-
   return 0;
 }

--- a/testing/sandbox.cpp
+++ b/testing/sandbox.cpp
@@ -4,10 +4,18 @@ using namespace asgard;
 
 using prec = asgard::default_precision;
 
-int main(int, char **)
+int main(int argc, char **argv)
 {
   // keep this file clean for each PR
   // allows someone to easily come here, dump code and start playing
   // this is good for prototyping and quick-testing features/behavior
+
+  prog_opts opts(argc, argv);
+
+  std::cout << " read start levels: \n";
+  for (auto l : opts.start_levels)
+    std::cout << l << "  ";
+  std::cout << '\n';
+
   return 0;
 }

--- a/testing/test_input1.txt
+++ b/testing/test_input1.txt
@@ -1,0 +1,11 @@
+# this is deliberately misalined
+# tests for robustness of the parser
+-l  : 5
+ -a: 0.125 
+# nothing of interest here
+  -g:   dense   
+-s : expl  
+  # more comments
+
+ bb1 :   yes 
+some_int : 8

--- a/testing/test_input2.txt
+++ b/testing/test_input2.txt
@@ -1,0 +1,9 @@
+# second test file
+-title : some long title
+-subtitle : short title
+  # # some deliberate misalignment
+ -start-levels  :  9  11 1 88  
+v_thermal : 0.5
+    half percent : 5.E-3 
+ extra name  :  some-name test
+    


### PR DESCRIPTION
Added the ability to use external input files for both ASGarD specific options, e.g., `-m` and `-l`, as well as project specific options. See the included example.

This will allows us to put variables such as temperature and thermal velocity in an input-deck.