### PR TITLE
Fix for set_adapt_weight() with Poisson solver.

### DIFF
--- a/python/asgard.py
+++ b/python/asgard.py
@@ -571,6 +571,7 @@ def plot_with_args(argv = None):
         savefig  = None
         auxfield = None
         moment   = None
+        efield   = None
         addgrid  = False
         colormap = "asg_default"
         cmaps = {"-jet" : "jet", "-vir" : "viridis", "-hot" : "hot", "-cool" : "coolwarm",

--- a/src/asgard_discretization.cpp
+++ b/src/asgard_discretization.cpp
@@ -123,6 +123,13 @@ void discretization_manager<precision>::start_cold(pde_scheme<precision> &pde)
 
   refinement = refinement_manager<precision>(options_, pde);
 
+  if (terms.has_poisson()) {
+    auto build_func = [this](term_entry<precision> &tentry, int const dim, int const level) -> void {
+      this->terms.rebuild_term1d(tentry, dim, level);
+    };
+    terms.moms.set_poisson(terms.max_level, terms.grid, terms.xleft, terms.xright, terms.conn, terms.hier, build_func, options_);
+  }
+
   // setting the initial conditions uses refinement, must come after the refinement_manager
   // this iterates depending on the adapt-weight and the separable/interpolation conditions
   // this is the first point of potentially heavy work
@@ -178,6 +185,13 @@ void discretization_manager<precision>::restart_from_file(pde_scheme<precision> 
 
   refinement = refinement_manager<precision>(options_, pde);
 
+  if (terms.has_poisson()) {
+    auto build_func = [this](term_entry<precision> &tentry, int const dim, int const level) -> void {
+      this->terms.rebuild_term1d(tentry, dim, level);
+    };
+    terms.moms.set_poisson(terms.max_level, terms.grid, terms.xleft, terms.xright, terms.conn, terms.hier, build_func, options_);
+  }
+  
   start_moments();
 
   terms.build_matrices();
@@ -216,12 +230,6 @@ void discretization_manager<precision>::restart_from_file(pde_scheme<precision> 
 template<typename precision>
 void discretization_manager<precision>::start_moments() {
   if (not terms.moms) return;
-  if (terms.has_poisson()) {
-    auto build_func = [this](term_entry<precision> &tentry, int const dim, int const level) -> void {
-      this->terms.rebuild_term1d(tentry, dim, level);
-    };
-    terms.moms.set_poisson(terms.max_level, terms.grid, terms.xleft, terms.xright, terms.conn, terms.hier, build_func, options_);
-  }
   terms.moms.update_position_grid(terms.grid);
   std::visit([&](auto &p)
     {

--- a/src/asgard_gpu_algorithms.hpp
+++ b/src/asgard_gpu_algorithms.hpp
@@ -48,6 +48,10 @@ void sum4(gpu::vector<P> const &x, no_deduce<P> a1, gpu::vector<P> const &x1, no
 template<typename P>
 void sum5(gpu::vector<P> const &x, no_deduce<P> a1, gpu::vector<P> const &x1, no_deduce<P> a2, gpu::vector<P> const &x2,
           no_deduce<P> a3, gpu::vector<P> const &x3, no_deduce<P> a4, gpu::vector<P> const &x4, gpu::vector<P> &y);
+//! copies block_size elements from src[transfers[i] * block_size] to dest[transfers[i + 1] * block_size]
+template<typename P>
+void flagged_memcopy_dev2dev(int block_size, gpu::vector<int64_t> const &transfers, gpu::vector<P> const &src,
+                             gpu::vector<P> &dest);
 
 //! returns the number of inf/nan entries in a vector
 template<typename P>

--- a/src/asgard_gpu_algorithms_cuda.cpp
+++ b/src/asgard_gpu_algorithms_cuda.cpp
@@ -173,6 +173,26 @@ __global__ void kernel_sum5(int64_t num, P const x[], P a1, P const x1[],
     i += num_threads * gridDim.x;
   }
 }
+template<typename P, int num_threads>
+__global__ void kernel_flagged_memcopy(int block_size, int64_t num_transfers,
+                                       int64_t const transfers[], P const src[], P dest[])
+{
+  int i = threadIdx.x + blockIdx.x * num_threads;
+  int64_t total_elements = block_size * num_transfers;
+  while (i < total_elements) {
+    int64_t transfer_idx = i / block_size;
+    int64_t element_offset = i % block_size;
+
+    // 3. Look up the old and new block indices from the transfer map
+    // transfers is packed as: [src_idx_0, dest_idx_0, src_idx_1, dest_idx_1, ...]
+    int64_t src_block_idx = transfers[transfer_idx * 2];
+    int64_t dest_block_idx = transfers[transfer_idx * 2 + 1];
+
+    // 4. Perform the exact element copy
+    dest[dest_block_idx * block_size + element_offset] = src[src_block_idx * block_size + element_offset];
+    i += num_threads * gridDim.x;
+  }
+}
 
 template<typename P>
 void sum2(gpu::vector<P> const &x, no_deduce<P> a1, gpu::vector<P> const &x1, gpu::vector<P> &y) {
@@ -207,6 +227,16 @@ void sum5(gpu::vector<P> const &x, no_deduce<P> a1, gpu::vector<P> const &x1, no
   int const num_blocks = round_up(num, max_threads);
   kernel_sum5<P, max_threads><<<num_blocks, max_threads>>>(
       num, x.data(), a1, x1.data(), a2, x2.data(), a3, x3.data(), a4, x4.data(), y.data());
+}
+template<typename P>
+void flagged_memcopy_dev2dev(int block_size, gpu::vector<int64_t> const &transfers, gpu::vector<P> const &src, gpu::vector<P> &dest) {
+  assert(transfers.size() % 2 == 0);
+  constexpr int max_threads = 1024;
+  int64_t const num_transfers = transfers.size() / 2;
+  int64_t const num = block_size * num_transfers;
+  int const num_blocks = round_up(num, max_threads);
+  kernel_flagged_memcopy<P, max_threads><<<num_blocks, max_threads>>>(
+      block_size, num_transfers, transfers.data(), src.data(), dest.data());
 }
 
 template<typename P, int num_threads>
@@ -245,7 +275,6 @@ __global__ void cg_update_x_r_kernel(int64_t num, P const *rho, P const *p_dot_q
     i += num_threads * gridDim.x;
   }
 }
-
 template<typename P, int num_threads>
 __global__ void cg_update_p_kernel(int64_t num, P const *rho_new, P const *rho, P const r[], P p[]) {
   int i = threadIdx.x + blockIdx.x * num_threads;
@@ -287,6 +316,8 @@ template void sum4(gpu::vector<double> const &, double, gpu::vector<double> cons
                    double, gpu::vector<double> const &, double, gpu::vector<double> const &, gpu::vector<double> &);
 template void sum5(gpu::vector<double> const &, double, gpu::vector<double> const &, double, gpu::vector<double> const &,
                    double, gpu::vector<double> const &, double, gpu::vector<double> const &, gpu::vector<double> &);
+template void flagged_memcopy_dev2dev(int block_size, gpu::vector<int64_t> const &transfers, gpu::vector<double> const &src,
+                                      gpu::vector<double> &dest);
 
 template int num_non_finite(int64_t num, double const x[]);
 
@@ -312,6 +343,8 @@ template void sum4(gpu::vector<float> const &, float, gpu::vector<float> const &
                    float, gpu::vector<float> const &, float, gpu::vector<float> const &, gpu::vector<float> &);
 template void sum5(gpu::vector<float> const &, float, gpu::vector<float> const &, float, gpu::vector<float> const &,
                    float, gpu::vector<float> const &, float, gpu::vector<float> const &, gpu::vector<float> &);
+template void flagged_memcopy_dev2dev(int block_size, gpu::vector<int64_t> const &transfers, gpu::vector<float> const &src,
+                                      gpu::vector<float> &dest);
 
 template int num_non_finite(int64_t num, float const x[]);
 

--- a/src/asgard_gpu_algorithms_rocm.cpp
+++ b/src/asgard_gpu_algorithms_rocm.cpp
@@ -175,6 +175,26 @@ __global__ void kernel_sum5(int64_t num, P const x[], P a1, P const x1[],
     i += num_threads * gridDim.x;
   }
 }
+template<typename P, int num_threads>
+__global__ void kernel_flagged_memcopy(int block_size, int64_t num_transfers,
+                                       int64_t const transfers[], P const src[], P dest[])
+{
+  int i = threadIdx.x + blockIdx.x * num_threads;
+  int64_t total_elements = block_size * num_transfers;
+  while (i < total_elements) {
+    int64_t transfer_idx = i / block_size;
+    int64_t element_offset = i % block_size;
+
+    // 3. Look up the old and new block indices from the transfer map
+    // transfers is packed as: [src_idx_0, dest_idx_0, src_idx_1, dest_idx_1, ...]
+    int64_t src_block_idx = transfers[transfer_idx * 2];
+    int64_t dest_block_idx = transfers[transfer_idx * 2 + 1];
+
+    // 4. Perform the exact element copy
+    dest[dest_block_idx * block_size + element_offset] = src[src_block_idx * block_size + element_offset];
+    i += num_threads * gridDim.x;
+  }
+}
 
 template<typename P>
 void sum2(gpu::vector<P> const &x, no_deduce<P> a1, gpu::vector<P> const &x1, gpu::vector<P> &y) {
@@ -209,6 +229,16 @@ void sum5(gpu::vector<P> const &x, no_deduce<P> a1, gpu::vector<P> const &x1, no
   int const num_blocks = round_up(num, max_threads);
   kernel_sum5<P, max_threads><<<num_blocks, max_threads>>>(
       num, x.data(), a1, x1.data(), a2, x2.data(), a3, x3.data(), a4, x4.data(), y.data());
+}
+template<typename P>
+void flagged_memcopy_dev2dev(int block_size, gpu::vector<int64_t> const &transfers, gpu::vector<P> const &src, gpu::vector<P> &dest) {
+  assert(transfers.size() % 2 == 0);
+  constexpr int max_threads = 1024;
+  int64_t const num_transfers = transfers.size() / 2;
+  int64_t const num = block_size * num_transfers;
+  int const num_blocks = round_up(num, max_threads);
+  kernel_flagged_memcopy<P, max_threads><<<num_blocks, max_threads>>>(
+      block_size, num_transfers, transfers.data(), src.data(), dest.data());
 }
 
 template<typename P>
@@ -465,6 +495,8 @@ template void sum4(gpu::vector<double> const &, double, gpu::vector<double> cons
                    double, gpu::vector<double> const &, double, gpu::vector<double> const &, gpu::vector<double> &);
 template void sum5(gpu::vector<double> const &, double, gpu::vector<double> const &, double, gpu::vector<double> const &,
                    double, gpu::vector<double> const &, double, gpu::vector<double> const &, gpu::vector<double> &);
+template void flagged_memcopy_dev2dev(int block_size, gpu::vector<int64_t> const &transfers, gpu::vector<double> const &src,
+                                      gpu::vector<double> &dest);
 
 template void tensor_by_index(int, int, int, int const[], double const[], double const[], double const[],
                               double const[], double const[], double const[], double[]);
@@ -491,6 +523,8 @@ template void sum4(gpu::vector<float> const &, float, gpu::vector<float> const &
                    float, gpu::vector<float> const &, float, gpu::vector<float> const &, gpu::vector<float> &);
 template void sum5(gpu::vector<float> const &, float, gpu::vector<float> const &, float, gpu::vector<float> const &,
                    float, gpu::vector<float> const &, float, gpu::vector<float> const &, gpu::vector<float> &);
+template void flagged_memcopy_dev2dev(int block_size, gpu::vector<int64_t> const &transfers, gpu::vector<float> const &src,
+                                      gpu::vector<float> &dest);
 
 template void tensor_by_index(int, int, int, int const[], float const[], float const[], float const[],
                               float const[], float const[], float const[], float[]);

--- a/src/asgard_moment_manager.cpp
+++ b/src/asgard_moment_manager.cpp
@@ -693,6 +693,11 @@ void moment_manager<P>::solve_poisson_gpu(connection_patterns const &conn, hiera
   std::visit([&](auto &p) {
       if constexpr (std::is_same_v<std::decay_t<decltype(p)>, poisson_1d<P>>) {
         // This is fast enough on CPU
+        int64_t const num_entries = pos_grid.num_dof();
+        std::array<gpu::vector<P>, max_num_gpus> &work1 = interp.gpu_it1;
+        assert(work1[0].size() >= num_entries);
+        gpu::wrap_array<P> w1(work1[0].data(), num_entries);
+        w1.vec.copy_to_host(raw_vals[p.moment0()]);
         p.solve_periodic(get_cached_level(p.moment0(), hier), full_level.get(p.moment_electric()));
       } else if constexpr (std::is_same_v<std::decay_t<decltype(p)>, poisson_md<P>>) {
         // Setup
@@ -786,7 +791,13 @@ void moment_manager<P>::compute_interps(
     else
       cache_moment(id, grid, state);
   }
-  if (has_poisson) solve_poisson(grid, conn, hier, interp, work);
+  if (has_poisson) {
+    std::visit([&](auto &p) {
+      if constexpr (not std::is_same_v<std::decay_t<decltype(p)>, std::monostate>)
+        cache_moment(p.moment0(), grid, state);
+      }, poisson_solver);
+    solve_poisson(grid, conn, hier, interp, work);
+  }
   for (auto const &id : ids)
     make_nodal(id, interp, work, interp.it1);
   interp.it1.resize(num_entries);
@@ -1082,6 +1093,16 @@ void moment_manager<P>::compute_moments(
   assert(work1[0].size() >= num_entries);
   gpu::wrap_array<P> w1(work1[0].data(), num_entries);
 
+  bool has_electric = false;
+  for (auto im : mids)
+  {
+    moment const mom = mlist[im];
+    if (mom.is_electric()) {
+      has_electric = true;
+      break;
+    }
+  }
+
   // perform work for all moments from im to iend
   for (auto im : mids)
   {
@@ -1124,7 +1145,7 @@ void moment_manager<P>::compute_moments(
     if (result_to_cpu) res.copy_to_host(interps[im]);
 
     // solve poisson equation while w1 holds density
-    if (mom.is_zero())
+    if (mom.is_zero() and has_electric)
       solve_poisson_gpu(conn, hier, interp, kwork);
   }
 }

--- a/src/asgard_pde.hpp
+++ b/src/asgard_pde.hpp
@@ -1883,6 +1883,16 @@ public:
             "set_adapt_weight() already called, cannot set two different adapt weights");
     has_interp_funcs = true;
     ref_interp_  = std::move(func);
+    bool has_electric = false;
+    for (moment_id mid : moments) {
+      moment const mom = mlist[mid];
+      if (mom.is_electric()) {
+        has_electric = true;
+        break;
+      }
+    }
+    if (has_electric)
+      moments.push_back(mlist.get_id(moment::zero(domain_.num_vel())));
     ref_moments_ = std::move(moments);
   }
   //! set an interpolation function for adaptivity
@@ -1894,6 +1904,16 @@ public:
             "set_adapt_weight() already called, cannot set two different adapt weights");
     has_interp_funcs = true;
     ref_interp_  = std::move(func);
+    bool has_electric = false;
+    for (moment_id mid : moments) {
+      moment const mom = mlist[mid];
+      if (mom.is_electric()) {
+        has_electric = true;
+        break;
+      }
+    }
+    if (has_electric)
+      moments.push_back(mlist.get_id(moment::zero(domain_.num_vel())));
     ref_moments_ = std::move(moments);
   }
 

--- a/src/asgard_poisson.cpp
+++ b/src/asgard_poisson.cpp
@@ -248,6 +248,9 @@ void poisson_md<P>::remap_(indexset const& iset_old, indexset const &iset_new, g
 
   // Initialize exactly to 0.0 to automatically handle newly refined points
   gpu::vector<P> x_new(num_new * block_size);
+  gpu::fill_zeros(x_new.size(), x_new.data());
+  std::vector<int64_t> transfers;
+  transfers.reserve(num_old + num_new);
 
   int64_t iold = 0;
   int64_t inew = 0;
@@ -273,8 +276,8 @@ void poisson_md<P>::remap_(indexset const& iset_old, indexset const &iset_new, g
 
     if (relation == index_relation::asameb) {
       // Point survived adaptation: Transfer data
-      // TODO: make these memcopies into a single kernel
-      gpu::memcopy_dev2dev(block_size, x.data() + iold * block_size, x_new.data() + inew * block_size);
+      transfers.push_back(iold);
+      transfers.push_back(inew);
       inew++;
       iold++;
     } else if (relation == index_relation::abeforeb) {
@@ -285,6 +288,10 @@ void poisson_md<P>::remap_(indexset const& iset_old, indexset const &iset_new, g
       iold++;
     }
   }
+
+  // Peform copy on GPU
+  gpu::vector<int64_t> gpu_transfers(transfers);
+  gpu::flagged_memcopy_dev2dev(block_size, gpu_transfers, x, x_new);
   std::swap(x, x_new);
 }
 

--- a/src/asgard_refinement.cpp
+++ b/src/asgard_refinement.cpp
@@ -110,6 +110,15 @@ void refinement_manager<P>::refine_(std::vector<P> const &state, strategy mode,
   // add the correction due to the interpolation terms
   if (iplan.is_enabled()) {
     if (iweights_.is_moment()) {
+      terms.moms.update_position_grid(terms.grid);
+      std::visit([&](auto &p)
+        {
+          if constexpr (std::is_same_v<std::decay_t<decltype(p)>, poisson_1d<P>>) {
+            p.update_level(terms.grid.current_level(0));
+          } else if constexpr (std::is_same_v<std::decay_t<decltype(p)>, poisson_md<P>>) {
+            p.update_preconditioner(terms.moms.get_position_grid(), terms.conn, poisson_bc::periodic);
+          }
+        }, terms.moms.poisson_solver);
       terms.moms.compute_interps(moments_, terms.grid, state, terms.interp, terms.conn, terms.hier, terms.kwork);
       iplan.use_moments(true);
       terms.interp(iplan, terms.grid, terms.conn, terms.moms.get_cached_interps(), 0, state.data(),
@@ -145,7 +154,15 @@ void refinement_manager<P>::refine_(gpu::vector<P> const &state, strategy mode,
   {
     if (iweights_.is_moment()) {
       iplan.use_moments(true);
-
+      terms.moms.update_position_grid(terms.grid);
+      std::visit([&](auto &p)
+        {
+          if constexpr (std::is_same_v<std::decay_t<decltype(p)>, poisson_1d<P>>) {
+            p.update_level(terms.grid.current_level(0));
+          } else if constexpr (std::is_same_v<std::decay_t<decltype(p)>, poisson_md<P>>) {
+            p.update_preconditioner(terms.moms.get_position_grid(), terms.conn, poisson_bc::periodic);
+          }
+        }, terms.moms.poisson_solver);
       terms.moms.compute_moments(moments_, terms.grid, terms.interp, terms.conn, terms.hier,
                                  terms.kwork, state, not iweights_.is_gpu());
     } else {

--- a/src/pde/two_stream_md.cpp
+++ b/src/pde/two_stream_md.cpp
@@ -109,17 +109,11 @@ asgard::pde_scheme<P> make_two_stream(int const pos_dims, asgard::prog_opts opti
 
   options.title = std::to_string(pos_dims) + "X" + std::to_string(pos_dims) + "V Two Stream Instability";
 
-  asgard::pde_domain<P> domain;
+  asgard::pde_domain<P> domain(asgard::position_dims{pos_dims}, asgard::velocity_dims{pos_dims},
+                               std::vector<asgard::domain_range>(2 * pos_dims, {-2 * PI, 2 * PI}));
   if (pos_dims == 2) {
-    domain = asgard::pde_domain<P>(asgard::position_dims{2}, asgard::velocity_dims{2},
-                                 {{-2 * PI, 2 * PI}, {-2 * PI, 2 * PI},
-                                  {-2 * PI, 2 * PI}, {-2 * PI, 2 * PI}});
     options.default_start_levels = {7, 7, 7, 7};
   } else if (pos_dims == 3) {
-    domain = asgard::pde_domain<P>(asgard::position_dims{3}, asgard::velocity_dims{3},
-                                 {{-2 * PI, 2 * PI}, {-2 * PI, 2 * PI},
-                                  {-2 * PI, 2 * PI}, {-2 * PI, 2 * PI},
-                                  {-2 * PI, 2 * PI}, {-2 * PI, 2 * PI}});
     options.default_start_levels = {6, 6, 6, 6, 6, 6};
   } else {
     throw std::runtime_error("dims must be 2 or 3");
@@ -150,6 +144,16 @@ asgard::pde_scheme<P> make_two_stream(int const pos_dims, asgard::prog_opts opti
   // create a pde from the given options and domain
   asgard::pde_scheme<P> pde(options, domain);
 
+  // set up moments
+  asgard::moment_id melectric_x = pde.register_electric_moment(asgard::dimension_id(0), pos_dims);
+  asgard::moment_id melectric_y = pde.register_electric_moment(asgard::dimension_id(1), pos_dims);
+  asgard::moment_id melectric_z;
+  if (pos_dims == 3)
+    melectric_z = pde.register_electric_moment(asgard::dimension_id(2), pos_dims);
+
+  std::vector<asgard::moment_id> mids{melectric_x, melectric_y, melectric_z};
+  std::vector<asgard::term_1d<P>> vterms(2 * pos_dims, asgard::term_identity{});
+
   // terms are split into positive and negative
   auto positive = [](std::vector<P> const &x, std::vector<P> &y)
       -> void
@@ -168,243 +172,21 @@ asgard::pde_scheme<P> make_two_stream(int const pos_dims, asgard::prog_opts opti
         y[i] = std::min(P{0}, x[i]);
     };
 
-  asgard::moment_id melectric_x;
-  asgard::moment_id melectric_y;
-  asgard::moment_id melectric_z;
-  if (pos_dims == 2) {
-    melectric_x = pde.register_electric_moment(asgard::dimension_id(0), 2);
-    melectric_y = pde.register_electric_moment(asgard::dimension_id(1), 2);
-  } else {
-    melectric_x = pde.register_electric_moment(asgard::dimension_id(0), 3);
-    melectric_y = pde.register_electric_moment(asgard::dimension_id(1), 3);
-    melectric_z = pde.register_electric_moment(asgard::dimension_id(2), 3);
-  }
-
-  auto md_positive_x = [=](P /* time */, asgard::vector2d<P> const& /* nodes */,
-                    asgard::momentset<P> const &moments, std::vector<P> const &field,
-                    std::vector<P> &vals)
-    {
-      std::vector<P> const &e_x = moments[melectric_x];
-#pragma omp parallel for
-      for (size_t i = 0; i < vals.size(); i++)
-        vals[i] = field[i] * std::max(P{0}, e_x[i]);
-    };
-
-  auto md_negative_x = [=](P /* time */, asgard::vector2d<P> const& /* nodes */,
-                    asgard::momentset<P> const &moments, std::vector<P> const &field,
-                    std::vector<P> &vals)
-    {
-      std::vector<P> const &e_x = moments[melectric_x];
-#pragma omp parallel for
-      for (size_t i = 0; i < vals.size(); i++)
-        vals[i] = field[i] * std::min(P{0}, e_x[i]);
-    };
-
-  auto md_positive_y = [=](P /* time */, asgard::vector2d<P> const& /* nodes */,
-                    asgard::momentset<P> const &moments, std::vector<P> const &field,
-                    std::vector<P> &vals)
-    {
-      std::vector<P> const &e_y = moments[melectric_y];
-#pragma omp parallel for
-      for (size_t i = 0; i < vals.size(); i++)
-        vals[i] = field[i] * std::max(P{0}, e_y[i]);
-    };
-
-  auto md_negative_y = [=](P /* time */, asgard::vector2d<P> const& /* nodes */,
-                    asgard::momentset<P> const &moments, std::vector<P> const &field,
-                    std::vector<P> &vals)
-    {
-      std::vector<P> const &e_y = moments[melectric_y];
-#pragma omp parallel for
-      for (size_t i = 0; i < vals.size(); i++)
-        vals[i] = field[i] * std::min(P{0}, e_y[i]);
-    };
-
-  auto md_positive_z = [=](P /* time */, asgard::vector2d<P> const& /* nodes */,
-                    asgard::momentset<P> const &moments, std::vector<P> const &field,
-                    std::vector<P> &vals)
-    {
-      std::vector<P> const &e_z = moments[melectric_z];
-#pragma omp parallel for
-      for (size_t i = 0; i < vals.size(); i++)
-        vals[i] = field[i] * std::max(P{0}, e_z[i]);
-    };
-
-  auto md_negative_z = [=](P /* time */, asgard::vector2d<P> const& /* nodes */,
-                    asgard::momentset<P> const &moments, std::vector<P> const &field,
-                    std::vector<P> &vals)
-    {
-      std::vector<P> const &e_z = moments[melectric_z];
-#pragma omp parallel for
-      for (size_t i = 0; i < vals.size(); i++)
-        vals[i] = field[i] * std::min(P{0}, e_z[i]);
-    };
-
-
-  if (pos_dims == 2) {
-    pde += asgard::term_md<P>(std::vector<asgard::term_1d<P>>{
-        asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::periodic),
-        asgard::term_identity{},
-        asgard::term_volume<P>(positive),
-        asgard::term_identity{}
-      });
-
-    pde += asgard::term_md<P>(std::vector<asgard::term_1d<P>>{
-        asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::periodic),
-        asgard::term_identity{},
-        asgard::term_volume<P>(negative),
-        asgard::term_identity{}
-      });
-
-    pde += asgard::term_md<P>(std::vector<asgard::term_1d<P>>{
-        asgard::term_identity{},
-        asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::periodic),
-        asgard::term_identity{},
-        asgard::term_volume<P>(positive)
-      });
-
-    pde += asgard::term_md<P>(std::vector<asgard::term_1d<P>>{
-        asgard::term_identity{},
-        asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::periodic),
-        asgard::term_identity{},
-        asgard::term_volume<P>(negative)
-      });
-  } else {
-    pde += asgard::term_md<P>(std::vector<asgard::term_1d<P>>{
-        asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::periodic),
-        asgard::term_identity{},
-        asgard::term_identity{},
-        asgard::term_volume<P>(positive),
-        asgard::term_identity{},
-        asgard::term_identity{}
-      });
-
-    pde += asgard::term_md<P>(std::vector<asgard::term_1d<P>>{
-        asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::periodic),
-        asgard::term_identity{},
-        asgard::term_identity{},
-        asgard::term_volume<P>(negative),
-        asgard::term_identity{},
-        asgard::term_identity{}
-      });
-
-    pde += asgard::term_md<P>(std::vector<asgard::term_1d<P>>{
-        asgard::term_identity{},
-        asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::periodic),
-        asgard::term_identity{},
-        asgard::term_identity{},
-        asgard::term_volume<P>(positive),
-        asgard::term_identity{}
-      });
-
-    pde += asgard::term_md<P>(std::vector<asgard::term_1d<P>>{
-        asgard::term_identity{},
-        asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::periodic),
-        asgard::term_identity{},
-        asgard::term_identity{},
-        asgard::term_volume<P>(negative),
-        asgard::term_identity{}
-      });
-
-    pde += asgard::term_md<P>(std::vector<asgard::term_1d<P>>{
-        asgard::term_identity{},
-        asgard::term_identity{},
-        asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::periodic),
-        asgard::term_identity{},
-        asgard::term_identity{},
-        asgard::term_volume<P>(positive)
-      });
-
-    pde += asgard::term_md<P>(std::vector<asgard::term_1d<P>>{
-        asgard::term_identity{},
-        asgard::term_identity{},
-        asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::periodic),
-        asgard::term_identity{},
-        asgard::term_identity{},
-        asgard::term_volume<P>(negative)
-      });
+  // v * df/dx
+  for (int d : asgard::iindexof(pos_dims)) {
+    vterms[d] = asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::periodic);
+    vterms[pos_dims + d] = asgard::term_volume<P>(positive);
+    pde += asgard::term_md<P>(vterms);
+    vterms[d] = asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::periodic);
+    vterms[pos_dims + d] = asgard::term_volume<P>(negative);
+    pde += asgard::term_md<P>(vterms);
+    vterms[d] = asgard::term_identity{};
+    vterms[pos_dims + d] = asgard::term_identity{};
   }
 
 #ifdef ASGARD_USE_GPU
-  auto gpu_md_positive_x = [=](int64_t num, P t, P const x[], asgard::momentset_gpu<P> const &moments, P const f[], P fx[]) {
-      int threads = 256;
-      int blocks = (num + threads - 1) / threads;
-      interp_positive_kernel<<<blocks, threads>>>(num, f, moments[melectric_x].data(), fx);
-  };
-
-  auto gpu_md_negative_x = [=](int64_t num, P t, P const x[], asgard::momentset_gpu<P> const &moments, P const f[], P fx[]) {
-      int threads = 256;
-      int blocks = (num + threads - 1) / threads;
-      interp_negative_kernel<<<blocks, threads>>>(num, f, moments[melectric_x].data(), fx);
-  };
-
-  auto gpu_md_positive_y = [=](int64_t num, P t, P const x[], asgard::momentset_gpu<P> const &moments, P const f[], P fx[]) {
-      int threads = 256;
-      int blocks = (num + threads - 1) / threads;
-      interp_positive_kernel<<<blocks, threads>>>(num, f, moments[melectric_y].data(), fx);
-  };
-
-  auto gpu_md_negative_y = [=](int64_t num, P t, P const x[], asgard::momentset_gpu<P> const &moments, P const f[], P fx[]) {
-      int threads = 256;
-      int blocks = (num + threads - 1) / threads;
-      interp_negative_kernel<<<blocks, threads>>>(num, f, moments[melectric_y].data(), fx);
-  };
-
-  auto gpu_md_positive_z = [=](int64_t num, P t, P const x[], asgard::momentset_gpu<P> const &moments, P const f[], P fx[]) {
-      int threads = 256;
-      int blocks = (num + threads - 1) / threads;
-      interp_positive_kernel<<<blocks, threads>>>(num, f, moments[melectric_z].data(), fx);
-  };
-
-  auto gpu_md_negative_z = [=](int64_t num, P t, P const x[], asgard::momentset_gpu<P> const &moments, P const f[], P fx[]) {
-      int threads = 256;
-      int blocks = (num + threads - 1) / threads;
-      interp_negative_kernel<<<blocks, threads>>>(num, f, moments[melectric_z].data(), fx);
-  };
-
   std::function<void(int64_t, P, P const[], asgard::momentset_gpu<P> const&, P const[], P[])> weight;
-
   if (pos_dims == 2) {
-    pde += asgard::term_md<P>{
-        asgard::term_md(asgard::term_interp<P>(gpu_md_positive_x, {melectric_x, })),
-        asgard::term_md<P>{
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides)),
-          asgard::term_identity{}
-        }
-      };
-
-    pde += asgard::term_md<P>{
-        asgard::term_md(asgard::term_interp<P>(gpu_md_negative_x, {melectric_x, })),
-        asgard::term_md<P>{
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides)),
-          asgard::term_identity{}
-        }
-      };
-
-    pde += asgard::term_md<P>{
-        asgard::term_md(asgard::term_interp<P>(gpu_md_positive_y, {melectric_y, })),
-        asgard::term_md<P>{
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides))
-        }
-      };
-
-    pde += asgard::term_md<P>{
-        asgard::term_md(asgard::term_interp<P>(gpu_md_negative_y, {melectric_y, })),
-        asgard::term_md<P>{
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides))
-        }
-      };
-
     weight = [=](int64_t num, P t, P const x[], asgard::momentset_gpu<P> const &moments, P const f[], P fx[])
     {
       int threads = 256;
@@ -414,80 +196,7 @@ asgard::pde_scheme<P> make_two_stream(int const pos_dims, asgard::prog_opts opti
       asgard::gpu::vector<P> const &e_y = moments[melectric_y];
       weight_kernel_2d<<<blocks, threads>>>(num, f, e_x.data(), e_y.data(), fx);
     };
-
   } else {
-    pde += asgard::term_md<P>{
-        asgard::term_md(asgard::term_interp<P>(gpu_md_positive_x, {melectric_x, })),
-        asgard::term_md<P>{
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides)),
-          asgard::term_identity{},
-          asgard::term_identity{}
-        }
-      };
-
-    pde += asgard::term_md<P>{
-        asgard::term_md(asgard::term_interp<P>(gpu_md_negative_x, {melectric_x, })),
-        asgard::term_md<P>{
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides)),
-          asgard::term_identity{},
-          asgard::term_identity{}
-        }
-      };
-
-    pde += asgard::term_md<P>{
-        asgard::term_md(asgard::term_interp<P>(gpu_md_positive_y, {melectric_y, })),
-        asgard::term_md<P>{
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides)),
-          asgard::term_identity{}
-        }
-      };
-
-    pde += asgard::term_md<P>{
-        asgard::term_md(asgard::term_interp<P>(gpu_md_negative_y, {melectric_y, })),
-        asgard::term_md<P>{
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides)),
-          asgard::term_identity{}
-        }
-      };
-
-      pde += asgard::term_md<P>{
-        asgard::term_md(asgard::term_interp<P>(gpu_md_positive_z, {melectric_z, })),
-        asgard::term_md<P>{
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides))
-        }
-      };
-
-    pde += asgard::term_md<P>{
-        asgard::term_md(asgard::term_interp<P>(gpu_md_negative_z, {melectric_z, })),
-        asgard::term_md<P>{
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides))
-        }
-      };
-
     weight = [=](int64_t num, P t, P const x[], asgard::momentset_gpu<P> const &moments, P const f[], P fx[])
     {
       int threads = 256;
@@ -499,169 +208,112 @@ asgard::pde_scheme<P> make_two_stream(int const pos_dims, asgard::prog_opts opti
       weight_kernel_3d<<<blocks, threads>>>(num, f, e_x.data(), e_y.data(), e_z.data(), fx);
     };
   }
