### PR TITLE
allow inlined comments in the file

### DIFF
--- a/src/asgard_program_options.cpp
+++ b/src/asgard_program_options.cpp
@@ -625,6 +625,9 @@ void prog_opts::process_file(std::string_view const &exec_name)
     while (std::isspace(static_cast<unsigned char>(s[be])))
       be++;
     std::string::size_type en = s.size() - 1;
+    std::string::size_type sharp = s.find('#');
+    if (sharp < s.size())
+      en = sharp - 1;
     while (en > be and std::isspace(static_cast<unsigned char>(s[en])))
       en--;
     return s.substr(be, en - be + 1);

--- a/src/asgard_program_options_tests.cpp
+++ b/src/asgard_program_options_tests.cpp
@@ -338,6 +338,11 @@ TEST_CASE("input file processing", "[file i/o]")
     static_assert(std::is_same_v<decltype(name), std::optional<std::string>>);
     REQUIRE(!!name);
     REQUIRE(name.value() == "some-name test");
+
+    auto nu = prog.file_value<int>("var nu");
+    static_assert(std::is_same_v<decltype(nu), std::optional<int>>);
+    REQUIRE(!!nu);
+    REQUIRE(nu.value() == 314);
   }
 
   SECTION("test_input1.txt -- direct ")

--- a/testing/test_input2.txt
+++ b/testing/test_input2.txt
@@ -7,3 +7,5 @@ v_thermal : 0.5
     half percent : 5.E-3 
  extra name  :  some-name test
     
+  # line above has white spaces # #
+ var nu  :  314 # inlined comment


### PR DESCRIPTION
Small improvement, allows parsing inline comments, e.g.,
```
thermal conductivity : 401 # W / mK
```