### PR TITLE
Command Line Parsing for Poisson Solver Options

### DIFF
--- a/python/asgard.py
+++ b/python/asgard.py
@@ -73,7 +73,7 @@ class pde_snapshot:
 
             self.degree = fdata['degree'][()]
             self.state  = fdata['state'][()]
-            assert np.isfinite(self.state).any(), "The state file is corrupt, contains 'inf' and/or 'nan'"
+            assert np.isfinite(self.state).all(), "The state file is corrupt, contains 'inf' and/or 'nan'"
 
             self.timer_report = fdata['timer_report'][()].decode("utf-8")
 
@@ -261,6 +261,20 @@ class pde_snapshot:
         for i in range(1, len(lpows)):
             name += f", {lpows[i]}"
         mom_field.title = f"moment ({name})"
+        mom_field.subtitle = ""
+
+        return mom_field
+
+    def get_efield(self, dim):
+        assert dim <= self.num_position, f"invalid dimension index {dim}, must be no larger than {self.num_position}"
+        name = "__moment_"
+        for p in range(self.num_velocity):
+            name += f"0" if p != dim - 1 else f"{-0xef}"
+        for i in range(self.num_velocity, 3):
+            name += "x"
+
+        mom_field = self.get_aux_field(name)
+        mom_field.title = f"moment E{dim}"
         mom_field.subtitle = ""
 
         return mom_field
@@ -507,6 +521,8 @@ def plot_with_args(argv = None):
         print(" -aux                        : auxilary field id")
         print(" -mom                        : plot a moment, must be registered in the pde-scheme")
         print('                               the format is -mom "0 1" or -mom "0:1" ')
+        print(" -efield                     : plot the electric field, must be registered in the pde-scheme")
+        print('                               the format is -efield {1 | 2 | 3} where the integer is the dimension index ')
         print(" -cmap                       : set the matplotlib colormap, see Matplotlib docs")
         print("")
         print("no file and no option provided, shows the version of the")
@@ -585,6 +601,12 @@ def plot_with_args(argv = None):
                     else:
                         lpows = moment.split(" ")
                     moment = [int(p) for p in lpows]
+                elif argv[i] == "-efield":
+                    assert auxfield is None, "cannot simultaneously plot aux field and electric field"
+                    efield = int(argv[i + 1]) if i + 1 < n else None
+                    assert 1 <= efield <= 3, "-efield requires an index between 1 and 3"
+                    i += 2
+                    assert efield is not None, "-efield requires an index, e.g., -efield 1 "
                 elif argv[i] == "-grid" or argv[i] == "-g":
                     addgrid = True
                     i += 1
@@ -604,6 +626,8 @@ def plot_with_args(argv = None):
             shot = shot.get_aux_field(auxfield)
         if moment is not None:
             shot = shot.get_moment(moment)
+        if efield is not None:
+            shot = shot.get_efield(efield)
 
         asgplot.title(shot.title, fontsize = 'large')
 