-
-#else
+#else 
   std::function<void(P, asgard::vector2d<P> const&, asgard::momentset<P> const&,
                      std::vector<P> const&, std::vector<P>&)> weight;
-
   if (pos_dims == 2) {
-    pde += asgard::term_md<P>{
-        asgard::term_md(asgard::term_interp<P>(md_positive_x, {melectric_x, })),
-        asgard::term_md<P>{
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides)),
-          asgard::term_identity{}
-        }
-      };
-
-    pde += asgard::term_md<P>{
-        asgard::term_md(asgard::term_interp<P>(md_negative_x, {melectric_x, })),
-        asgard::term_md<P>{
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides)),
-          asgard::term_identity{}
-        }
-      };
-
-    pde += asgard::term_md<P>{
-        asgard::term_md(asgard::term_interp<P>(md_positive_y, {melectric_y, })),
-        asgard::term_md<P>{
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides))
-        }
-      };
-
-    pde += asgard::term_md<P>{
-        asgard::term_md(asgard::term_interp<P>(md_negative_y, {melectric_y, })),
-        asgard::term_md<P>{
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides))
-        }
-      };
-
     weight = [=](P /* time */, asgard::vector2d<P> const& /* nodes */,
-                      asgard::momentset<P> const &moments, std::vector<P> const &field,
-                      std::vector<P> &vals)
-      {
-        std::vector<P> const &e_x = moments[melectric_x];
-        std::vector<P> const &e_y = moments[melectric_y];
-  #pragma omp parallel for
-        for (size_t i = 0; i < vals.size(); i++)
-          vals[i] = field[i] * (e_x[i] * e_x[i] + e_y[i] * e_y[i]);
-      };
+                 asgard::momentset<P> const &moments, std::vector<P> const &field,
+                 std::vector<P> &vals)
+    {
+      std::vector<P> const &e_x = moments[melectric_x];
+      std::vector<P> const &e_y = moments[melectric_y];
+#pragma omp parallel for
+      for (size_t i = 0; i < vals.size(); i++)
+        vals[i] = field[i] * (e_x[i] * e_x[i] + e_y[i] * e_y[i]);
+    };
   } else {
-    pde += asgard::term_md<P>{
-        asgard::term_md(asgard::term_interp<P>(md_positive_x, {melectric_x, })),
-        asgard::term_md<P>{
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides)),
-          asgard::term_identity{},
-          asgard::term_identity{}
-        }
-      };
-
-    pde += asgard::term_md<P>{
-        asgard::term_md(asgard::term_interp<P>(md_negative_x, {melectric_x, })),
-        asgard::term_md<P>{
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides)),
-          asgard::term_identity{},
-          asgard::term_identity{}
-        }
-      };
-
-    pde += asgard::term_md<P>{
-        asgard::term_md(asgard::term_interp<P>(md_positive_y, {melectric_y, })),
-        asgard::term_md<P>{
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides)),
-          asgard::term_identity{}
-        }
-      };
-
-    pde += asgard::term_md<P>{
-        asgard::term_md(asgard::term_interp<P>(md_negative_y, {melectric_y, })),
-        asgard::term_md<P>{
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides)),
-          asgard::term_identity{}
-        }
-      };
-
-    pde += asgard::term_md<P>{
-        asgard::term_md(asgard::term_interp<P>(md_positive_z, {melectric_z, })),
-        asgard::term_md<P>{
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides))
-        }
-      };
-
-    pde += asgard::term_md<P>{
-        asgard::term_md(asgard::term_interp<P>(md_negative_z, {melectric_z, })),
-        asgard::term_md<P>{
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_identity{},
-          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides))
-        }
-      };
-
     weight = [=](P /* time */, asgard::vector2d<P> const& /* nodes */,
-                      asgard::momentset<P> const &moments, std::vector<P> const &field,
-                      std::vector<P> &vals)
-      {
-        std::vector<P> const &e_x = moments[melectric_x];
-        std::vector<P> const &e_y = moments[melectric_y];
-        std::vector<P> const &e_z = moments[melectric_z];
-  #pragma omp parallel for
-        for (size_t i = 0; i < vals.size(); i++)
-          vals[i] = field[i] * (e_x[i] * e_x[i] + e_y[i] * e_y[i] + e_z[i] * e_z[i]);
-      };
+                 asgard::momentset<P> const &moments, std::vector<P> const &field,
+                 std::vector<P> &vals)
+    {
+      std::vector<P> const &e_x = moments[melectric_x];
+      std::vector<P> const &e_y = moments[melectric_y];
+      std::vector<P> const &e_z = moments[melectric_z];
+#pragma omp parallel for
+      for (size_t i = 0; i < vals.size(); i++)
+        vals[i] = field[i] * (e_x[i] * e_x[i] + e_y[i] * e_y[i] + e_z[i] * e_z[i]);
+    };
   }
 #endif
 
+  for (int d : asgard::iindexof(pos_dims)) {
+    asgard::moment_id mid = mids[d];
+
+#ifdef ASGARD_USE_GPU
+    auto gpu_md_positive = [=](int64_t num, P t, P const x[], asgard::momentset_gpu<P> const &moments, P const f[], P fx[]) {
+      int threads = 256;
+      int blocks = (num + threads - 1) / threads;
+      interp_negative_kernel<<<blocks, threads>>>(num, f, moments[mid].data(), fx);
+    };
+
+    auto gpu_md_negative = [=](int64_t num, P t, P const x[], asgard::momentset_gpu<P> const &moments, P const f[], P fx[]) {
+      int threads = 256;
+      int blocks = (num + threads - 1) / threads;
+      interp_negative_kernel<<<blocks, threads>>>(num, f, moments[mid].data(), fx);
+    };
+
+    vterms[pos_dims + d] = asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides));
+    pde += asgard::term_md<P>{
+        asgard::term_md(asgard::term_interp<P>(gpu_md_positive, {mid, })),
+        asgard::term_md<P>(vterms)
+      };
+    vterms[pos_dims + d] = asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides));
+    pde += asgard::term_md<P>{
+        asgard::term_md(asgard::term_interp<P>(gpu_md_negative, {mid, })),
+        asgard::term_md<P>(vterms)
+      };
+    vterms[pos_dims + d] = asgard::term_identity{};
+#else
+    auto md_positive = [=](P /* time */, asgard::vector2d<P> const& /* nodes */,
+                      asgard::momentset<P> const &moments, std::vector<P> const &field,
+                      std::vector<P> &vals)
+    {
+      std::vector<P> const &ef = moments[mid];
+#pragma omp parallel for
+      for (size_t i = 0; i < vals.size(); i++)
+        vals[i] = field[i] * std::max(P{0}, ef[i]);
+    };
+
+    auto md_negative = [=](P /* time */, asgard::vector2d<P> const& /* nodes */,
+                      asgard::momentset<P> const &moments, std::vector<P> const &field,
+                      std::vector<P> &vals)
+    {
+        std::vector<P> const &ef = moments[mid];
+#pragma omp parallel for
+        for (size_t i = 0; i < vals.size(); i++)
+          vals[i] = field[i] * std::min(P{0}, ef[i]);
+    };
+
+    vterms[pos_dims + d] = asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides));
+    pde += asgard::term_md<P>{
+        asgard::term_md(asgard::term_interp<P>(md_positive, {mid, })),
+        asgard::term_md<P>(vterms)
+      };
+
+    vterms[pos_dims + d] = asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides));
+    pde += asgard::term_md<P>{
+        asgard::term_md(asgard::term_interp<P>(md_negative, {mid, })),
+        asgard::term_md<P>(vterms)
+      };
+    vterms[pos_dims + d] = asgard::term_identity{};
+#endif
+  }
+
   // initial conditions in x and v