--- a/src/asgard_discretization.cpp
+++ b/src/asgard_discretization.cpp
@@ -220,7 +220,7 @@ void discretization_manager<precision>::start_moments() {
     auto build_func = [this](term_entry<precision> &tentry, int const dim, int const level) -> void {
       this->terms.rebuild_term1d(tentry, dim, level);
     };
-    terms.moms.set_poisson(terms.max_level, terms.grid, terms.xleft, terms.xright, terms.conn, terms.hier, build_func);
+    terms.moms.set_poisson(terms.max_level, terms.grid, terms.xleft, terms.xright, terms.conn, terms.hier, build_func, options_);
   }
   terms.moms.update_position_grid(terms.grid);
   std::visit([&](auto &p)

--- a/src/asgard_io.cpp
+++ b/src/asgard_io.cpp
@@ -141,7 +141,8 @@ void h5manager<P>::write(prog_opts const &options, pde_domain<P> const &domain,
     if (moms.has_poisson()) {
       moment_id m0 = moms.find_id(moment::zero(moms.num_vel()));
       moms.cache_moment(m0, grid, state);
-      moms.solve_poisson(terms.grid, terms.conn, terms.hier, terms.interp, terms.kwork);
+      constexpr bool raw_on_cpu = true;
+      moms.solve_poisson(terms.grid, terms.conn, terms.hier, terms.interp, terms.kwork, raw_on_cpu);
     }
     for (int i : iindexof(moms.num_moments()))
     {

--- a/src/asgard_iterative_solver.cpp
+++ b/src/asgard_iterative_solver.cpp
@@ -29,8 +29,6 @@ int cg<P>::solve(operation_apply_precon<P> precon, operation_apply_lhs<P> apply_
   apply_lhs(-1.0, x.data(), 1.0, r.data()); // r = b - A * x
 
   P rho = dot(r, r);
-  if (rho < tolerance_)
-    return num_apply;
 
   if (precon != nullptr) {
     z = r;

--- a/src/asgard_moment_manager.cpp
+++ b/src/asgard_moment_manager.cpp
@@ -1038,7 +1038,7 @@ void moment_manager<P>::compute_moments(
 
       // solve poisson equation while w1 holds density
       if (mom.is_zero()) {
-        assert(g == 0); // poisson used gpu 0 for solve
+        assert(g == 0); // poisson uses gpu 0 for solve
         solve_poisson_gpu(conn, hier, interp, kwork);
       }
 

--- a/src/asgard_moment_manager.cpp
+++ b/src/asgard_moment_manager.cpp
@@ -80,17 +80,19 @@ void moment_manager<P>::set_poisson(int const max_level, sparse_grid const &grid
                                     std::array<P, max_num_dimensions> const &xright,
                                     connection_patterns const &conn,
                                     hierarchy_manipulator<P> const &hier,
-                                    build_term_func<P> build_func)
+                                    build_term_func<P> build_func, prog_opts const &opts)
 {
   if (mlist.has_electric()) {
     moment_id const m0 = find_id(moment::zero(num_vel_));
     if (num_pos_ == 1) {
       moment_id const melectric = find_id(moment::electric(dimension_id(0), num_pos_));
-      poisson_solver = poisson_1d<P>(hier.degree(), xleft[0], xright[0],
-                                     grid.current_level(0), m0, melectric);
+      poisson_solver = poisson_1d<P>(hier.degree(), xleft[0], xright[0], grid.current_level(0), m0, melectric);
     } else {
-      poisson_solver = poisson_md<P>(num_pos_, max_level, xleft, xright, conn, hier,
-                                     mlist, build_func, m0);
+      rassert(opts.poisson_tolerance, "The tolerance for the poisson solver must be provided. "
+                                      "Use -poisson-tol or -pt");
+      rassert(opts.poisson_iterations, "The maximum number of iterations for the poisson solver must be provided. "
+                                       "Use -poisson-iter or -pi");
+      poisson_solver = poisson_md<P>(num_pos_, max_level, xleft, xright, conn, hier, mlist, build_func, m0, opts);
     }
   }
 }

--- a/src/asgard_moment_manager.hpp
+++ b/src/asgard_moment_manager.hpp
@@ -203,7 +203,7 @@ public:
                    std::array<P, max_num_dimensions> const &xright,
                    connection_patterns const &conn,
                    hierarchy_manipulator<P> const &hier,
-                   build_term_func<P> build_func);
+                   build_term_func<P> build_func, prog_opts const &opts);
 
   //! Updates the position grid if needed
   void update_position_grid(sparse_grid const &grid) const;

--- a/src/asgard_pde.hpp
+++ b/src/asgard_pde.hpp
@@ -1608,6 +1608,13 @@ public:
         options_.isolver_iterations = options_.default_isolver_iterations.value();
       if (not options_.isolver_inner_iterations and options_.default_isolver_inner_iterations)
         options_.isolver_inner_iterations = options_.default_isolver_inner_iterations.value();
+      // setting up the poisson solver options for a possible poisson solver
+      if (not options_.poisson_precon and options_.default_poisson_precon)
+        options_.poisson_precon = options_.default_poisson_precon.value();
+      if (not options_.poisson_tolerance and options_.default_poisson_tolerance)
+        options_.poisson_tolerance = options_.default_poisson_tolerance.value();
+      if (not options_.poisson_iterations and options_.default_poisson_iterations)
+        options_.poisson_iterations = options_.default_poisson_iterations.value();
     }
   }
 

--- a/src/asgard_poisson.cpp
+++ b/src/asgard_poisson.cpp
@@ -109,23 +109,71 @@ void poisson_md<P>::solve(std::vector<P> &density, momentset<P> &moms,
 }
 
 template<typename P>
+void poisson_md<P>::remap_(std::vector<P> &x, indexset const& iset_old, indexset const &iset_new) const
+{
+  int64_t const num_old = iset_old.num_indexes();
+  int64_t const num_new = iset_new.num_indexes();
+  int const block_size = fm::ipow(pdof, num_dims);
+
+  // Initialize exactly to 0 to automatically handle newly refined points
+  std::vector<P> x_new(num_new * block_size, P{0});
+
+  int64_t iold = 0;
+  int64_t inew = 0;
+
+  enum class index_relation
+  {
+    asameb,
+    abeforeb,
+    bbeforea
+  };
+
+  auto compare_indexes = [&](int const a[], int const b[]) -> index_relation
+    {
+      for(int const d : iindexof(num_dims)) {
+        if (a[d] < b[d]) return index_relation::abeforeb;
+        if (a[d] > b[d]) return index_relation::bbeforea;
+      }
+      return index_relation::asameb;
+    };
+
+  while (inew < num_new && iold < num_old) {
+    index_relation relation = compare_indexes(iset_new[inew], iset_old[iold]);
+
+    if (relation == index_relation::asameb) {
+      // Point survived adaptation: Transfer data
+      std::copy_n(x.data() + iold * block_size, block_size, x_new.data() + inew * block_size);
+      inew++;
+      iold++;
+    } else if (relation == index_relation::abeforeb) {
+      // New point added (Refinement): Already 0, just advance
+      inew++;
+    } else {
+      // Old point removed (Coarsening): Discard data
+      iold++;
+    }
+  }
+  std::swap(x, x_new);
+}
+
+template<typename P>
 void poisson_md<P>::solve_potential_(std::vector<P> &density, sparse_grid const &position_grid,
                                      connection_patterns const &conn, kronmult::workspace<P> &work, poisson_bc const bc)
 {
-  size_t const n = density.size();
-
-  // Resize efield and set an initial guess of zeros
-  potential.resize(n);
-  std::fill(potential.begin(), potential.end(), P{0.0});
+  // Remap the previous potential to the new grid if needed to use as a warm start
+  if (generation != position_grid.generation()) {
+    remap_(potential, iset_, position_grid.iset());
+    iset_ = position_grid.iset();
+    generation = position_grid.generation();
+  }
 
   // Save the average density to restore it later
   P density0 = density[0];
 
   // For periodic boundaries, the solution is only unique up to a constant.
   // We must force the mean of the RHS to 0 so the iterative solver doesn't blow up.
-  if (bc == poisson_bc::periodic) {
+  if (bc == poisson_bc::periodic)
     density[0] = P{0};
-  }
 
   // Define the Matrix-Vector Product (The LHS)
   auto apply_lhs = [&](P alpha, P const x[], P beta, P y[]) -> void
@@ -192,14 +240,63 @@ void poisson_md<P>::solve(gpu::vector<P> &density, sparse_grid const &position_g
 }
 
 template<typename P>
+void poisson_md<P>::remap_(gpu::vector<P> &x, indexset const& iset_old, indexset const &iset_new) const
+{
+  int64_t const num_old = iset_old.num_indexes();
+  int64_t const num_new = iset_new.num_indexes();
+  int const block_size = fm::ipow(pdof, num_dims);
+
+  // Initialize exactly to 0.0 to automatically handle newly refined points
+  gpu::vector<P> x_new(num_new * block_size);
+
+  int64_t iold = 0;
+  int64_t inew = 0;
+
+  enum class index_relation
+  {
+    asameb,
+    abeforeb,
+    bbeforea
+  };
+
+  auto compare_indexes = [&](int const a[], int const b[]) -> index_relation
+    {
+      for(int const d : iindexof(num_dims)) {
+        if (a[d] < b[d]) return index_relation::abeforeb;
+        if (a[d] > b[d]) return index_relation::bbeforea;
+      }
+      return index_relation::asameb;
+    };
+
+  while (inew < num_new && iold < num_old) {
+    index_relation relation = compare_indexes(iset_new[inew], iset_old[iold]);
+
+    if (relation == index_relation::asameb) {
+      // Point survived adaptation: Transfer data
+      gpu::memcopy_dev2dev(block_size, x.data() + iold * block_size, x_new.data() + inew * block_size);
+      inew++;
+      iold++;
+    } else if (relation == index_relation::abeforeb) {
+      // New point added (Refinement): Already 0.0, just advance
+      inew++;
+    } else {
+      // Old point removed (Coarsening): Discard data
+      iold++;
+    }
+  }
+  std::swap(x, x_new);
+}
+
+template<typename P>
 void poisson_md<P>::solve_potential_(gpu::vector<P> &density, sparse_grid const &position_grid,
                                      connection_patterns const &conn, kronmult::workspace<P> &work, poisson_bc const bc)
 {
-  size_t const n = position_grid.num_dof();
-
-  // Resize efield and set an initial guess of zeros
-  gpu_potential.resize(n);
-  gpu::fill_zeros(n, gpu_potential.data());
+  // Remap the previous potential to the new grid if needed to use as a warm start
+  if (generation != position_grid.generation()) {
+    remap_(gpu_potential, iset_, position_grid.iset());
+    iset_ = position_grid.iset();
+    generation = position_grid.generation();
+  }
 
   // For periodic boundaries, the solution is only unique up to a constant.
   // We must force the mean of the RHS to 0 so the iterative solver doesn't blow up.
@@ -234,6 +331,7 @@ void poisson_md<P>::solve_potential_(gpu::vector<P> &density, sparse_grid const 
   } else {
     num_iter = cg_solver.solve(nullptr, apply_lhs, density, gpu_potential);
   }
+  // std::cout << num_iter << " iterations\n";
   std::ignore = num_iter;
 
   // Restore the density
@@ -243,7 +341,7 @@ void poisson_md<P>::solve_potential_(gpu::vector<P> &density, sparse_grid const 
 #endif
 
 template<typename P>
-void poisson_md<P>::kron_diag(term_entry<P> const &tme, sparse_grid const &grid, connection_patterns const &conn,
+void poisson_md<P>::kron_diag_(term_entry<P> const &tme, sparse_grid const &grid, connection_patterns const &conn,
                               int const block_size, std::vector<P> &y) const
 {
 #pragma omp parallel
@@ -299,7 +397,7 @@ void poisson_md<P>::update_preconditioner(sparse_grid const &position_grid, conn
     }
 
     for (term_entry<P> const &tentry : laplacian_terms)
-      kron_diag(tentry, position_grid, conn, block_size, jacobi);
+      kron_diag_(tentry, position_grid, conn, block_size, jacobi);
 
     if (bc == poisson_bc::periodic)
       jacobi[0] = P{0};

--- a/src/asgard_poisson.cpp
+++ b/src/asgard_poisson.cpp
@@ -12,8 +12,10 @@ template<typename P>
 poisson_md<P>::poisson_md(int const num_pos, int const max_level, std::array<P, max_num_dimensions> const &xleft,
                           std::array<P, max_num_dimensions> const &xright, connection_patterns const &conn,
                           hierarchy_manipulator<P> const &hier, moments_list const &mlist,
-                          build_term_func<P> build, moment_id const m0)
-  : num_dims(num_pos), pdof(hier.degree() + 1), mom0(m0), cg_solver(1e-8, 1000), precon(precon_method::jacobi)
+                          build_term_func<P> build, moment_id const m0, prog_opts const &opts)
+  : num_dims(num_pos), pdof(hier.degree() + 1), mom0(m0),
+    cg_solver(opts.poisson_tolerance.value(), opts.poisson_iterations.value()),
+    precon(opts.poisson_precon.value_or(precon_method::none))
 {
   assert((num_dims > 1) and (num_dims <= max_pos_dims));
   int const nelem = fm::ipow2(max_level);
@@ -274,11 +276,11 @@ template<typename P>
 void poisson_md<P>::update_preconditioner(sparse_grid const &position_grid, connection_patterns const &conn,
                                           poisson_bc const bc)
 {
-  tools::time_event timing_("updating poisson_md preconditioner");
-
   // return if nothing more to do
   if (precon.valid_for(position_grid))
     return;
+
+  tools::time_event timing_("updating poisson_md preconditioner");
 
   precon.grid_gen = position_grid.generation(); // update the grid gen
 

--- a/src/asgard_poisson.cpp
+++ b/src/asgard_poisson.cpp
@@ -109,7 +109,7 @@ void poisson_md<P>::solve(std::vector<P> &density, momentset<P> &moms,
 }
 
 template<typename P>
-void poisson_md<P>::remap_(std::vector<P> &x, indexset const& iset_old, indexset const &iset_new) const
+void poisson_md<P>::remap_(indexset const& iset_old, indexset const &iset_new, std::vector<P> &x) const
 {
   int64_t const num_old = iset_old.num_indexes();
   int64_t const num_new = iset_new.num_indexes();
@@ -162,7 +162,7 @@ void poisson_md<P>::solve_potential_(std::vector<P> &density, sparse_grid const 
 {
   // Remap the previous potential to the new grid if needed to use as a warm start
   if (generation != position_grid.generation()) {
-    remap_(potential, iset_, position_grid.iset());
+    remap_(iset_, position_grid.iset(), potential);
     iset_ = position_grid.iset();
     generation = position_grid.generation();
   }
@@ -240,7 +240,7 @@ void poisson_md<P>::solve(gpu::vector<P> &density, sparse_grid const &position_g
 }
 
 template<typename P>
-void poisson_md<P>::remap_(gpu::vector<P> &x, indexset const& iset_old, indexset const &iset_new) const
+void poisson_md<P>::remap_(indexset const& iset_old, indexset const &iset_new, gpu::vector<P> &x) const
 {
   int64_t const num_old = iset_old.num_indexes();
   int64_t const num_new = iset_new.num_indexes();
@@ -273,6 +273,7 @@ void poisson_md<P>::remap_(gpu::vector<P> &x, indexset const& iset_old, indexset
 
     if (relation == index_relation::asameb) {
       // Point survived adaptation: Transfer data
+      // TODO: make these memcopies into a single kernel
       gpu::memcopy_dev2dev(block_size, x.data() + iold * block_size, x_new.data() + inew * block_size);
       inew++;
       iold++;
@@ -293,7 +294,7 @@ void poisson_md<P>::solve_potential_(gpu::vector<P> &density, sparse_grid const 
 {
   // Remap the previous potential to the new grid if needed to use as a warm start
   if (generation != position_grid.generation()) {
-    remap_(gpu_potential, iset_, position_grid.iset());
+    remap_(iset_, position_grid.iset(), gpu_potential);
     iset_ = position_grid.iset();
     generation = position_grid.generation();
   }

--- a/src/asgard_poisson.hpp
+++ b/src/asgard_poisson.hpp
@@ -110,20 +110,27 @@ public:
   #endif
 
 private:
-  // Solves for just the electric potential, used as a substep inside the solver
+  #ifndef ASGARD_USE_GPU
+  //! remaps a vector from the old grid to the new grid, used for warm starting the potential
+  void remap_(std::vector<P> &x, indexset const& iset_old, indexset const &iset_new) const;
+  //! solves for just the electric potential, used as a substep inside the solver
   void solve_potential_(std::vector<P> &density, sparse_grid const &grid,
                         connection_patterns const &conn, kronmult::workspace<P> &work, poisson_bc const bc);
+  #endif
   //! build the diagonal preconditioner
-  void kron_diag(term_entry<P> const &tme, sparse_grid const &grid, connection_patterns const &conn,
+  void kron_diag_(term_entry<P> const &tme, sparse_grid const &grid, connection_patterns const &conn,
                  int const block_size, std::vector<P> &y) const;
   #ifdef ASGARD_USE_GPU
+  //! remaps a vector from the old grid to the new grid, used for warm starting the potential
+  void remap_(gpu::vector<P> &x, indexset const& iset_old, indexset const &iset_new) const;
   // Solves for just the electric potential, used as a substep inside the solver
   void solve_potential_(gpu::vector<P> &density, sparse_grid const &grid,
                         connection_patterns const &conn, kronmult::workspace<P> &work, poisson_bc const bc);
   #endif
 
   int num_dims = -1;
-  int pdof = -1; 
+  int pdof = -1;
+  int generation = -1;
   moment_id mom0 = moment_id::unset();
   std::array<moment_id, max_pos_dims> moms_electric;
   std::vector<term_entry<P>> laplacian_terms;
@@ -132,6 +139,7 @@ private:
   std::vector<P> potential;
   solvers::cg<P> cg_solver;
   preconditioner_data<P> precon;
+  indexset iset_;
   #ifdef ASGARD_USE_GPU
   #ifdef ASGARD_GPU_MEMGREEDY
   //! gpu derivative matrix

--- a/src/asgard_poisson.hpp
+++ b/src/asgard_poisson.hpp
@@ -112,7 +112,7 @@ public:
 private:
   #ifndef ASGARD_USE_GPU
   //! remaps a vector from the old grid to the new grid, used for warm starting the potential
-  void remap_(std::vector<P> &x, indexset const& iset_old, indexset const &iset_new) const;
+  void remap_(indexset const& iset_old, indexset const &iset_new, std::vector<P> &x) const;
   //! solves for just the electric potential, used as a substep inside the solver
   void solve_potential_(std::vector<P> &density, sparse_grid const &grid,
                         connection_patterns const &conn, kronmult::workspace<P> &work, poisson_bc const bc);
@@ -122,7 +122,7 @@ private:
                  int const block_size, std::vector<P> &y) const;
   #ifdef ASGARD_USE_GPU
   //! remaps a vector from the old grid to the new grid, used for warm starting the potential
-  void remap_(gpu::vector<P> &x, indexset const& iset_old, indexset const &iset_new) const;
+  void remap_(indexset const& iset_old, indexset const &iset_new, gpu::vector<P> &x) const;
   // Solves for just the electric potential, used as a substep inside the solver
   void solve_potential_(gpu::vector<P> &density, sparse_grid const &grid,
                         connection_patterns const &conn, kronmult::workspace<P> &work, poisson_bc const bc);

--- a/src/asgard_poisson.hpp
+++ b/src/asgard_poisson.hpp
@@ -62,7 +62,7 @@ public:
   poisson_md(int const num_pos, int const max_level, std::array<P, max_num_dimensions> const &xleft,
              std::array<P, max_num_dimensions> const &xright, connection_patterns const &conn,
              hierarchy_manipulator<P> const &hier, moments_list const &mlist,
-             build_term_func<P> build, moment_id const m0);
+             build_term_func<P> build, moment_id const m0, prog_opts const &opts);
   #ifndef ASGARD_USE_GPU
   /*!
   * \brief Given the wavelet representation of the density, find the electric field also in wavelet space

--- a/src/asgard_poisson_tests.cpp
+++ b/src/asgard_poisson_tests.cpp
@@ -62,11 +62,14 @@ struct PoissonErrors
 template<typename P>
 PoissonErrors<P> test_poisson_md(separable_func<P> rhs, std::array<P, 2> xleft, std::array<P, 2> xright,
                                  separable_func<P> phi, separable_func<P> ex, separable_func<P> ey,
-                                 int degree, int level)
+                                 int degree, int level, int max_iter, precon_method precon)
 {
   prog_opts options;
   options.degree = degree;
   options.start_levels = {level, level};
+  options.poisson_tolerance = 1e-12;
+  options.poisson_iterations = max_iter;
+  options.poisson_precon = precon;
   pde_domain<P> domain(position_dims{2}, velocity_dims{0},
                        {{xleft[0], xright[0]}, {xleft[1], xright[1]}});
   pde_scheme<P> pde(options, domain);
@@ -80,7 +83,7 @@ PoissonErrors<P> test_poisson_md(separable_func<P> rhs, std::array<P, 2> xleft, 
   auto build_func = [&terms](term_entry<P> &tentry, int const dim, int const lvl) -> void {
     terms.rebuild_term1d(tentry, dim, lvl);
   };
-  poisson_md<P> poisson(2, level, terms.xleft, terms.xright, terms.conn, terms.hier, mlist, build_func, moment_id{0});
+  poisson_md<P> poisson(2, level, terms.xleft, terms.xright, terms.conn, terms.hier, mlist, build_func, moment_id{0}, options);
   poisson.update_preconditioner(terms.grid, terms.conn, poisson_bc::periodic);
 
   // fill vectors from functions
@@ -197,6 +200,7 @@ void poisson_tests()
 
     int const degree = 3;
     int const level = 8;
+    int const max_iter = 1000;
 
     // example 1, rhs(x, y) = 1 - 0.5 * cos(pi * x) over x: (-1, 1) and y: (-1, 1),
     // phi(x, y) = 0.5 * x^2 + 0.5 * cos(pi * x)/pi^2 + 0.5 * (1/pi^2 - 1)
@@ -212,7 +216,7 @@ void poisson_tests()
     separable_func<TestType> ey{{vectorize<TestType>(zero), vectorize<TestType>(zero)}};
 
     PoissonErrors<TestType> errs = test_poisson_md<TestType>(
-        rhs, {-1, -1}, {1, 1}, phi, ex, ey, degree, level);
+        rhs, {-1, -1}, {1, 1}, phi, ex, ey, degree, level, max_iter, precon_method::none);
 
     tassert(errs.phi < poisson_md_tol);
     tassert(errs.ex < poisson_md_tol);
@@ -225,6 +229,7 @@ void poisson_tests()
 
     int const degree = 3;
     int const level = 8;
+    int const max_iter = 2000;
 
     // example 2, rhs(x, y) =  4 * exp(-x^2 - y^2) * (x^2 + y^2 - 1) over x: (-5, 5) and y: (-5, 5),
     // phi(x, y) = exp(-x^2 - y^2)
@@ -243,7 +248,7 @@ void poisson_tests()
     separable_func<TestType> ey{{vectorize<TestType>(ey_x), vectorize<TestType>(ey_y)}};
 
     PoissonErrors<TestType> errs = test_poisson_md<TestType>(
-        rhs, {0, 0}, {2*pi, 2*pi}, phi, ex, ey, degree, level);
+        rhs, {0, 0}, {2*pi, 2*pi}, phi, ex, ey, degree, level, max_iter, precon_method::jacobi);
 
     tassert(errs.phi < poisson_md_tol);
     tassert(errs.ex < poisson_md_tol);

--- a/src/asgard_program_options.cpp
+++ b/src/asgard_program_options.cpp
@@ -166,9 +166,9 @@ Options          Short   Value      Description
                                     specifies the preconditioner for the Poisson solver
                                     none - is not advisable as it takes too long
                                     jacobi - preconditioner that applies basic rescaling
--poisson-tol     -pt     double     Poisson solver tolerance,
+-poisson-tol     -ptol   double     Poisson solver tolerance,
                                     applies to domains with 2 or 3 spatial dimensions and an electric field moment
--poisson-iter    -pi     int        Poisson solver maximum number of iterations,
+-poisson-iter    -piter  int        Poisson solver maximum number of iterations,
                                     applies to domains with 2 or 3 spatial dimensions and an electric field moment
 
 )help";
@@ -208,8 +208,8 @@ void prog_opts::process_inputs(std::vector<std::string_view> const &argv, handle
       {"-isolve-inner", optentry::isol_inner_iterations},
       {"-isn", optentry::isol_inner_iterations},
       {"-poisson-precon", optentry::poisson_precond}, {"-ppc", optentry::poisson_precond},
-      {"-poisson-tol", optentry::poisson_tolerance}, {"-pt", optentry::poisson_tolerance},
-      {"-poisson-iter", optentry::poisson_iterations}, {"-pi", optentry::poisson_iterations},
+      {"-poisson-tol", optentry::poisson_tolerance}, {"-ptol", optentry::poisson_tolerance},
+      {"-poisson-iter", optentry::poisson_iterations}, {"-piter", optentry::poisson_iterations},
       {"-restart", optentry::restart_file},
   };
 

--- a/src/asgard_program_options.cpp
+++ b/src/asgard_program_options.cpp
@@ -161,6 +161,15 @@ Options          Short   Value      Description
                                     for GMRES this is the number of outer iterations.
 -isolve-inner    -isn    int        (GMRES only) The maximum number of inner GMRES iterations,
                                     this is ignored by BiCGSTAB.
+-poisson-precon  -ppc    string     accepts: none/jacobi
+                                    applies to domains with 2 or 3 spatial dimensions and an electric field moment
+                                    specifies the preconditioner for the Poisson solver
+                                    none - is not advisable as it takes too long
+                                    jacobi - preconditioner that applies basic rescaling
+-poisson-tol     -pt     double     Poisson solver tolerance,
+                                    applies to domains with 2 or 3 spatial dimensions and an electric field moment
+-poisson-iter    -pi     int        Poisson solver maximum number of iterations,
+                                    applies to domains with 2 or 3 spatial dimensions and an electric field moment
 
 )help";
 }
@@ -198,6 +207,9 @@ void prog_opts::process_inputs(std::vector<std::string_view> const &argv, handle
       {"-isolve-iter", optentry::isol_iterations}, {"-isi", optentry::isol_iterations},
       {"-isolve-inner", optentry::isol_inner_iterations},
       {"-isn", optentry::isol_inner_iterations},
+      {"-poisson-precon", optentry::poisson_precond}, {"-ppc", optentry::poisson_precond},
+      {"-poisson-tol", optentry::poisson_tolerance}, {"-pt", optentry::poisson_tolerance},
+      {"-poisson-iter", optentry::poisson_iterations}, {"-pi", optentry::poisson_iterations},
       {"-restart", optentry::restart_file},
   };
 
@@ -499,6 +511,45 @@ void prog_opts::process_inputs(std::vector<std::string_view> const &argv, handle
         throw std::runtime_error(report_no_value());
       try {
         isolver_inner_iterations = std::stoi(selected->data());
+      } catch(std::invalid_argument &) {
+        throw std::runtime_error(report_wrong_value());
+      } catch(std::out_of_range &) {
+        throw std::runtime_error(report_wrong_value());
+      }
+    }
+    break;
+    case optentry::poisson_precond: {
+      // if we get more preconditioners we may switch to a map
+      auto selected = move_process_next();
+      if (not selected)
+        throw std::runtime_error(report_no_value());
+      if (*selected == "none")
+        poisson_precon = precon_method::none;
+      else if (*selected == "jacobi")
+        poisson_precon = precon_method::jacobi;
+      else
+        throw std::runtime_error(report_wrong_value());
+    }
+    break;
+    case optentry::poisson_tolerance: {
+      auto selected = move_process_next();
+      if (not selected)
+        throw std::runtime_error(report_no_value());
+      try {
+        poisson_tolerance = std::stod(selected->data());
+      } catch(std::invalid_argument &) {
+        throw std::runtime_error(report_wrong_value());
+      } catch(std::out_of_range &) {
+        throw std::runtime_error(report_wrong_value());
+      }
+    }
+    break;
+    case optentry::poisson_iterations: {
+      auto selected = move_process_next();
+      if (not selected)
+        throw std::runtime_error(report_no_value());
+      try {
+        poisson_iterations = std::stoi(selected->data());
       } catch(std::invalid_argument &) {
         throw std::runtime_error(report_wrong_value());
       } catch(std::out_of_range &) {

--- a/src/asgard_program_options.hpp
+++ b/src/asgard_program_options.hpp
@@ -367,6 +367,12 @@ struct prog_opts
   std::optional<int> isolver_iterations;
   //! max number of output gmres iterations
   std::optional<int> isolver_inner_iterations;
+  //! preconditioner, used for the poisson solver, if there is one
+  std::optional<precon_method> poisson_precon;
+  //! tolerance for the poisson solver, if there is one
+  std::optional<double> poisson_tolerance;
+  //! max number of iterations for the poisson solver, if there is one
+  std::optional<int> poisson_iterations;
 
   //! restart the simulation from a file
   std::string restart_file;
@@ -597,6 +603,12 @@ struct prog_opts
   std::optional<int> default_isolver_iterations;
   //! max number of outer gmres iterations
   std::optional<int> default_isolver_inner_iterations;
+  //! used in place of the poisson preconditioner type, if poisson preconditioner is not specified
+  std::optional<precon_method> default_poisson_precon;
+  //! used in place of the poisson tolerance, if poisson tolerance is not specified
+  std::optional<double> default_poisson_tolerance;
+  //! max number of iterations for the poisson solver
+  std::optional<int> default_poisson_iterations;
 
   //! returns the first available from stop-time, default-stop-time or -1
   double get_stop_time() const { return stop_time.value_or(default_stop_time.value_or(-1)); }
@@ -678,6 +690,9 @@ private:
     isol_tolerance,
     isol_iterations,
     isol_inner_iterations,
+    poisson_precond,
+    poisson_tolerance,
+    poisson_iterations,
     restart_file,
     view,
     set_verbosity,

--- a/src/asgard_program_options_tests.cpp
+++ b/src/asgard_program_options_tests.cpp
@@ -247,6 +247,41 @@ void new_prog_opts() {
     terror_message(prog_opts(vecstrview({"exe", "-pc", "dummy"})),
                    "invalid value for -pc, see exe -help");
   }{
+    current_test name_("-poisson_tol");
+    prog_opts prog(vecstrview({"", "-poisson-tol", "0.25"}));
+    tassert(prog.poisson_tolerance);
+    tassert(prog.poisson_tolerance.value() == 0.25);
+    tassert(prog_opts(vecstrview({"exe", "-ptol", "0.1"})).poisson_tolerance);
+    tassert(prog_opts(vecstrview({"exe", "-poisson-tol", "0.01"})).poisson_tolerance.value() < 0.02);
+    terror_message(prog_opts(vecstrview({"exe", "-poisson-tol"})),
+                   "-poisson-tol must be followed by a value, see exe -help");
+    terror_message(prog_opts(vecstrview({"exe", "-ptol", "dummy"})),
+                   "invalid value for -ptol, see exe -help");
+    terror_message(prog_opts(vecstrview({"exe", "-ptol", "7.E+310"})),
+                   "invalid value for -ptol, see exe -help");
+  }{
+    current_test name_("-poisson_iter");
+    prog_opts prog(vecstrview({"", "-poisson-iter", "100"}));
+    tassert(prog.poisson_iterations);
+    tassert(prog.poisson_iterations.value() == 100);
+    terror_message(prog_opts(vecstrview({"exe", "-poisson-iter"})),
+                   "-poisson-iter must be followed by a value, see exe -help");
+    terror_message(prog_opts(vecstrview({"exe", "-piter", "dummy"})),
+                   "invalid value for -piter, see exe -help");
+    terror_message(prog_opts(vecstrview({"exe", "-piter", "8100100100"})),
+                   "invalid value for -piter, see exe -help");
+  }{
+    current_test name_("-poisson_precon");
+    prog_opts prog(vecstrview({"", "-poisson-precon", "none"}));
+    tassert(prog.poisson_precon);
+    tassert(prog.poisson_precon.value() == precon_method::none);
+    tassert(prog_opts(vecstrview({"exe", "-poisson-precon", "jacobi"})).poisson_precon);
+    tassert(prog_opts(vecstrview({"exe", "-ppc", "jacobi"})).poisson_precon.value() == precon_method::jacobi);
+    terror_message(prog_opts(vecstrview({"exe", "-poisson-precon"})),
+                   "-poisson-precon must be followed by a value, see exe -help");
+    terror_message(prog_opts(vecstrview({"exe", "-ppc", "dummy"})),
+                   "invalid value for -ppc, see exe -help");
+  }{
     current_test name_("-title");
     prog_opts prog(vecstrview({"", "-title", "mypde"}));
     tassert(not prog.title.empty());

--- a/src/pde/landau_damping.cpp
+++ b/src/pde/landau_damping.cpp
@@ -100,6 +100,9 @@ asgard::pde_scheme<P> make_landau(asgard::prog_opts options) {
 
   options.default_degree = default_degree;
   options.default_start_levels = {7, 7, 7, 7};
+  options.default_poisson_tolerance = 1e-6;
+  options.default_poisson_iterations = 1000;
+  options.default_poisson_precon = asgard::precon_method::jacobi;
 
   options.default_plotter_colormap = "viridis";
 

--- a/src/pde/landau_damping.cpp
+++ b/src/pde/landau_damping.cpp
@@ -100,7 +100,7 @@ asgard::pde_scheme<P> make_landau(asgard::prog_opts options) {
 
   options.default_degree = default_degree;
   options.default_start_levels = {7, 7, 7, 7};
-  options.default_poisson_tolerance = 1e-6;
+  options.default_poisson_tolerance = 1e-8;
   options.default_poisson_iterations = 1000;
   options.default_poisson_precon = asgard::precon_method::jacobi;
 
@@ -523,7 +523,8 @@ void self_test() {
 
 #ifdef ASGARD_ENABLE_DOUBLE
 
-  test_damping<double>("-l 4 -a 1.e-3 -t 4.8");
+  test_damping<double>("-l 4 -a 1.e-3 -t 4.8 -ppc none");
+  test_damping<double>("-s rk4 -l 4 -a 1.e-3 -t 4.8");
 
 #endif
 

--- a/src/pde/landau_damping.cpp
+++ b/src/pde/landau_damping.cpp
@@ -145,7 +145,7 @@ asgard::pde_scheme<P> make_landau(asgard::prog_opts options) {
                     asgard::momentset<P> const &moments, std::vector<P> const &field,
                     std::vector<P> &vals)
     {
-      std::vector<P> e_x = moments[melectric_x];
+      std::vector<P> const &e_x = moments[melectric_x];
 #pragma omp parallel for
       for (size_t i = 0; i < vals.size(); i++)
         vals[i] = field[i] * std::max(P{0}, e_x[i]);
@@ -155,7 +155,7 @@ asgard::pde_scheme<P> make_landau(asgard::prog_opts options) {
                     asgard::momentset<P> const &moments, std::vector<P> const &field,
                     std::vector<P> &vals)
     {
-      std::vector<P> e_x = moments[melectric_x];
+      std::vector<P> const &e_x = moments[melectric_x];
 #pragma omp parallel for
       for (size_t i = 0; i < vals.size(); i++)
         vals[i] = field[i] * std::min(P{0}, e_x[i]);
@@ -165,7 +165,7 @@ asgard::pde_scheme<P> make_landau(asgard::prog_opts options) {
                     asgard::momentset<P> const &moments, std::vector<P> const &field,
                     std::vector<P> &vals)
     {
-      std::vector<P> e_y = moments[melectric_y];
+      std::vector<P> const &e_y = moments[melectric_y];
 #pragma omp parallel for
       for (size_t i = 0; i < vals.size(); i++)
         vals[i] = field[i] * std::max(P{0}, e_y[i]);
@@ -175,7 +175,7 @@ asgard::pde_scheme<P> make_landau(asgard::prog_opts options) {
                     asgard::momentset<P> const &moments, std::vector<P> const &field,
                     std::vector<P> &vals)
     {
-      std::vector<P> e_y = moments[melectric_y];
+      std::vector<P> const &e_y = moments[melectric_y];
 #pragma omp parallel for
       for (size_t i = 0; i < vals.size(); i++)
         vals[i] = field[i] * std::min(P{0}, e_y[i]);

--- a/src/pde/two_stream_md.cpp
+++ b/src/pde/two_stream_md.cpp
@@ -100,7 +100,7 @@ asgard::pde_scheme<P> make_two_stream(asgard::prog_opts options) {
 
   options.default_degree = default_degree;
   options.default_start_levels = {7, 7, 7, 7};
-  options.default_poisson_tolerance = 1e-6;
+  options.default_poisson_tolerance = 1e-8;
   options.default_poisson_iterations = 1000;
   options.default_poisson_precon = asgard::precon_method::jacobi;
 

--- a/src/pde/two_stream_md.cpp
+++ b/src/pde/two_stream_md.cpp
@@ -100,6 +100,9 @@ asgard::pde_scheme<P> make_two_stream(asgard::prog_opts options) {
 
   options.default_degree = default_degree;
   options.default_start_levels = {7, 7, 7, 7};
+  options.default_poisson_tolerance = 1e-6;
+  options.default_poisson_iterations = 1000;
+  options.default_poisson_precon = asgard::precon_method::jacobi;
 
   options.default_plotter_colormap = "viridis";
 
@@ -524,7 +527,7 @@ void self_test() {
 
 #ifdef ASGARD_ENABLE_DOUBLE
 
-  test_energy<double>("-l 6 -d 3 -n 5 -dt 6.25e-3 -a 1.0e-6");
+  test_energy<double>("-l 6 -d 3 -n 5 -dt 6.25e-3 -a 1.0e-6 -ppc none");
   test_energy<double>("-s rk4 -l 6 -d 2 -n 5 -dt 6.25e-3 -a 1.0e-6");
 
 #endif

--- a/src/pde/two_stream_md.cpp
+++ b/src/pde/two_stream_md.cpp
@@ -145,7 +145,7 @@ asgard::pde_scheme<P> make_two_stream(asgard::prog_opts options) {
                     asgard::momentset<P> const &moments, std::vector<P> const &field,
                     std::vector<P> &vals)
     {
-      std::vector<P> e_x = moments[melectric_x];
+      std::vector<P> const &e_x = moments[melectric_x];
 #pragma omp parallel for
       for (size_t i = 0; i < vals.size(); i++)
         vals[i] = field[i] * std::max(P{0}, e_x[i]);
@@ -155,7 +155,7 @@ asgard::pde_scheme<P> make_two_stream(asgard::prog_opts options) {
                     asgard::momentset<P> const &moments, std::vector<P> const &field,
                     std::vector<P> &vals)
     {
-      std::vector<P> e_x = moments[melectric_x];
+      std::vector<P> const &e_x = moments[melectric_x];
 #pragma omp parallel for
       for (size_t i = 0; i < vals.size(); i++)
         vals[i] = field[i] * std::min(P{0}, e_x[i]);
@@ -165,7 +165,7 @@ asgard::pde_scheme<P> make_two_stream(asgard::prog_opts options) {
                     asgard::momentset<P> const &moments, std::vector<P> const &field,
                     std::vector<P> &vals)
     {
-      std::vector<P> e_y = moments[melectric_y];
+      std::vector<P> const &e_y = moments[melectric_y];
 #pragma omp parallel for
       for (size_t i = 0; i < vals.size(); i++)
         vals[i] = field[i] * std::max(P{0}, e_y[i]);
@@ -175,7 +175,7 @@ asgard::pde_scheme<P> make_two_stream(asgard::prog_opts options) {
                     asgard::momentset<P> const &moments, std::vector<P> const &field,
                     std::vector<P> &vals)
     {
-      std::vector<P> e_y = moments[melectric_y];
+      std::vector<P> const &e_y = moments[melectric_y];
 #pragma omp parallel for
       for (size_t i = 0; i < vals.size(); i++)
         vals[i] = field[i] * std::min(P{0}, e_y[i]);


### PR DESCRIPTION
Added command line parsing for Poisson solver options:
-poisson-precon <none/jacobi> (or -ppc)
-poisson-tol <double> (or -pt)
-poisson-iter <int> (or -pi)

Also included a warm start for the Poisson solver.