-  auto ic_x = [](std::vector<P> const &x, P /* time */, std::vector<P> &fx) ->
+  auto ic_perturbed_pos = [](std::vector<P> const &x, P /* time */, std::vector<P> &fx) ->
     void {
       for (size_t i = 0; i < x.size(); i++)
         fx[i] = 1.0 - 0.5 * std::cos(0.5 * x[i]);
     };
 
-  auto ic_y = [](std::vector<P> const &y, P /* time */, std::vector<P> &fy) ->
+  auto ic_uniform_pos = [](std::vector<P> const &y, P /* time */, std::vector<P> &fy) ->
     void {
       for (size_t i = 0; i < y.size(); i++)
         fy[i] = 1.0;
     };
 
-  auto ic_z = [](std::vector<P> const &z, P /* time */, std::vector<P> &fz) ->
-    void {
-      for (size_t i = 0; i < z.size(); i++)
-        fz[i] = 1.0;
-    };
-
-  auto ic_vx = [](std::vector<P> const &vx, P /* time */, std::vector<P> &fv) ->
+  auto ic_twostream_vel = [](std::vector<P> const &vx, P /* time */, std::vector<P> &fv) ->
     void {
       P const c = P{2} / std::sqrt(PI);
 
@@ -669,7 +321,7 @@ asgard::pde_scheme<P> make_two_stream(int const pos_dims, asgard::prog_opts opti
         fv[i] = c * vx[i] * vx[i] * std::exp(-vx[i] * vx[i]);
     };
 
-  auto ic_vy = [](std::vector<P> const &vy, P /* time */, std::vector<P> &fv) ->
+  auto ic_maxwellian_vel = [](std::vector<P> const &vy, P /* time */, std::vector<P> &fv) ->
     void {
       P const c = P{1} / std::sqrt(PI);
 
@@ -677,19 +329,12 @@ asgard::pde_scheme<P> make_two_stream(int const pos_dims, asgard::prog_opts opti
         fv[i] = c * std::exp(-vy[i] * vy[i]);
     };
 
-  auto ic_vz = [](std::vector<P> const &vz, P /* time */, std::vector<P> &fv) ->
-    void {
-      P const c = P{1} / std::sqrt(PI);
-
-      for (size_t i = 0; i < vz.size(); i++)
-        fv[i] = c * std::exp(-vz[i] * vz[i]);
-    };
-
   if (pos_dims == 2) {
-    pde.add_initial(asgard::separable_func<P>({ic_x, ic_y, ic_vx, ic_vy}));
+    pde.add_initial(asgard::separable_func<P>({ic_perturbed_pos, ic_uniform_pos, ic_twostream_vel, ic_maxwellian_vel}));
     pde.set_adapt_weight(weight, {melectric_x, melectric_y});
   } else {
-    pde.add_initial(asgard::separable_func<P>({ic_x, ic_y, ic_z, ic_vx, ic_vy, ic_vz}));
+    pde.add_initial(asgard::separable_func<P>({ic_perturbed_pos, ic_uniform_pos, ic_uniform_pos,
+                                               ic_twostream_vel, ic_maxwellian_vel, ic_maxwellian_vel}));
     pde.set_adapt_weight(weight, {melectric_x, melectric_y, melectric_z});
   }
 

--- a/src/pde/two_stream_md.cpp
+++ b/src/pde/two_stream_md.cpp
@@ -244,7 +244,7 @@ asgard::pde_scheme<P> make_two_stream(int const pos_dims, asgard::prog_opts opti
     auto gpu_md_positive = [=](int64_t num, P t, P const x[], asgard::momentset_gpu<P> const &moments, P const f[], P fx[]) {
       int threads = 256;
       int blocks = (num + threads - 1) / threads;
-      interp_negative_kernel<<<blocks, threads>>>(num, f, moments[mid].data(), fx);
+      interp_positive_kernel<<<blocks, threads>>>(num, f, moments[mid].data(), fx);
     };
 
     auto gpu_md_negative = [=](int64_t num, P t, P const x[], asgard::momentset_gpu<P> const &moments, P const f[], P fx[]) {
@@ -455,13 +455,16 @@ void test_energy(std::string const &opt_str) {
   // the pde needs only the zeroth moment and computes that internally
   // we are using the other moments to check energy conservation properties
   auto pde = make_two_stream(2, options);
+  moment_id const melectric_x = pde.register_electric_moment(asgard::dimension_id(0), 2);
+  moment_id const melectric_y = pde.register_electric_moment(asgard::dimension_id(1), 2);
+
+  // needed for verification but not for running
   moment_id const rho = pde.register_moment({0, 0});
-  moment_id const p0 = pde.register_moment({1, 0}); // needed for verification, but not running
+  moment_id const p0 = pde.register_moment({1, 0});
   moment_id const p1 = pde.register_moment({0, 1});
   moment_id const ke0 = pde.register_moment({2, 0});
   moment_id const ke1 = pde.register_moment({0, 2});
-  moment_id const melectric_x = pde.register_electric_moment(asgard::dimension_id(0), 2);
-  moment_id const melectric_y = pde.register_electric_moment(asgard::dimension_id(1), 2);
+
   discretization_manager disc(std::move(pde), verbosity_level::quiet);
 
   P E0 = 0; // initial total energy (potential + kinetic), will initialize on first iteration

--- a/src/pde/two_stream_md.cpp
+++ b/src/pde/two_stream_md.cpp
@@ -67,10 +67,19 @@ __global__ void interp_negative_kernel(int64_t num, P const* field, P const* mom
 }
 
 template<typename P>
-__global__ void weight_kernel(int64_t num, P const *field, P const *ex, P const *ey, P* out) {
+__global__ void weight_kernel_2d(int64_t num, P const *field, P const *ex, P const *ey, P* out) {
   int64_t i = blockIdx.x * blockDim.x + threadIdx.x;
   while (i < num) {
     out[i] = field[i] * (ex[i] * ex[i] + ey[i] * ey[i]);
+    i += blockDim.x * gridDim.x;
+  }
+}
+
+template<typename P>
+__global__ void weight_kernel_3d(int64_t num, P const *field, P const *ex, P const *ey, P const *ez, P* out) {
+  int64_t i = blockIdx.x * blockDim.x + threadIdx.x;
+  while (i < num) {
+    out[i] = field[i] * (ex[i] * ex[i] + ey[i] * ey[i] + ez[i] * ez[i]);
     i += blockDim.x * gridDim.x;
   }
 }
@@ -93,24 +102,34 @@ __global__ void weight_kernel(int64_t num, P const *field, P const *ex, P const 
  * \snippet two_stream.cpp two_stream make
  */
 template<typename P = asgard::default_precision>
-asgard::pde_scheme<P> make_two_stream(asgard::prog_opts options) {
+asgard::pde_scheme<P> make_two_stream(int const pos_dims, asgard::prog_opts options) {
 #ifndef __ASGARD_DOXYGEN_SKIP
 //! [two_stream make]
 #endif
 
-  options.title = "Multi-D Two Stream Instability";
+  options.title = std::to_string(pos_dims) + "X" + std::to_string(pos_dims) + "V Two Stream Instability";
 
-  // the domain has one position and one velocity dimension: 1x1v
-  asgard::pde_domain<P> domain(asgard::position_dims{2}, asgard::velocity_dims{2},
-                               {{-2 * PI, 2 * PI}, {-2 * PI, 2 * PI},
-                                {-2 * PI, 2 * PI}, {-2 * PI, 2 * PI}});
+  asgard::pde_domain<P> domain;
+  if (pos_dims == 2) {
+    domain = asgard::pde_domain<P>(asgard::position_dims{2}, asgard::velocity_dims{2},
+                                 {{-2 * PI, 2 * PI}, {-2 * PI, 2 * PI},
+                                  {-2 * PI, 2 * PI}, {-2 * PI, 2 * PI}});
+    options.default_start_levels = {7, 7, 7, 7};
+  } else if (pos_dims == 3) {
+    domain = asgard::pde_domain<P>(asgard::position_dims{3}, asgard::velocity_dims{3},
+                                 {{-2 * PI, 2 * PI}, {-2 * PI, 2 * PI},
+                                  {-2 * PI, 2 * PI}, {-2 * PI, 2 * PI},
+                                  {-2 * PI, 2 * PI}, {-2 * PI, 2 * PI}});
+    options.default_start_levels = {6, 6, 6, 6, 6, 6};
+  } else {
+    throw std::runtime_error("dims must be 2 or 3");
+  }
 
   // setting some default options
   // defaults are used only the corresponding values are missing from the command line
   int const default_degree = 2;
 
   options.default_degree = default_degree;
-  options.default_start_levels = {7, 7, 7, 7};
   options.default_poisson_tolerance = 1e-8;
   options.default_poisson_iterations = 1000;
   options.default_poisson_precon = asgard::precon_method::jacobi;
@@ -123,7 +142,7 @@ asgard::pde_scheme<P> make_two_stream(asgard::prog_opts options) {
   int const n = (1 << options.max_level());
   options.default_dt = 3.0 / (2 * (2 * k + 1) * n);
 
-  options.default_stop_time = 0.25;
+  options.default_stop_time = 2.0;
 
   // using explicit RK2
   options.default_step_method = asgard::time_method::rk2;
@@ -149,8 +168,17 @@ asgard::pde_scheme<P> make_two_stream(asgard::prog_opts options) {
         y[i] = std::min(P{0}, x[i]);
     };
 
-  asgard::moment_id melectric_x = pde.register_electric_moment(asgard::dimension_id(0), 2);
-  asgard::moment_id melectric_y = pde.register_electric_moment(asgard::dimension_id(1), 2);
+  asgard::moment_id melectric_x;
+  asgard::moment_id melectric_y;
+  asgard::moment_id melectric_z;
+  if (pos_dims == 2) {
+    melectric_x = pde.register_electric_moment(asgard::dimension_id(0), 2);
+    melectric_y = pde.register_electric_moment(asgard::dimension_id(1), 2);
+  } else {
+    melectric_x = pde.register_electric_moment(asgard::dimension_id(0), 3);
+    melectric_y = pde.register_electric_moment(asgard::dimension_id(1), 3);
+    melectric_z = pde.register_electric_moment(asgard::dimension_id(2), 3);
+  }
 
   auto md_positive_x = [=](P /* time */, asgard::vector2d<P> const& /* nodes */,
                     asgard::momentset<P> const &moments, std::vector<P> const &field,
@@ -192,33 +220,110 @@ asgard::pde_scheme<P> make_two_stream(asgard::prog_opts options) {
         vals[i] = field[i] * std::min(P{0}, e_y[i]);
     };
 
-  pde += asgard::term_md<P>(std::vector<asgard::term_1d<P>>{
-      asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::periodic),
-      asgard::term_identity{},
-      asgard::term_volume<P>(positive),
-      asgard::term_identity{}
-    });
+  auto md_positive_z = [=](P /* time */, asgard::vector2d<P> const& /* nodes */,
+                    asgard::momentset<P> const &moments, std::vector<P> const &field,
+                    std::vector<P> &vals)
+    {
+      std::vector<P> const &e_z = moments[melectric_z];
+#pragma omp parallel for
+      for (size_t i = 0; i < vals.size(); i++)
+        vals[i] = field[i] * std::max(P{0}, e_z[i]);
+    };
 
-  pde += asgard::term_md<P>(std::vector<asgard::term_1d<P>>{
-    asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::periodic),
-    asgard::term_identity{},
-    asgard::term_volume<P>(negative),
-    asgard::term_identity{}
-    });
+  auto md_negative_z = [=](P /* time */, asgard::vector2d<P> const& /* nodes */,
+                    asgard::momentset<P> const &moments, std::vector<P> const &field,
+                    std::vector<P> &vals)
+    {
+      std::vector<P> const &e_z = moments[melectric_z];
+#pragma omp parallel for
+      for (size_t i = 0; i < vals.size(); i++)
+        vals[i] = field[i] * std::min(P{0}, e_z[i]);
+    };
 
-  pde += asgard::term_md<P>(std::vector<asgard::term_1d<P>>{
-    asgard::term_identity{},
-    asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::periodic),
-    asgard::term_identity{},
-    asgard::term_volume<P>(positive)
-  });
 
-  pde += asgard::term_md<P>(std::vector<asgard::term_1d<P>>{
-    asgard::term_identity{},
-    asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::periodic),
-    asgard::term_identity{},
-    asgard::term_volume<P>(negative)
-    });
+  if (pos_dims == 2) {
+    pde += asgard::term_md<P>(std::vector<asgard::term_1d<P>>{
+        asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::periodic),
+        asgard::term_identity{},
+        asgard::term_volume<P>(positive),
+        asgard::term_identity{}
+      });
+
+    pde += asgard::term_md<P>(std::vector<asgard::term_1d<P>>{
+        asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::periodic),
+        asgard::term_identity{},
+        asgard::term_volume<P>(negative),
+        asgard::term_identity{}
+      });
+
+    pde += asgard::term_md<P>(std::vector<asgard::term_1d<P>>{
+        asgard::term_identity{},
+        asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::periodic),
+        asgard::term_identity{},
+        asgard::term_volume<P>(positive)
+      });
+
+    pde += asgard::term_md<P>(std::vector<asgard::term_1d<P>>{
+        asgard::term_identity{},
+        asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::periodic),
+        asgard::term_identity{},
+        asgard::term_volume<P>(negative)
+      });
+  } else {
+    pde += asgard::term_md<P>(std::vector<asgard::term_1d<P>>{
+        asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::periodic),
+        asgard::term_identity{},
+        asgard::term_identity{},
+        asgard::term_volume<P>(positive),
+        asgard::term_identity{},
+        asgard::term_identity{}
+      });
+
+    pde += asgard::term_md<P>(std::vector<asgard::term_1d<P>>{
+        asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::periodic),
+        asgard::term_identity{},
+        asgard::term_identity{},
+        asgard::term_volume<P>(negative),
+        asgard::term_identity{},
+        asgard::term_identity{}
+      });
+
+    pde += asgard::term_md<P>(std::vector<asgard::term_1d<P>>{
+        asgard::term_identity{},
+        asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::periodic),
+        asgard::term_identity{},
+        asgard::term_identity{},
+        asgard::term_volume<P>(positive),
+        asgard::term_identity{}
+      });
+
+    pde += asgard::term_md<P>(std::vector<asgard::term_1d<P>>{
+        asgard::term_identity{},
+        asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::periodic),
+        asgard::term_identity{},
+        asgard::term_identity{},
+        asgard::term_volume<P>(negative),
+        asgard::term_identity{}
+      });
+
+    pde += asgard::term_md<P>(std::vector<asgard::term_1d<P>>{
+        asgard::term_identity{},
+        asgard::term_identity{},
+        asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::periodic),
+        asgard::term_identity{},
+        asgard::term_identity{},
+        asgard::term_volume<P>(positive)
+      });
+
+    pde += asgard::term_md<P>(std::vector<asgard::term_1d<P>>{
+        asgard::term_identity{},
+        asgard::term_identity{},
+        asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::periodic),
+        asgard::term_identity{},
+        asgard::term_identity{},
+        asgard::term_volume<P>(negative)
+      });
+  }
 
 #ifdef ASGARD_USE_GPU
   auto gpu_md_positive_x = [=](int64_t num, P t, P const x[], asgard::momentset_gpu<P> const &moments, P const f[], P fx[]) {
@@ -245,106 +350,296 @@ asgard::pde_scheme<P> make_two_stream(asgard::prog_opts options) {
       interp_negative_kernel<<<blocks, threads>>>(num, f, moments[melectric_y].data(), fx);
   };
 
-  pde += asgard::term_md<P>{
-      asgard::term_md(asgard::term_interp<P>(gpu_md_positive_x, {melectric_x, })),
-      asgard::term_md<P>{
-        asgard::term_identity{},
-        asgard::term_identity{},
-        asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides)),
-        asgard::term_identity{}
-      }
-    };
+  auto gpu_md_positive_z = [=](int64_t num, P t, P const x[], asgard::momentset_gpu<P> const &moments, P const f[], P fx[]) {
+      int threads = 256;
+      int blocks = (num + threads - 1) / threads;
+      interp_positive_kernel<<<blocks, threads>>>(num, f, moments[melectric_z].data(), fx);
+  };
 
-  pde += asgard::term_md<P>{
-      asgard::term_md(asgard::term_interp<P>(gpu_md_negative_x, {melectric_x, })),
-      asgard::term_md<P>{
-        asgard::term_identity{},
-        asgard::term_identity{},
-        asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides)),
-        asgard::term_identity{}
-      }
-    };
+  auto gpu_md_negative_z = [=](int64_t num, P t, P const x[], asgard::momentset_gpu<P> const &moments, P const f[], P fx[]) {
+      int threads = 256;
+      int blocks = (num + threads - 1) / threads;
+      interp_negative_kernel<<<blocks, threads>>>(num, f, moments[melectric_z].data(), fx);
+  };
 
-  pde += asgard::term_md<P>{
-      asgard::term_md(asgard::term_interp<P>(gpu_md_positive_y, {melectric_y, })),
-      asgard::term_md<P>{
-        asgard::term_identity{},
-        asgard::term_identity{},
-        asgard::term_identity{},
-        asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides))
-      }
-    };
+  std::function<void(int64_t, P, P const[], asgard::momentset_gpu<P> const&, P const[], P[])> weight;
 
-  pde += asgard::term_md<P>{
-      asgard::term_md(asgard::term_interp<P>(gpu_md_negative_y, {melectric_y, })),
-      asgard::term_md<P>{
-        asgard::term_identity{},
-        asgard::term_identity{},
-        asgard::term_identity{},
-        asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides))
-      }
-    };
+  if (pos_dims == 2) {
+    pde += asgard::term_md<P>{
+        asgard::term_md(asgard::term_interp<P>(gpu_md_positive_x, {melectric_x, })),
+        asgard::term_md<P>{
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides)),
+          asgard::term_identity{}
+        }
+      };
 
-  auto weight = [=](int64_t num, P t, P const x[], asgard::momentset_gpu<P> const &moments, P const f[], P fx[])
+    pde += asgard::term_md<P>{
+        asgard::term_md(asgard::term_interp<P>(gpu_md_negative_x, {melectric_x, })),
+        asgard::term_md<P>{
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides)),
+          asgard::term_identity{}
+        }
+      };
+
+    pde += asgard::term_md<P>{
+        asgard::term_md(asgard::term_interp<P>(gpu_md_positive_y, {melectric_y, })),
+        asgard::term_md<P>{
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides))
+        }
+      };
+
+    pde += asgard::term_md<P>{
+        asgard::term_md(asgard::term_interp<P>(gpu_md_negative_y, {melectric_y, })),
+        asgard::term_md<P>{
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides))
+        }
+      };
+
+    weight = [=](int64_t num, P t, P const x[], asgard::momentset_gpu<P> const &moments, P const f[], P fx[])
     {
       int threads = 256;
       int blocks = (num + threads - 1) / threads;
 
       asgard::gpu::vector<P> const &e_x = moments[melectric_x];
       asgard::gpu::vector<P> const &e_y = moments[melectric_y];
-      weight_kernel<<<blocks, threads>>>(num, f, e_x.data(), e_y.data(), fx);
-    };
-#else
-  pde += asgard::term_md<P>{
-      asgard::term_md(asgard::term_interp<P>(md_positive_x, {melectric_x, })),
-      asgard::term_md<P>{
-        asgard::term_identity{},
-        asgard::term_identity{},
-        asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides)),
-        asgard::term_identity{}
-      }
+      weight_kernel_2d<<<blocks, threads>>>(num, f, e_x.data(), e_y.data(), fx);
     };
 
-  pde += asgard::term_md<P>{
-      asgard::term_md(asgard::term_interp<P>(md_negative_x, {melectric_x, })),
-      asgard::term_md<P>{
-        asgard::term_identity{},
-        asgard::term_identity{},
-        asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides)),
-        asgard::term_identity{}
-      }
-    };
+  } else {
+    pde += asgard::term_md<P>{
+        asgard::term_md(asgard::term_interp<P>(gpu_md_positive_x, {melectric_x, })),
+        asgard::term_md<P>{
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides)),
+          asgard::term_identity{},
+          asgard::term_identity{}
+        }
+      };
 
-  pde += asgard::term_md<P>{
-      asgard::term_md(asgard::term_interp<P>(md_positive_y, {melectric_y, })),
-      asgard::term_md<P>{
-        asgard::term_identity{},
-        asgard::term_identity{},
-        asgard::term_identity{},
-        asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides))
-      }
-    };
+    pde += asgard::term_md<P>{
+        asgard::term_md(asgard::term_interp<P>(gpu_md_negative_x, {melectric_x, })),
+        asgard::term_md<P>{
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides)),
+          asgard::term_identity{},
+          asgard::term_identity{}
+        }
+      };
 
-  pde += asgard::term_md<P>{
-      asgard::term_md(asgard::term_interp<P>(md_negative_y, {melectric_y, })),
-      asgard::term_md<P>{
-        asgard::term_identity{},
-        asgard::term_identity{},
-        asgard::term_identity{},
-        asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides))
-      }
-    };
+    pde += asgard::term_md<P>{
+        asgard::term_md(asgard::term_interp<P>(gpu_md_positive_y, {melectric_y, })),
+        asgard::term_md<P>{
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides)),
+          asgard::term_identity{}
+        }
+      };
 
-  auto weight = [=](P /* time */, asgard::vector2d<P> const& /* nodes */,
-                    asgard::momentset<P> const &moments, std::vector<P> const &field,
-                    std::vector<P> &vals)
+    pde += asgard::term_md<P>{
+        asgard::term_md(asgard::term_interp<P>(gpu_md_negative_y, {melectric_y, })),
+        asgard::term_md<P>{
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides)),
+          asgard::term_identity{}
+        }
+      };
+
+      pde += asgard::term_md<P>{
+        asgard::term_md(asgard::term_interp<P>(gpu_md_positive_z, {melectric_z, })),
+        asgard::term_md<P>{
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides))
+        }
+      };
+
+    pde += asgard::term_md<P>{
+        asgard::term_md(asgard::term_interp<P>(gpu_md_negative_z, {melectric_z, })),
+        asgard::term_md<P>{
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides))
+        }
+      };
+
+    weight = [=](int64_t num, P t, P const x[], asgard::momentset_gpu<P> const &moments, P const f[], P fx[])
     {
-      std::vector<P> const &e_x = moments[melectric_x];
-      std::vector<P> const &e_y = moments[melectric_y];
-#pragma omp parallel for
-      for (size_t i = 0; i < vals.size(); i++)
-        vals[i] = field[i] * (e_x[i] * e_x[i] + e_y[i] * e_y[i]);
+      int threads = 256;
+      int blocks = (num + threads - 1) / threads;
+
+      asgard::gpu::vector<P> const &e_x = moments[melectric_x];
+      asgard::gpu::vector<P> const &e_y = moments[melectric_y];
+      asgard::gpu::vector<P> const &e_z = moments[melectric_z];
+      weight_kernel_3d<<<blocks, threads>>>(num, f, e_x.data(), e_y.data(), e_z.data(), fx);
     };
+  }
+
+#else
+  std::function<void(P, asgard::vector2d<P> const&, asgard::momentset<P> const&,
+                     std::vector<P> const&, std::vector<P>&)> weight;
+
+  if (pos_dims == 2) {
+    pde += asgard::term_md<P>{
+        asgard::term_md(asgard::term_interp<P>(md_positive_x, {melectric_x, })),
+        asgard::term_md<P>{
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides)),
+          asgard::term_identity{}
+        }
+      };
+
+    pde += asgard::term_md<P>{
+        asgard::term_md(asgard::term_interp<P>(md_negative_x, {melectric_x, })),
+        asgard::term_md<P>{
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides)),
+          asgard::term_identity{}
+        }
+      };
+
+    pde += asgard::term_md<P>{
+        asgard::term_md(asgard::term_interp<P>(md_positive_y, {melectric_y, })),
+        asgard::term_md<P>{
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides))
+        }
+      };
+
+    pde += asgard::term_md<P>{
+        asgard::term_md(asgard::term_interp<P>(md_negative_y, {melectric_y, })),
+        asgard::term_md<P>{
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides))
+        }
+      };
+
+    weight = [=](P /* time */, asgard::vector2d<P> const& /* nodes */,
+                      asgard::momentset<P> const &moments, std::vector<P> const &field,
+                      std::vector<P> &vals)
+      {
+        std::vector<P> const &e_x = moments[melectric_x];
+        std::vector<P> const &e_y = moments[melectric_y];
+  #pragma omp parallel for
+        for (size_t i = 0; i < vals.size(); i++)
+          vals[i] = field[i] * (e_x[i] * e_x[i] + e_y[i] * e_y[i]);
+      };
+  } else {
+    pde += asgard::term_md<P>{
+        asgard::term_md(asgard::term_interp<P>(md_positive_x, {melectric_x, })),
+        asgard::term_md<P>{
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides)),
+          asgard::term_identity{},
+          asgard::term_identity{}
+        }
+      };
+
+    pde += asgard::term_md<P>{
+        asgard::term_md(asgard::term_interp<P>(md_negative_x, {melectric_x, })),
+        asgard::term_md<P>{
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides)),
+          asgard::term_identity{},
+          asgard::term_identity{}
+        }
+      };
+
+    pde += asgard::term_md<P>{
+        asgard::term_md(asgard::term_interp<P>(md_positive_y, {melectric_y, })),
+        asgard::term_md<P>{
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides)),
+          asgard::term_identity{}
+        }
+      };
+
+    pde += asgard::term_md<P>{
+        asgard::term_md(asgard::term_interp<P>(md_negative_y, {melectric_y, })),
+        asgard::term_md<P>{
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides)),
+          asgard::term_identity{}
+        }
+      };
+
+    pde += asgard::term_md<P>{
+        asgard::term_md(asgard::term_interp<P>(md_positive_z, {melectric_z, })),
+        asgard::term_md<P>{
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::upwind, asgard::boundary_type::bothsides))
+        }
+      };
+
+    pde += asgard::term_md<P>{
+        asgard::term_md(asgard::term_interp<P>(md_negative_z, {melectric_z, })),
+        asgard::term_md<P>{
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_identity{},
+          asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides))
+        }
+      };
+
+    weight = [=](P /* time */, asgard::vector2d<P> const& /* nodes */,
+                      asgard::momentset<P> const &moments, std::vector<P> const &field,
+                      std::vector<P> &vals)
+      {
+        std::vector<P> const &e_x = moments[melectric_x];
+        std::vector<P> const &e_y = moments[melectric_y];
+        std::vector<P> const &e_z = moments[melectric_z];
+  #pragma omp parallel for
+        for (size_t i = 0; i < vals.size(); i++)
+          vals[i] = field[i] * (e_x[i] * e_x[i] + e_y[i] * e_y[i] + e_z[i] * e_z[i]);
+      };
+  }
 #endif
 
   // initial conditions in x and v
@@ -358,6 +653,12 @@ asgard::pde_scheme<P> make_two_stream(asgard::prog_opts options) {
     void {
       for (size_t i = 0; i < y.size(); i++)
         fy[i] = 1.0;
+    };
+
+  auto ic_z = [](std::vector<P> const &z, P /* time */, std::vector<P> &fz) ->
+    void {
+      for (size_t i = 0; i < z.size(); i++)
+        fz[i] = 1.0;
     };
 
   auto ic_vx = [](std::vector<P> const &vx, P /* time */, std::vector<P> &fv) ->
@@ -376,9 +677,21 @@ asgard::pde_scheme<P> make_two_stream(asgard::prog_opts options) {
         fv[i] = c * std::exp(-vy[i] * vy[i]);
     };
 
-  pde.add_initial(asgard::separable_func<P>({ic_x, ic_y, ic_vx, ic_vy}));
+  auto ic_vz = [](std::vector<P> const &vz, P /* time */, std::vector<P> &fv) ->
+    void {
+      P const c = P{1} / std::sqrt(PI);
 
-  pde.set_adapt_weight(weight, {melectric_x, melectric_y});
+      for (size_t i = 0; i < vz.size(); i++)
+        fv[i] = c * std::exp(-vz[i] * vz[i]);
+    };
+
+  if (pos_dims == 2) {
+    pde.add_initial(asgard::separable_func<P>({ic_x, ic_y, ic_vx, ic_vy}));
+    pde.set_adapt_weight(weight, {melectric_x, melectric_y});
+  } else {
+    pde.add_initial(asgard::separable_func<P>({ic_x, ic_y, ic_z, ic_vx, ic_vy, ic_vz}));
+    pde.set_adapt_weight(weight, {melectric_x, melectric_y, melectric_z});
+  }
 
   return pde;
 
@@ -417,15 +730,19 @@ int main(int argc, char** argv)
     std::cout << "\n solves the two stream Vlasov-Poisson in 2x-2v dimensions\n\n";
     std::cout << "    -- standard ASGarD options --";
     options.print_help(std::cout);
-    std::cout << "<< additional options for this file >>\n";
-    std::cout << "-test                               perform self-testing\n\n";
+    std::cout <<
+R"help(<< additional options for this file >>
+-dims            -dm     int        accepts: 2 or 3
+                                    the number of position dimensions
+-test                               perform self-testing
+)help";
     return 0;
   }
 
   // this is an optional step, check if there are misspelled or incorrect cli entries
   // the first set/vector of entries are those that can appear by themselves
   // the second set/vector requires extra parameters
-  options.throw_if_argv_not_in({"-test", "--test"}, {});
+  options.throw_if_argv_not_in({"-test", "--test"}, {"-dims", "-dm"});
 
   if (options.has_cli_entry("-test") or options.has_cli_entry("--test")) {
     // perform series of internal tests, not part of the example/tutorial
@@ -433,9 +750,11 @@ int main(int argc, char** argv)
     return 0;
   }
 
+  int const pos_dims = options.extra_cli_value_group<int>({"-dims", "-dm"}).value_or(2);
+
   // the discretization_manager takes in a pde and handles sparse-grid construction
   // separable and non-separable operators, holds the current state, etc.
-  asgard::discretization_manager<P> disc(make_two_stream(options),
+  asgard::discretization_manager<P> disc(make_two_stream(pos_dims, options),
                                          asgard::verbosity_level::low);
 
   // save the initial condition
@@ -490,7 +809,7 @@ void test_energy(std::string const &opt_str) {
 
   // the pde needs only the zeroth moment and computes that internally
   // we are using the other moments to check energy conservation properties
-  auto pde = make_two_stream(options);
+  auto pde = make_two_stream(2, options);
   moment_id const rho = pde.register_moment({0, 0});
   moment_id const p0 = pde.register_moment({1, 0}); // needed for verification, but not running
   moment_id const p1 = pde.register_moment({0, 1});

--- a/src/pde/two_stream_md.cpp
+++ b/src/pde/two_stream_md.cpp
@@ -49,19 +49,30 @@ void self_test();
 #ifdef ASGARD_USE_GPU
 template<typename P>
 __global__ void interp_positive_kernel(int64_t num, P const* field, P const* mom, P* out) {
-    int64_t i = blockIdx.x * blockDim.x + threadIdx.x;
-    if (i < num) {
-        // Avoiding std::max to prevent __device__ compilation header conflicts
-        out[i] = field[i] * ((mom[i] > 0.0) ? mom[i] : 0.0); 
-    }
+  int64_t i = blockIdx.x * blockDim.x + threadIdx.x;
+  while (i < num) {
+    // Avoiding std::max to prevent __device__ compilation header conflicts
+    out[i] = field[i] * ((mom[i] > 0.0) ? mom[i] : 0.0); 
+    i += blockDim.x * gridDim.x;
+  }
 }
 
 template<typename P>
 __global__ void interp_negative_kernel(int64_t num, P const* field, P const* mom, P* out) {
-    int64_t i = blockIdx.x * blockDim.x + threadIdx.x;
-    if (i < num) {
-        out[i] = field[i] * ((mom[i] < 0.0) ? mom[i] : 0.0);
-    }
+  int64_t i = blockIdx.x * blockDim.x + threadIdx.x;
+  while (i < num) {
+    out[i] = field[i] * ((mom[i] < 0.0) ? mom[i] : 0.0);
+    i += blockDim.x * gridDim.x;
+  }
+}
+
+template<typename P>
+__global__ void weight_kernel(int64_t num, P const *field, P const *ex, P const *ey, P* out) {
+  int64_t i = blockIdx.x * blockDim.x + threadIdx.x;
+  while (i < num) {
+    out[i] = field[i] * (ex[i] * ex[i] + ey[i] * ey[i]);
+    i += blockDim.x * gridDim.x;
+  }
 }
 #endif
 
@@ -273,6 +284,16 @@ asgard::pde_scheme<P> make_two_stream(asgard::prog_opts options) {
         asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides))
       }
     };
+
+  auto weight = [=](int64_t num, P t, P const x[], asgard::momentset_gpu<P> const &moments, P const f[], P fx[])
+    {
+      int threads = 256;
+      int blocks = (num + threads - 1) / threads;
+
+      asgard::gpu::vector<P> const &e_x = moments[melectric_x];
+      asgard::gpu::vector<P> const &e_y = moments[melectric_y];
+      weight_kernel<<<blocks, threads>>>(num, f, e_x.data(), e_y.data(), fx);
+    };
 #else
   pde += asgard::term_md<P>{
       asgard::term_md(asgard::term_interp<P>(md_positive_x, {melectric_x, })),
@@ -313,6 +334,17 @@ asgard::pde_scheme<P> make_two_stream(asgard::prog_opts options) {
         asgard::term_1d<P>(asgard::term_div<P>(1, asgard::flux_type::downwind, asgard::boundary_type::bothsides))
       }
     };
+
+  auto weight = [=](P /* time */, asgard::vector2d<P> const& /* nodes */,
+                    asgard::momentset<P> const &moments, std::vector<P> const &field,
+                    std::vector<P> &vals)
+    {
+      std::vector<P> const &e_x = moments[melectric_x];
+      std::vector<P> const &e_y = moments[melectric_y];
+#pragma omp parallel for
+      for (size_t i = 0; i < vals.size(); i++)
+        vals[i] = field[i] * (e_x[i] * e_x[i] + e_y[i] * e_y[i]);
+    };
 #endif
 
   // initial conditions in x and v
@@ -345,6 +377,8 @@ asgard::pde_scheme<P> make_two_stream(asgard::prog_opts options) {
     };
 
   pde.add_initial(asgard::separable_func<P>({ic_x, ic_y, ic_vx, ic_vy}));
+
+  pde.set_adapt_weight(weight, {melectric_x, melectric_y});
 
   return pde;
 
@@ -496,7 +530,7 @@ void test_energy(std::string const &opt_str) {
       E0 = 0.5 * (Ep + Ek);
 
     // std::cout << "Total energy error: " << std::abs(0.5 * (Ep + Ek) - E0) << "\n";
-    tcheckless(i, std::abs(0.5 * (Ep + Ek) - E0), 3.E-4);
+    tcheckless(i, std::abs(0.5 * (Ep + Ek) - E0), 7.E-6);
 
     std::vector<P> mom0 = disc.get_moment(rho);
     std::vector<P> momp0 = disc.get_moment(p0);
@@ -527,7 +561,7 @@ void self_test() {
 
 #ifdef ASGARD_ENABLE_DOUBLE
 
-  test_energy<double>("-l 6 -d 3 -n 5 -dt 6.25e-3 -a 1.0e-6 -ppc none");
+  test_energy<double>("-l 6 -d 3 -n 10 -dt 6.25e-3 -a 1.0e-6 -ppc none");
   test_energy<double>("-s rk4 -l 6 -d 2 -n 5 -dt 6.25e-3 -a 1.0e-6");
 
 #endif


### PR DESCRIPTION
Adapt weight was crashing when used with an electric moment because the poisson solver was not initialized before set_initial_condition() was called. I fixed this so set_adapt_weight() works with the Poisson solver. I also added a single kernel for the remap_() function on GPU in asgard_poisson.cpp to reduce the number of kernel launches.